### PR TITLE
Fix inverse link tracking to not "remove" hasOne links

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -670,10 +670,7 @@ var Cache = Class.extend({
     if (this.retrieve([type, id])) {
       var op = this._addLinkOp(type, id, key, value);
 
-      // Apply operation only if necessary
-      if (!this.retrieve(op.path)) {
-        this.transform(parentOperation.spawn(op));
-      }
+      this.transform(parentOperation.spawn(op));
     }
   },
 
@@ -689,15 +686,12 @@ var Cache = Class.extend({
   },
 
   _transformUpdateLink: function(type, id, key, value, parentOperation) {
-    console.log('_transformUpdateLink', type, id, key, value);
+    // console.log('_transformUpdateLink', type, id, key, value);
 
     if (this.retrieve([type, id])) {
       var op = this._updateLinkOp(type, id, key, value);
 
-      // Apply operation only if necessary
-      if (!this.retrieve(op.path)) {
-        this.transform(parentOperation.spawn(op));
-      }
+      this.transform(parentOperation.spawn(op));
     }
   },
 
@@ -724,14 +718,20 @@ var Cache = Class.extend({
   _removeLinkOp: function(type, id, key, value) {
     var linkDef = this.schema.models[type].links[key];
     var path = [type, id, '__rel', key];
+    var op;
 
     if (linkDef.type === 'hasMany') {
       path.push(value);
+      op = 'remove';
+    } else {
+      op = 'replace';
+      value = null;
     }
 
     return new Operation({
-      op: 'remove',
-      path: path
+      op: op,
+      path: path,
+      value: value
     });
   },
 

--- a/test/tests/orbit-common/unit/memory-source-test.js
+++ b/test/tests/orbit-common/unit/memory-source-test.js
@@ -377,11 +377,11 @@ test("#add - creates a record - data defaults to empty object", function() {
 });
 
 test("#add / #remove - can create and remove has-one links and their inverse links", function() {
-  expect(6);
+  expect(10);
 
   equal(source.length('planet'), 0, 'source should be empty');
 
-  var jupiter,
+  var jupiter, earth,
       io;
 
   stop();
@@ -395,8 +395,22 @@ test("#add / #remove - can create and remove has-one links and their inverse lin
     ok(jupiter.__rel.moons[io.id], 'Jupiter\'s moon is Io');
     equal(io.__rel.planet, jupiter.id, 'Io\'s planet is Jupiter');
 
-    return source.remove('moon', io.id);
+    return source.add('planet', { name: 'Earth' });
+  }).then(function(planet) {
+    earth = planet;
+    // Change the "inverse" link on the moon by linking it to our new planet
+    return source.addLink('planet', earth.id, 'moons', io.id);
+  }).then(function() {
+    equal(Object.keys(earth.__rel.moons).length, 1, 'Earth has one moon after changing link');
+    equal(Object.keys(jupiter.__rel.moons).length, 0, 'Jupiter has no moons after changing link');
 
+    return source.remove('planet', earth.id);
+  }).then(function() {
+    strictEqual(io.__rel.planet, null, 'Removing earth set io\'s planet to null');
+    return source.addLink('moon', io.id, 'planet', jupiter.id);
+  }).then(function() {
+    equal(Object.keys(jupiter.__rel.moons).length, 1, 'Jupiter has one moon after linking');
+    return source.remove('moon', io.id);
   }).then(function() {
     start();
 


### PR DESCRIPTION
Ran into this bug in "prod"

If you remove a link with an inverse, it will actually "REMOVE" the key from a hasOne which causes further "crashes" in trasnforms that try to add links back...  hasOne's should be replaced with null instead of removed.