### PR TITLE
Add coalesceOperations helper

### DIFF
--- a/lib/orbit/lib/operations.js
+++ b/lib/orbit/lib/operations.js
@@ -1,0 +1,187 @@
+import { isObject, merge } from 'orbit/lib/objects';
+import Document from 'orbit/document';
+import { eq } from 'orbit/lib/eq';
+import Operation from 'orbit/operation';
+
+function _requiresMerge(superceded, superceding){
+  return (
+    superceded.path.join("/").indexOf(superceding.path.join("/")) === 0 ||
+    superceding.path.join("/").indexOf(superceded.path.join("/")) === 0
+  );
+}
+
+function _valueTypeForPath(path) {
+  if(path[2] === '__rel') return 'link';
+  if(path.length === 2) return 'record';
+  return 'field';
+}
+
+function _linkTypeFor(path){
+  return path.length === 4 ? 'hasOne' : 'hasMany';
+}
+
+function _mergeAttributeWithRecord(superceded, superceding){
+  var record = superceded.value;
+  var fieldName = superceding.path[2];
+  record[fieldName] = superceding.value;
+  return new Operation({ op: 'add', path: superceded.path, value: record });
+}
+
+function _mergeRecordWithAttribute(superceded, superceding){
+  var record = superceding.value,
+      recordPath = superceding.path;
+  var fieldName = superceded.path[2];
+  record[fieldName] = record[fieldName] || superceded.value;
+  return new Operation({ op: 'add', path: recordPath, value: record });
+}
+
+function _mergeLinkWithRecord(superceded, superceding){
+  var record = superceded.value;
+  var linkName = superceding.path[3];
+  var linkId = superceding.path[4];
+  var linkType = _linkTypeFor(superceding.path);
+
+  record.__rel = record.__rel || {};
+
+  if(linkType === 'hasMany'){
+    record.__rel[linkName] = record.__rel[linkName] || {};
+    record.__rel[linkName][linkId] = true;
+
+  }
+  else if(linkType === 'hasOne') {
+    record.__rel[linkName] = superceding.value;
+
+  }
+  else {
+    throw new Error("linkType not supported: " + linkType);
+  }
+
+  return new Operation({ op: 'add', path: superceded.path, value: record });
+}
+
+function _mergeRecordWithLink(superceded, superceding){
+  var record = superceding.value;
+  var linkName = superceded.path[3];
+  var linkId = superceded.path[4];
+  var linkType = _linkTypeFor(superceded.path);
+
+  record.__rel = record.__rel || {};
+
+  if(linkType === 'hasMany'){
+    record.__rel[linkName] = record.__rel[linkName] || {};
+    record.__rel[linkName][linkId] = true;
+
+  }
+  else if(linkType === 'hasOne') {
+    record.__rel[linkName] = record.__rel[linkName] || superceded.value;
+
+  }
+  else {
+    throw new Error("linkType not supported: " + linkType);
+  }
+
+  return new Operation({ op: 'add', path: superceding.path, value: record });
+}
+
+function _valueTypeForLinkValue(value){
+  if(!value) return 'unknown';
+  if(isObject(value)) return 'hasMany';
+  return 'hasOne';
+}
+
+function _mergeRecords(target, source) {
+  Object.keys(source).forEach( function(attribute) {
+    var attributeValue = source[attribute];
+    if (attribute !== '__rel') {
+      target[attribute] = attributeValue;
+    }
+  });
+
+  source.__rel = source.__rel || {};
+  target.__rel = target.__rel || {};
+
+  var sourceLinks = Object.keys(source.__rel);
+  var targetLinks = Object.keys(target.__rel);
+  var links = sourceLinks.concat(targetLinks);
+
+  links.forEach( function(link) {
+    var linkType = _valueTypeForLinkValue(source.__rel[link] || target.__rel[link]);
+
+    if (linkType === 'hasOne') {
+      target.__rel[link] = source.__rel[link];
+    } else if (linkType === 'unknown') {
+      target.__rel[link] = null;
+    } else {
+      target.__rel[link] = target.__rel[link] || {};
+      target.__rel[link] = merge(target.__rel[link], source.__rel[link]);
+    }
+  });
+
+  return target;
+}
+
+function _mergeRecordWithRecord(superceded, superceding) {
+  var mergedRecord = { id: superceded.id, __rel: {} },
+      supercededRecord = superceded.value,
+      supercedingRecord = superceding.value,
+      record;
+
+  record = _mergeRecords({}, supercededRecord);
+  record = _mergeRecords(record, supercedingRecord);
+
+  return new Operation({ op: 'add', path: superceding.path, value: record });
+}
+
+function _merge(superceded, superceding){
+  var supercedingType = _valueTypeForPath(superceding.path),
+      supercededType = _valueTypeForPath(superceded.path);
+
+  if(supercededType === 'record' && supercedingType === 'field'){
+    return _mergeAttributeWithRecord(superceded, superceding);
+  }
+  else if(supercededType === 'field' && supercedingType === 'record'){
+    return _mergeRecordWithAttribute(superceded, superceding);
+  }
+  else if (supercededType === 'record' && supercedingType === 'link'){
+    return _mergeLinkWithRecord(superceded, superceding);
+  }
+  else if (supercededType === 'link' && supercedingType === 'record'){
+    return _mergeRecordWithLink(superceded, superceding);
+  }
+  else if (supercededType === 'record' && supercedingType === 'record'){
+    return _mergeRecordWithRecord(superceded, superceding);
+  }
+  else {
+    return superceding;
+  }
+}
+
+/**
+ Coalesces operations into a minimal set of equivalent operations
+
+ @method coalesceOperations
+ @for Orbit
+ @param {Array} operations
+ @returns {Array}
+ */
+function coalesceOperations(operations) {
+  var coalesced = [];
+  var superceding;
+
+  operations.forEach(function(superceding){
+    coalesced.slice(0).forEach(function(superceded){
+
+      if(_requiresMerge(superceded, superceding)){
+        var index = coalesced.indexOf(superceded);
+        coalesced.splice(index, 1);
+        superceding = _merge(superceded, superceding);
+      }
+
+    });
+    coalesced.push(superceding);
+  });
+
+  return coalesced;
+}
+
+export { coalesceOperations };

--- a/test/tests/orbit/unit/lib/operations-test.js
+++ b/test/tests/orbit/unit/lib/operations-test.js
@@ -1,0 +1,200 @@
+import { op, equalOps } from 'tests/test-helper';
+import { coalesceOperations } from 'orbit/lib/operations';
+
+module("Orbit - Lib - Operations - coalesce", {
+
+});
+
+function shouldCoalesceOperations(original, expected){
+  var actual = coalesceOperations(original);
+
+  for(var i = 0; i < expected.length; i++){
+    equalOps(actual[i], expected[i], 'operation ' + i + ' matched');
+  }
+}
+
+test("can coalesce attribute operations", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234', 'name'], null),
+      op('add', ['contact', '1234', 'name'], "Jim")
+    ],
+    [
+      op('add', ['contact', '1234', 'name'], "Jim")
+    ]
+    );
+});
+
+test("can coalesce attributes into records", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234'], { id: '1234' }),
+      op('add', ['contact', '1234', 'name'], "Jim")
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', name: "Jim" })
+    ]
+    );
+});
+
+test("can coalesce hasMany links into records", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234'], { id: '1234' }),
+      op('add', ['contact', '1234', '__rel', 'phoneNumbers', 'abc123'], true)
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', __rel: { phoneNumbers: { 'abc123': true } } })
+    ]
+    );
+});
+
+test("can coalesce hasOne links into records", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234'], { id: '1234' }),
+      op('add', ['contact', '1234', '__rel', 'address'], "abc123")
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', __rel: { address: "abc123" } } )
+    ]
+    );
+});
+
+test("can coalesce record into attributes operation", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234', 'name'], "Jim"),
+      op('add', ['contact', '1234'], { id: '1234' })
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', name: "Jim" })
+    ]
+    );
+});
+
+test("can coalesce record into hasMany operation", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234', '__rel', 'phoneNumbers', 'abc123'], true),
+      op('add', ['contact', '1234'], { id: '1234' })
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', __rel: { phoneNumbers: { 'abc123': true } } })
+    ]
+    );
+});
+
+test("can coalesce record into hasOne operation", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234', '__rel', 'address'], "abc123"),
+      op('add', ['contact', '1234'], { id: '1234' })
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', __rel: { address: "abc123" } } )
+    ]
+    );
+});
+
+test("record values take precedence over existing hasOne operations", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234', '__rel', 'address'], "abc123"),
+      op('add', ['contact', '1234'], { id: '1234', __rel: { address: 'def789' } })
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', __rel: { address: "def789" } } )
+    ]
+    );
+});
+
+test("record values take precedence over existing hasOne operations", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234'], {
+        id: '1234',
+        title: "Big Boss",
+        __rel: {
+          address: 'abc123',
+          phoneNumbers: { id123: true }
+        }
+      }),
+      op('add', ['contact', '1234'], {
+        id: '1234',
+        __rel: {
+          address: 'def789'
+        }
+      })
+    ],
+    [
+      op('add', ['contact', '1234'], {
+        id: '1234',
+        title: "Big Boss",
+        __rel: { address: "def789",
+          phoneNumbers: { id123: true }
+        }
+      })
+    ]
+  );
+});
+
+test("can coalesce remove operation with add operation", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234', 'name'], "Jim"),
+      op('remove', ['contact', '1234', 'name'])
+    ],
+    [
+      op('remove', ['contact', '1234', 'name'])
+    ]
+  );
+});
+
+test("can coalesce add operation with remove operation", function(){
+  shouldCoalesceOperations(
+    [
+      op('remove', ['contact', '1234', 'name']),
+      op('add', ['contact', '1234', 'name'], "Jim")
+    ],
+    [
+      op('add', ['contact', '1234', 'name'], "Jim")
+    ]
+  );
+});
+
+test("can coalesce remove operation with other remove operation", function(){
+  shouldCoalesceOperations(
+    [
+      op('remove', ['contact', '1234', 'name']),
+      op('remove', ['contact', '1234', 'name'])
+    ],
+    [
+      op('remove', ['contact', '1234', 'name'])
+    ]
+  );
+});
+
+test("can coalesce remove operation into record operation", function(){
+  shouldCoalesceOperations(
+    [
+      op('add', ['contact', '1234'], { id: '1234', __rel: { address: 'def789' } }),
+      op('remove', ['contact', '1234', '__rel', 'address'])
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', __rel: { address: null } })
+    ]
+  );
+});
+
+test("record link takes precedence over remove operation", function(){
+  shouldCoalesceOperations(
+    [
+      op('remove', ['contact', '1234', '__rel', 'address']),
+      op('add', ['contact', '1234'], { id: '1234', __rel: { address: 'def789' } }),
+    ],
+    [
+      op('add', ['contact', '1234'], { id: '1234', __rel: { address: 'def789' } })
+    ]
+  );
+});


### PR DESCRIPTION
Adds orbit/lib/operation#coalesceOperations helper. It will coalesce a list of operations into the minimal set of operations that will produce the same transformations on a target document. 

@dgeb the main difference over the version you had in peeps-ember-orbit is that it combines attribute and link operations into record operations e.g.

	test("can coalesce attributes into records", function(){
	  shouldCoalesceOperations(
	    [
	      op('add', ['contact', '1234'], { id: '1234' }),
	      op('add', ['contact', '1234', 'name'], "Jim")
	    ],
	    [
	      op('add', ['contact', '1234'], { id: '1234', name: "Jim" })
	    ]
	    );
	});

There's one case where it's perhaps too aggressive, it will coalesce add link operations into the record, but before the target object has been created. I haven't seen any issues with this testing against peeps-ember-orbit but you probably have a better idea of whether or not this is reasonable.

Shout out to @walter who was pairing with me on this one.