### PR TITLE
Update example code to use current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ collection of compatible sources.
 
   // Create data sources with a common schema
   var schema = new OC.Schema({
-    idField: '__id',
+    keys: {
+      __id: { primaryKey: true, defaultValue: Orbit.uuid }
+    },
     models: {
       planet: {
         attributes: {


### PR DESCRIPTION
The `idField` configuration value was removed in version 0.5.0 [1].
Update the project's README.md file with the currently-supported method
for specifying primary keys.

[1] See commit 55900d4f671a4c778eb0b8c4b629ebe3aa10e2d6