### PR TITLE
Restructure Evented promise chains

### DIFF
--- a/lib/orbit/evented.js
+++ b/lib/orbit/evented.js
@@ -188,6 +188,14 @@ var Evented = {
         }
       }, this);
 
+      if (eventNames === 'error' && listeners.length === 0) {
+        listeners = [[function(error, eventNames, args) {
+          console.error('Error during Orbit event: ' + eventNames);
+          console.error('Arguments: ', args);
+          console.error(error.stack || e);
+        }]];
+      }
+
       return listeners;
     },
 

--- a/lib/orbit/evented.js
+++ b/lib/orbit/evented.js
@@ -192,34 +192,36 @@ var Evented = {
     },
 
     resolve: function(eventNames) {
-      var listeners = this.listeners(eventNames),
-          args = Array.prototype.slice.call(arguments, 1);
+      var _this = this,
+          args = Array.prototype.slice.call(arguments, 1),
+          // Resolve is ok with errors but we may want to report errors if all
+          // resolve listeners failed.
+          errors = [];
+      return this.listeners(eventNames)
+        .reduce(function(carry, listener) {
+          return carry
+            .then(function(pastSuccess) {
+              if (pastSuccess) { return pastSuccess; }
+              return listener[0].apply(listener[1], args);
+            })
+            .catch(function(error) {
+              errors.push(['error', error, eventNames, args]);
+            });
+        }, Orbit.Promise.resolve())
+        .then(function(success) {
+          if (success) { return success; }
 
-      return new Orbit.Promise(function(resolve, reject) {
-        var resolveEach = function() {
-          if (listeners.length === 0) {
-            reject();
+          // Allow for handling or reporting of all errors.
+          errors.forEach(function(errorArgs) {
+            _this.settle.apply(_this, errorArgs);
+          });
+
+          if (errors.length) {
+            throw errors[0][1];
           } else {
-            var listener = listeners.shift();
-            var response = listener[0].apply(listener[1], args);
-
-            if (response) {
-              response.then(
-                function(success) {
-                  resolve(success);
-                },
-                function(error) {
-                  resolveEach();
-                }
-              );
-            } else {
-              resolveEach();
-            }
+            throw new Error('Coult not resolve ' + eventNames);
           }
-        };
-
-        resolveEach();
-      });
+        });
     },
 
     settle: function(eventNames) {

--- a/lib/orbit/evented.js
+++ b/lib/orbit/evented.js
@@ -223,34 +223,17 @@ var Evented = {
     },
 
     settle: function(eventNames) {
-      var listeners = this.listeners(eventNames),
+      var _this = this,
           args = Array.prototype.slice.call(arguments, 1);
-
-      return new Orbit.Promise(function(resolve) {
-        var settleEach = function() {
-          if (listeners.length === 0) {
-            resolve();
-          } else {
-            var listener = listeners.shift(),
-                response = listener[0].apply(listener[1], args);
-
-            if (response) {
-              return response.then(
-                function(success) {
-                  settleEach();
-                },
-                function(error) {
-                  settleEach();
-                }
-              );
-            } else {
-              settleEach();
-            }
-          }
-        };
-
-        settleEach();
-      });
+      return this.listeners(eventNames).reduce(function(carry, listener) {
+        return carry
+          .then(function() {
+            return listener[0].apply(listener[1], args);
+          })
+          .catch(function(error) {
+            return _this.settle('error', error, eventNames, args);
+          });
+      }, Orbit.Promise.resolve());
     }
   }
 };


### PR DESCRIPTION
Evented.settle and Evented.resolve do some work that promise chains themselves
can do. Instead of leaving these functions in a somewhat hard to follow
direction with calling a function to process the next listener we can leverage
a reduce promise chain I think to remove some work and give us one place to
handle errors (as opposed to two in #85, one for the try catch and another for
  a rejected promise).

A second problem these methods face is that currently it swallows all error
making debugging Orbit, EmberOrbit, or specific application code more
difficult. With a common error location from solving the first issue, creating
a error hanlding and exposing interface will be easier.