### PR TITLE
Allow all operation attributes to be specified for new Operation(options)

### DIFF
--- a/lib/orbit/operation.js
+++ b/lib/orbit/operation.js
@@ -42,12 +42,12 @@ var Operation = Class.extend({
       this.value = options.value;
     }
 
-    this.id = uuid();
+    this.id = options.id || uuid();
 
     if (options.parent) {
       this.log = options.parent.log.concat(options.parent.id);
     } else {
-      this.log = [];
+      this.log = options.log || [];
     }
   },
 

--- a/test/tests/orbit/unit/operation-test.js
+++ b/test/tests/orbit/unit/operation-test.js
@@ -63,3 +63,16 @@ test("can be serialized", function() {
   deepEqual(operation.serialize(), {op: 'add', path: 'planet/1', value: 'earth'}, 'serialization is correct');
 });
 
+test("can be created from with all attributes specified as options", function() {
+  var operationDetails = {id: 'abc123', op: 'add', path: ['planet','1'], value: 'earth', log: ['abc1','abc2','abc3']};
+
+  var operation = new Operation(operationDetails);
+
+  equal(operation.id, operationDetails.id, 'id was populated');
+  equal(operation.op, operationDetails.op, 'op was populated');
+  equal(operation.path, operationDetails.path, 'path was populated');
+  equal(operation.value, operationDetails.value, 'value was populated');
+  equal(operation.log, operationDetails.log, 'log was populated');
+  
+});
+


### PR DESCRIPTION
Because I'm roundtripping operations via firebase I need to serialize and then deserialize them. This PR allows all operation attributes to be specified in the constructor e.g. 

    new Operation(id: 'id', path: 'planet/1', value: {}, log: log).