### PR TITLE
Wrap operations in Operation class

### DIFF
--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -6,6 +6,7 @@ import { assert } from 'orbit/lib/assert';
 import { required } from 'orbit/lib/stubs';
 import { Class, expose, isArray, isObject, isNone } from 'orbit/lib/objects';
 import Cache from './cache';
+import Operation from 'orbit/operation';
 
 /**
  `Source` is an abstract base class to be extended by other sources.
@@ -241,11 +242,11 @@ var Source = Class.extend({
       value = true;
     }
 
-    return {
+    return new Operation({
       op: 'add',
       path: path,
       value: value
-    };
+    });
   },
 
   _removeLinkOp: function(type, id, key, value) {
@@ -256,10 +257,10 @@ var Source = Class.extend({
       path.push(value);
     }
 
-    return {
+    return new Operation({
       op: 'remove',
       path: path
-    };
+    });
   },
 
   _updateLinkOp: function(type, id, key, value) {
@@ -275,11 +276,11 @@ var Source = Class.extend({
       value = obj;
     }
 
-    return {
+    return new Operation({
       op: 'replace',
       path: path,
       value: value
-    };
+    });
   }
 });
 


### PR DESCRIPTION
I noticed some operations flying around without any ids and noticed these points where operations are created without using the new Operation class (I'm presuming your intention is to always use the Operation class).