### PR TITLE
Fix call stack overflow when removing circular hasOne inverse

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -683,7 +683,7 @@ var Cache = Class.extend({
     var op = this._removeLinkOp(type, id, key, value);
 
     // Apply operation only if necessary
-    if (this.retrieve(op.path)) {
+    if (this.retrieve(op.path) && !this._isMarkedForRemoval(op.path)) {
       this.transform(parentOperation.spawn(op));
     }
   },

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -275,16 +275,22 @@ var Cache = Class.extend({
   },
 
   _markForRemoval: function(path) {
-    this._pathsToRemove.push(path.join('/'));
+    path = path.join('/');
+    // console.log('_markForRemoval', path);
+    this._pathsToRemove.push(path);
   },
 
   _unmarkForRemoval: function(path) {
-    var i = this._pathsToRemove.indexOf(path.join('/'));
+    path = path.join('/');
+    var i = this._pathsToRemove.indexOf(path);
+    // console.log('_unmarkForRemoval', path, i);
     if (i > -1) this._pathsToRemove.splice(i, 1);
   },
 
   _isMarkedForRemoval: function(path) {
-    return (this._pathsToRemove.indexOf(path.join('/')) > -1);
+    path = path.join('/');
+    // console.log('_isMarkedForRemoval', path);
+    return (this._pathsToRemove.indexOf(path) > -1);
   },
 
   _isOperationRequired: function(operation) {


### PR DESCRIPTION
I also added some console logging in the "marked for removal" logic (as it's own commit, in case you don't want to keep it around)