### PR TITLE
Improve tracking of related operations

### DIFF
--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -1,6 +1,7 @@
 import Orbit from 'orbit/main';
 import { assert } from 'orbit/lib/assert';
 import { isArray, isObject } from 'orbit/lib/objects';
+import Operation from 'orbit/operation';
 import Source from './source';
 import Serializer from './serializer';
 import JSONAPISerializer from './jsonapi-serializer';
@@ -721,6 +722,16 @@ var JSONAPISource = Source.extend({
   deserialize: function(type, id, data, parentOperation) {
     var deserialized = this.serializer.deserialize(type, id, data);
     var primaryRecords = deserialized[type];
+
+    // Create a new parent operation, if necessary, to ensure that subsequent
+    // operations are related and will be settled together in the same
+    // transformation.
+    //
+    // Note: this parent operation is not actually performed on this source.
+    // It is only created to establish a common ancestor.
+    if (!parentOperation) {
+      parentOperation = new Operation();
+    }
 
     if (this._cache) {
       if (isArray(primaryRecords)) {

--- a/lib/orbit-common/memory-source.js
+++ b/lib/orbit-common/memory-source.js
@@ -318,12 +318,19 @@ var MemorySource = Source.extend({
 
   _transformAddLink: function(type, id, key, value, parentOperation) {
     if (this._cache.retrieve([type, id])) {
-      this._cache.transform(parentOperation.spawn(this._addLinkOp(type, id, key, value)));
+      var op = this._addLinkOp(type, id, key, value);
+
+      // Apply operation only if necessary
+      if (!this._cache.retrieve(op.path)) {
+        this._cache.transform(parentOperation.spawn(op));
+      }
     }
   },
 
   _transformRemoveLink: function(type, id, key, value, parentOperation) {
     var op = this._removeLinkOp(type, id, key, value);
+
+    // Apply operation only if necessary
     if (this._cache.retrieve(op.path)) {
       this._cache.transform(parentOperation.spawn(op));
     }
@@ -331,7 +338,12 @@ var MemorySource = Source.extend({
 
   _transformUpdateLink: function(type, id, key, value, parentOperation) {
     if (this._cache.retrieve([type, id])) {
-      this._cache.transform(parentOperation.spawn(this._updateLinkOp(type, id, key, value)));
+      var op = this._updateLinkOp(type, id, key, value);
+
+      // Apply operation only if necessary
+      if (!this._cache.retrieve(op.path)) {
+        this._cache.transform(parentOperation.spawn(op));
+      }
     }
   },
 

--- a/lib/orbit/operation.js
+++ b/lib/orbit/operation.js
@@ -53,7 +53,7 @@ var Operation = Class.extend({
     }
   },
 
-  spawnedFrom: function(operation) {
+  descendedFrom: function(operation) {
     return this.log.indexOf(operation.id || operation) > -1;
   },
 

--- a/lib/orbit/operation.js
+++ b/lib/orbit/operation.js
@@ -33,6 +33,8 @@ var Operation = Class.extend({
   log: null,
 
   init: function(options) {
+    options = options || {};
+
     var path = options.path;
     if (typeof path === 'string') path = path.split('/');
 

--- a/lib/orbit/operation.js
+++ b/lib/orbit/operation.js
@@ -57,6 +57,16 @@ var Operation = Class.extend({
     return this.log.indexOf(operation.id || operation) > -1;
   },
 
+  relatedTo: function(operation) {
+    if (operation instanceof Operation) {
+      return (operation.descendedFrom(this.log[0] || this.id) ||
+              this.descendedFrom(operation.log[0] || operation.id) ||
+              this.id === operation.id);
+    } else {
+      return this.descendedFrom(operation) || this.id === operation;
+    }
+  },
+
   spawn: function(data) {
     return new Operation({
       op: data.op,

--- a/lib/orbit/transform-connector.js
+++ b/lib/orbit/transform-connector.js
@@ -148,15 +148,11 @@ var TransformConnector = Class.extend({
     }
 
     if (this.blocking) {
-      return this._applyTransform(operation, inverseOps);
+      return this.transform(operation);
 
     } else {
-      this._applyTransform(operation, inverseOps);
+      this.transform(operation);
     }
-  },
-
-  _applyTransform: function(operation, inverseOps) {
-    return this.transform(operation);
   }
 });
 

--- a/lib/orbit/transform-connector.js
+++ b/lib/orbit/transform-connector.js
@@ -116,15 +116,17 @@ var TransformConnector = Class.extend({
   },
 
   resolveConflicts: function(path, currentValue, updatedValue, operation) {
-    var ops = diffs(currentValue, updatedValue, {basePath: path});
+    var ops = diffs(currentValue, updatedValue, {basePath: path, ignore: ['__rev']});
 
-    var spawnedOps = ops.map(function(op) {
-      return operation.spawn(op);
-    });
+    if (ops) {
+      var spawnedOps = ops.map(function(op) {
+        return operation.spawn(op);
+      });
 
-    // console.log(this.target.id, 'resolveConflicts', path, currentValue, updatedValue, spawnedOps);
+      // console.log(this.target.id, 'resolveConflicts', path, currentValue, updatedValue, spawnedOps);
 
-    return this.target.transform(spawnedOps);
+      return this.target.transform(spawnedOps);
+    }
   },
 
   /**

--- a/lib/orbit/transformation.js
+++ b/lib/orbit/transformation.js
@@ -10,7 +10,7 @@ export default Class.extend({
 
   queue: null,
 
-  originalOperationIds: null,
+  originalOperations: null,
 
   completedOperations: null,
 
@@ -26,15 +26,15 @@ export default Class.extend({
     this.target = target;
     this.queue = new ActionQueue({autoProcess: false});
     this.completedOperations = [];
-    this.originalOperationIds = [];
+    this.originalOperations = [];
     this.inverseOperations = [];
   },
 
   verifyOperation: function(operation) {
-    var id;
-    for (var i = 0; i < this.originalOperationIds.length; i++) {
-      id = this.originalOperationIds[i];
-      if (operation.id === id || operation.spawnedFrom(id)) {
+    var original;
+    for (var i = 0; i < this.originalOperations.length; i++) {
+      original = this.originalOperations[i];
+      if (operation.relatedTo(original)) {
         // console.log('Transformation#verifyOperation - TRUE', this.target.id, operation);
         return true;
       }
@@ -47,9 +47,9 @@ export default Class.extend({
     var _this = this;
 
     if (isArray(operation)) {
-      if (_this.originalOperationIds.length === 0) {
+      if (_this.originalOperations.length === 0) {
         operation.forEach(function(o) {
-          _this.originalOperationIds.push(o.id);
+          _this.originalOperations.push(o);
         });
       }
 
@@ -62,11 +62,11 @@ export default Class.extend({
 
       // console.log('Transformation#push - queued', _this.target.id, operation);
 
-      if (_this.originalOperationIds.length === 0) {
-        _this.originalOperationIds.push(operation.id);
+      if (_this.originalOperations.length === 0) {
+        _this.originalOperations.push(operation);
       }
 
-      if (_this.currentOperation && operation.spawnedFrom(_this.currentOperation)) {
+      if (_this.currentOperation && operation.relatedTo(_this.currentOperation)) {
         // console.log('!!! Transformation spawned from current op');
 
         return _this._transform(operation);
@@ -89,8 +89,8 @@ export default Class.extend({
   pushCompletedOperation: function(operation, inverse) {
     assert('completed operation must be an `Operation`', operation instanceof Operation);
 
-    if (this.originalOperationIds.length === 0) {
-      this.originalOperationIds.push(operation.id);
+    if (this.originalOperations.length === 0) {
+      this.originalOperations.push(operation);
     }
 
     this.inverseOperations = this.inverseOperations.concat(inverse);

--- a/test/tests/integration/rest-memory-local-non-blocking-transforms-test.js
+++ b/test/tests/integration/rest-memory-local-non-blocking-transforms-test.js
@@ -133,7 +133,7 @@ test("records inserted into memory should be posted with rest", function() {
 });
 
 test("records updated in memory should be updated with rest", function() {
-  expect(35);
+  expect(31);
 
   var memorySourceTransforms = 0,
       localSourceTransforms = 0,
@@ -192,6 +192,7 @@ test("records updated in memory should be updated with rest", function() {
       }, 0);
 
     } else if (restSourceTransforms === 2) {
+      start();
       equal(operation.op, 'replace',  'rest source - name replaced');
       equal(operation.value, 'Earth', 'rest source - name - Earth');
 
@@ -218,16 +219,6 @@ test("records updated in memory should be updated with rest", function() {
       // `id` is added when the REST POST response returns
       equal(operation.op, 'replace',   'local source - id updated');
       equal(operation.value, '12345',  'local source - id');
-
-    } else if (localSourceTransforms === 4) {
-      equal(operation.op, 'replace',    'local source - name replaced when the REST POST response returns');
-      equal(operation.value, 'Jupiter', 'local source - name temporarily changed back to Jupiter');
-
-    } else if (localSourceTransforms === 5) {
-      start();
-
-      equal(operation.op, 'replace',  'local source - name replaced when the REST PUT response returns');
-      equal(operation.value, 'Earth', 'local source - name changed back to Earth');
 
     } else {
       ok(false, 'too many transforms');
@@ -257,7 +248,7 @@ test("records updated in memory should be updated with rest", function() {
 });
 
 test("records patched in memory should be patched with rest", function() {
-  expect(35);
+  expect(31);
 
   var memorySourceTransforms = 0,
       localSourceTransforms = 0,
@@ -316,6 +307,7 @@ test("records patched in memory should be patched with rest", function() {
       }, 0);
 
     } else if (restSourceTransforms === 2) {
+      start();
       equal(operation.op, 'replace',  'rest source - name replaced');
       equal(operation.value, 'Earth', 'rest source - name - Earth');
 
@@ -342,16 +334,6 @@ test("records patched in memory should be patched with rest", function() {
       // `id` is added when the REST POST response returns
       equal(operation.op, 'replace',   'local source - id updated');
       equal(operation.value, '12345',  'local source - id');
-
-    } else if (localSourceTransforms === 4) {
-      equal(operation.op, 'replace',    'local source - name replaced when the REST POST response returns');
-      equal(operation.value, 'Jupiter', 'local source - name temporarily changed back to Jupiter');
-
-    } else if (localSourceTransforms === 5) {
-      start();
-
-      equal(operation.op, 'replace',  'local source - name replaced when the REST PATCH response returns');
-      equal(operation.value, 'Earth', 'local source - name changed back to Earth');
 
     } else {
       ok(false, 'too many transforms');

--- a/test/tests/integration/rest-memory-source-assist-test.js
+++ b/test/tests/integration/rest-memory-source-assist-test.js
@@ -1,0 +1,220 @@
+import Orbit from 'orbit/main';
+import { uuid } from 'orbit/lib/uuid';
+import Schema from 'orbit-common/schema';
+import MemorySource from 'orbit-common/memory-source';
+import JSONAPISource from 'orbit-common/jsonapi-source';
+import TransformConnector from 'orbit/transform-connector';
+import { Promise } from 'rsvp';
+import jQuery from 'jquery';
+
+var memorySource;
+var restSource;
+
+var memToRestConnector;
+var restToMemConnector;
+
+var server;
+
+module("Integration - Rest / Memory Source Assist", {
+  setup: function() {
+    Orbit.Promise = Promise;
+    Orbit.ajax = jQuery.ajax;
+
+    // fake xhr
+    server = sinon.fakeServer.create();
+    server.autoRespond = true;
+
+    // Create schema
+    var schema = new Schema({
+      modelDefaults: {
+        keys: {
+          '__id': {primaryKey: true, defaultValue: uuid},
+          'id': {}
+        }
+      },
+      models: {
+        planet: {
+          attributes: {
+            name: {type: 'string'},
+            classification: {type: 'string'}
+          },
+          links: {
+            moons: {type: 'hasMany', model: 'moon', inverse: 'planet'}
+          }
+        },
+        moon: {
+          attributes: {
+            name: {type: 'string'}
+          },
+          links: {
+            planet: {type: 'hasOne', model: 'planet', inverse: 'moons'},
+            mountains: {type: 'hasMany', model: 'mountain', inverse: 'moon'}
+          }
+        },
+        mountain: {
+          attributes: {
+            name: {type: 'string'}
+          },
+          links: {
+            moon: {type: 'hasOne', model: 'moon', inverse: 'mountains'}
+          }
+        }
+      }
+    });
+
+    // Create sources
+    memorySource = new MemorySource(schema);
+    restSource = new JSONAPISource(schema);
+
+    memorySource.id = 'memory';
+    restSource.id = 'rest';
+
+    // Create connectors
+    memToRestConnector = new TransformConnector(memorySource, restSource);
+    restToMemConnector = new TransformConnector(restSource, memorySource);
+  },
+
+  teardown: function() {
+    memToRestConnector = restToMemConnector = null;
+    memorySource = restSource = null;
+
+    server.restore();
+  }
+});
+
+test("multiple subsequent find requests", function() {
+  expect(6);
+
+  var planets = {
+    "planets": [
+      {
+        "id": "1",
+        "name": "Jupiter",
+        "links": {
+          "moons": ["2"]
+        }
+      }
+    ]
+  };
+  server.respondWith('GET', '/planets', function(xhr) {
+      ok(true, 'GET /planets request');
+      xhr.respond(200,
+                  {'Content-Type': 'application/json'},
+                  JSON.stringify(planets));
+  });
+
+  var moons = {
+    "moons": [
+      {
+        "id": "2",
+        "name": "Io",
+        "links": {
+          "mountains": ["3"],
+          "planet": "1"
+        }
+      }
+    ]
+  };
+  server.respondWith('GET', '/moons', function(xhr) {
+      ok(true, 'GET /moons request');
+      xhr.respond(200,
+                  {'Content-Type': 'application/json'},
+                  JSON.stringify(moons));
+  });
+
+  var mountains = {
+    "mountains": [
+      {
+        "id": "3",
+        "name": "Danube Planum",
+        "links": {
+          "moon": "2"
+        }
+      }
+    ]
+  };
+  server.respondWith('GET', '/mountains', function(xhr) {
+      ok(true, 'GET /mountains request');
+      xhr.respond(200,
+                  {'Content-Type': 'application/json'},
+                  JSON.stringify(mountains));
+  });
+
+  stop();
+
+  memorySource.on('assistFind', function(type, id) {
+    if (id === undefined) {
+      return restSource.find.apply(restSource, arguments);
+    }
+  });
+
+  memorySource.find("planet")
+    .then(function(planets) {
+      equal(planets.length, 1, 'found one planet');
+
+      return memorySource.find("moon");
+    })
+    .then(function(moons) {
+      equal(moons.length, 1, 'found one moon');
+
+      return memorySource.find("mountain");
+    })
+    .then(function(mountains) {
+      start();
+
+      equal(mountains.length, 1, 'found one mountain');
+    });
+});
+
+test("a single find request that returns a compound document", function() {
+  expect(2);
+
+  var planets = {
+    "linked": {
+      "mountains": [
+        {
+          "id": "3",
+          "name": "Danube Planum",
+          "links": {
+            "moon": "2"
+          }
+        }
+      ],
+      "moons": [
+        {
+          "id": "2",
+          "name": "Io",
+          "links": {
+            "mountains": ["3"]
+          }
+        }
+      ]
+    },
+    "planets": [
+      {
+        "id": "1",
+        "name": "Jupiter",
+        "links": {
+          "moons": ["2"]
+        }
+      }
+    ]
+  };
+  server.respondWith('GET', '/planets', function(xhr) {
+      ok(true, 'GET /planets request');
+      xhr.respond(200,
+                  {'Content-Type': 'application/json'},
+                  JSON.stringify(planets));
+  });
+
+  memorySource.on('assistFind', function(type, id) {
+    return restSource.find.apply(restSource, arguments);
+  });
+
+  stop();
+  memorySource.find("planet").then(function(planets) {
+    start();
+
+    equal(planets.length, 1, 'found one planet');
+  });
+});

--- a/test/tests/orbit/unit/operation-test.js
+++ b/test/tests/orbit/unit/operation-test.js
@@ -26,6 +26,10 @@ test("it is assigned an `id`", function() {
 
 test("can track ancestors in a log", function() {
   expect(7);
+test("it can be created with no attributes", function() {
+  var operation = new Operation();
+  ok(operation.id, 'operation has an id');
+});
 
   var grandparent = new Operation({op: 'add', path: '/planet/1', value: 'earth'});
   var parent = new Operation({op: 'replace', path: '/planet/1', value: 'venus', parent: grandparent});


### PR DESCRIPTION
This solves a number of issues related to transformations, relationships, and timeouts.

This introduces a new methodology for tracking operation relationships. Operations are now considered "related" if they share a common ancestor. Related operations are always processed together as part of the same transformation.

This change is validated by the tests:
* formerly, some flip-flopping of values was happening in non-blocking tests, since related transforms weren't always processed together.
* new "assistFind" tests validate the solution to #109.

Furthermore, the TransformConnector was diff'ing reverse links (`__rev`) along with objects. These are now explicitly ignored so that reverse link tracking can remain entirely a concern of each source that tracks them.