### PR TITLE
Add test for updating record with inverse relation

### DIFF
--- a/test/tests/integration/rest-memory-source-assist-test.js
+++ b/test/tests/integration/rest-memory-source-assist-test.js
@@ -218,3 +218,61 @@ test("a single find request that returns a compound document", function() {
     equal(planets.length, 1, 'found one planet');
   });
 });
+
+test("update record with an inverse relation", function() {
+  expect(4);
+  var planets = {
+    "linked": {
+      "moons": [
+        {
+          "id": "2",
+          "name": "Io",
+          "links": {
+            "planet": "1"
+          }
+        }
+      ]
+    },
+    "planets": [
+      {
+        "id": "1",
+        "name": "Jupiter",
+        "links": {
+          "moons": ["2"]
+        }
+      }
+    ]
+  };
+
+  server.respondWith(function(request) {
+    if (request.method === 'GET' && request.url === '/planets') {
+      ok(true, 'GET /planets request');
+      request.respond(200,
+                      {'Content-Type': 'application/json'},
+                      JSON.stringify(planets));
+    } else if (request.method === 'PUT' && request.url === '/planets/1') {
+      ok(true, 'PUT /planets/1 request');
+      request.respond(204, {}, "");
+    } else {
+      ok(false, request.method + ' ' + request.url + ' unexpected request');
+    }
+  });
+
+  memorySource.on('assistFind', function(type, id) {
+    return restSource.find.apply(restSource, arguments);
+  });
+
+  stop(2);
+  memorySource.find("planet").then(function(planets) {
+    equal(planets.length, 1, 'found one planet');
+    start();
+
+    var planet = planets[0];
+    planet.classification = "Gas giant";
+
+    memorySource.update("planet", planet).then(function() {
+      ok(true, 'planet updated');
+      start();
+    });
+  });
+});


### PR DESCRIPTION
Suppose we have a memory source and a JSON API source that are connected to each other with two-way transform connectors (memory source ↔︎ JSON API source) and that there's a planet "Jupiter" that has one moon "Io". When we update Jupiter's classification to "Gas giant" through memory source, Orbit correctly makes a PUT request to JSON API to update the classification. However, it also ends up in an infinite loop trying to delete and create Io's relationship to Jupiter and Jupiter's relationship to Io to JSON API:

```
DELETE /moons/2/links/planet
POST /moons/2/links/planet
DELETE /planets/1/links/moons/2
DELETE /moons/2/links/planet
POST /moons/2/links/planet
POST /planets/1/links/moons
DELETE /moons/2/links/planet
DELETE /planets/1/links/moons/2
POST /moons/2/links/planet
POST /planets/1/links/moons
...
```

This PR adds a test case for this scenario.