### PR TITLE
[DO NOT MERGE] Problem Demo

### DIFF
--- a/test/tests/integration/memory-source-sync-with-blocking-connector-test.js
+++ b/test/tests/integration/memory-source-sync-with-blocking-connector-test.js
@@ -37,13 +37,17 @@ module("Integration - Memory Source Sync (Blocking)", {
     // Create sources
     source1 = new MemorySource(schema);
     source2 = new MemorySource(schema);
+    source3 = new MemorySource(schema);
 
     source1.id = 'source1';
     source2.id = 'source2';
+    source3.id = 'source3';
 
     // Create connectors
     source1to2Connector = new TransformConnector(source1, source2);
     source2to1Connector = new TransformConnector(source2, source1);
+    source1to3Connector = new TransformConnector(source1, source3);
+    source3to1Connector = new TransformConnector(source3, source1);
   },
 
   teardown: function() {


### PR DESCRIPTION
Putting this up here more as an issue than a pull request.

Doing two transforms that argue before the entire chain has a chance to settle creates an "argument" in the conflict resolution of transform connectors.

This simple tweak to the integration tests shows the problem quite well, the first test will now never resolve, lock up your debugger, and forever try to solve the eternal argument over the planet name... Earth or Jupiter

Personally I'm rooting for "Earth"