### PR TITLE
Fix too loose check for existing data in JSON API source

### DIFF
--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -585,7 +585,7 @@ var JSONAPISource = Source.extend({
       pathToVerify = operation.path;
     }
 
-    if (this.retrieve(pathToVerify)) {
+    if (this.retrieve(pathToVerify) !== null) {
       // transforming the cache will trigger a call to `_cacheDidTransform`,
       // which will then trigger `didTransform`
       this._cache.transform(operation);


### PR DESCRIPTION
`_transformCache()` incorrectly changed operation type from `'replace'` to `'add'` if the existing data was a falsy value.

This bug can be reproduced using the following scenario:

Suppose we have a memory source and a JSON API source, which are connected to each other using `TransformConnector`s. If we update an attribute value from `false` to `null` in a record using the memory source, Orbit.js starts making `PUT` requests to update the attribute value to `null` infinitely.

I'd love to add a test for this, but I'm not sure what would be the correct place for it.