### PR TITLE
Add `merge` helper

### DIFF
--- a/lib/orbit/lib/objects.js
+++ b/lib/orbit/lib/objects.js
@@ -275,4 +275,28 @@ var isNone = function(obj) {
   return obj === undefined || obj === null;
 };
 
-export { Class, clone, defineClass, expose, extend, extendClass, isArray, isObject, isNone };
+/**
+ Combines two objects values
+
+ @method merge
+ @for Orbit
+ @param {Object} base
+ @param {Object} source
+ @returns {Object}
+ */
+var merge =  function(base, source) {
+  var merged = clone(base);
+  if (source) {
+    Object.keys(source).forEach(function(field) {
+      if (source.hasOwnProperty(field)) {
+        var fieldDef = source[field];
+        merged[field] = fieldDef;
+      }
+    });
+  }
+
+  return merged;
+};
+
+
+export { Class, clone, defineClass, expose, extend, extendClass, isArray, isObject, isNone, merge };

--- a/test/tests/orbit/unit/lib/object-test.js
+++ b/test/tests/orbit/unit/lib/object-test.js
@@ -1,4 +1,4 @@
-import { Class, clone, defineClass, expose, extend, extendClass, isArray, isObject, isNone } from 'orbit/lib/objects';
+import { Class, clone, defineClass, expose, extend, extendClass, isArray, isObject, isNone, merge } from 'orbit/lib/objects';
 
 module("Orbit - Lib - Object", {
 });
@@ -273,4 +273,15 @@ test("`isNone` checks whether an object is `null` or `undefined`", function() {
   equal(isNone({}), false, 'Object is not null or undefined');
   equal(isNone(null), true, 'isNone identifies null');
   equal(isNone(undefined), true, 'isNone identifies undefined');
+});
+
+test("`merge` combines two objects", function() {
+  var a = { firstNames: 'Bob', underling: false },
+      b = { lastName: 'Dobbs', 'title': 'Mr.', underlings: null },
+      expected = { title: 'Mr.', firstNames: 'Bob',
+                   lastName: 'Dobbs', underling: false, underlings: null };
+
+  deepEqual(merge(a, b), expected, 'Object values are not merged');
+  deepEqual(a, { firstNames: 'Bob', underling: false },
+            'Original object mutated');
 });


### PR DESCRIPTION
Adds orbit/lib/objects#merge helper for merging objects

e.g.

	test("`merge` combines two objects", function() {
	  var a = { firstNames: 'Bob'},
	      b = { lastName: 'Dobbs', 'title': 'Mr.'},
	      expected = { title: 'Mr.', firstNames: 'Bob', lastName: 'Dobbs'};
	  deepEqual(merge(a, b), expected, 'Object values are not merged');
	  deepEqual(a, { firstNames: 'Bob' }, 'Original object mutated');
	});
    