### PR TITLE
Isolate reverse link tracking.

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -21,8 +21,7 @@ import { deprecate } from 'orbit/lib/deprecate';
  @param {OC.Schema} schema
  @param {Object}  [options]
  @param {Boolean} [options.trackChanges=true] Should the `didTransform` event be triggered after calls to `transform`?
- @param {Boolean} [options.maintainRevLinks=true] Should `__rev` be maintained for each record, indicating which other records reference them?
- @param {Boolean} [options.trackRevLinkChanges=false] Should the `didTransform` event be triggered after `__rev` is updated?
+ @param {Boolean} [options.maintainRevLinks=true] Should reverse links be maintained for each record, indicating which other records reference them?
  @param {Boolean} [options.maintainInverseLinks=true] Should inverse links be maintained for relationships?
  @param {Boolean} [options.maintainDependencies=true] Should dependencies between related records (e.g. `dependent: 'remove'`) be maintained?
  @constructor
@@ -38,11 +37,14 @@ var Cache = Class.extend({
 
     this.trackChanges = options.trackChanges !== undefined ? options.trackChanges : true;
     this.maintainRevLinks = options.maintainRevLinks !== undefined ? options.maintainRevLinks : true;
-    this.trackRevLinkChanges = options.trackRevLinkChanges !== undefined ? options.trackRevLinkChanges : false;
     this.maintainInverseLinks = options.maintainInverseLinks !== undefined ? options.maintainRevLinks : true;
     this.maintainDependencies = options.maintainDependencies !== undefined ? options.maintainDependencies : true;
 
     this._doc = new Document(null, {arrayBasedPaths: true});
+
+    if (this.maintainRevLinks) {
+      this._rev = {};
+    }
 
     this._pathsToRemove = [];
 
@@ -195,80 +197,68 @@ var Cache = Class.extend({
 
     if (eq(currentValue, value)) return false;
 
-    if (path.length > 2 && path[2] === '__rev') {
-      // Apply reverse link transform
-      if (this.trackRevLinkChanges) {
-        inverse = this._doc.transform(normalizedOperation, true);
-        this.emit('didTransform', normalizedOperation, inverse);
+    var dependentOperations;
 
-      } else {
-        this._doc.transform(normalizedOperation, false);
+    if (this.maintainDependencies) {
+      dependentOperations = this._transformDependencies(normalizedOperation);
+    }
+
+    if (op === 'remove' || op === 'replace') {
+      this._markForRemoval(path);
+
+      if (this.maintainInverseLinks) {
+        if (op === 'replace') {
+          this._transformRelatedInverseLinks(normalizedOperation.spawn({
+            op: 'remove',
+            path: path
+          }));
+        }
+
+        this._transformRelatedInverseLinks(normalizedOperation);
       }
+
+      if (this.maintainRevLinks) {
+        this._removeRevLinks(path, normalizedOperation);
+      }
+    }
+
+    if (this.trackChanges) {
+      inverse = this._doc.transform(normalizedOperation, true);
+      this.emit('didTransform',
+                normalizedOperation,
+                inverse);
 
     } else {
-      var dependentOperations;
+      this._doc.transform(normalizedOperation, false);
+    }
 
-      if (this.maintainDependencies) {
-        dependentOperations = this._transformDependencies(normalizedOperation);
+    if (op === 'remove' || op === 'replace') {
+      this._unmarkForRemoval(path);
+    }
+
+    if (op === 'add' || op === 'replace') {
+      if (this.maintainRevLinks) {
+        this._addRevLinks(path, value, normalizedOperation);
       }
 
-      if (op === 'remove' || op === 'replace') {
-        this._markForRemoval(path);
+      if (this.maintainInverseLinks) {
+        if (op === 'replace') {
+          this._transformRelatedInverseLinks(normalizedOperation.spawn({
+            op: 'add',
+            path: path,
+            value: value
+          }));
 
-        if (this.maintainInverseLinks) {
-          if (op === 'replace') {
-            this._transformRelatedInverseLinks(normalizedOperation.spawn({
-              op: 'remove',
-              path: path
-            }));
-          }
-
+        } else {
           this._transformRelatedInverseLinks(normalizedOperation);
         }
-
-        if (this.maintainRevLinks) {
-          this._removeRevLinks(path, normalizedOperation);
-        }
       }
+    }
 
-      if (this.trackChanges) {
-        inverse = this._doc.transform(normalizedOperation, true);
-        this.emit('didTransform',
-                  normalizedOperation,
-                  inverse);
-
-      } else {
-        this._doc.transform(normalizedOperation, false);
-      }
-
-      if (op === 'remove' || op === 'replace') {
-        this._unmarkForRemoval(path);
-      }
-
-      if (op === 'add' || op === 'replace') {
-        if (this.maintainRevLinks) {
-          this._addRevLinks(path, value, normalizedOperation);
-        }
-
-        if (this.maintainInverseLinks) {
-          if (op === 'replace') {
-            this._transformRelatedInverseLinks(normalizedOperation.spawn({
-              op: 'add',
-              path: path,
-              value: value
-            }));
-
-          } else {
-            this._transformRelatedInverseLinks(normalizedOperation);
-          }
-        }
-      }
-
-      if (dependentOperations) {
-        dependentOperations.forEach(function(operation) {
-          _this.transform(operation);
-        });
-      }
+    if (dependentOperations) {
+      dependentOperations.forEach(function(operation) {
+        _this.transform(operation);
+      });
     }
 
     return true;
@@ -342,7 +332,7 @@ var Cache = Class.extend({
     return operations;
   },
 
-  _addRevLinks: function(path, value, parentOperation) {
+  _addRevLinks: function(path, value) {
     // console.log('_addRevLinks', path, value);
 
     if (value) {
@@ -361,11 +351,11 @@ var Cache = Class.extend({
 
             if (linkSchema.type === 'hasMany') {
               Object.keys(linkValue).forEach(function(v) {
-                _this._addRevLink(linkSchema, type, id, link, v, parentOperation);
+                _this._addRevLink(linkSchema, type, id, link, v);
               });
 
             } else {
-              _this._addRevLink(linkSchema, type, id, link, linkValue, parentOperation);
+              _this._addRevLink(linkSchema, type, id, link, linkValue);
             }
           });
         }
@@ -381,12 +371,24 @@ var Cache = Class.extend({
           linkValue = value;
         }
 
-        this._addRevLink(linkSchema, type, id, link, linkValue, parentOperation);
+        this._addRevLink(linkSchema, type, id, link, linkValue);
       }
     }
   },
 
-  _addRevLink: function(linkSchema, type, id, link, value, parentOperation) {
+  _revLink: function(type, id) {
+    var revForType = this._rev[type];
+    if (revForType === undefined) {
+      revForType = this._rev[type] = {};
+    }
+    var rev = revForType[id];
+    if (rev === undefined) {
+      rev = revForType[id] = {};
+    }
+    return rev;
+  },
+
+  _addRevLink: function(linkSchema, type, id, link, value) {
     // console.log('_addRevLink', linkSchema, type, id, link, value);
 
     if (value && typeof value === 'string') {
@@ -396,28 +398,8 @@ var Cache = Class.extend({
       }
       linkPath = linkPath.join('/');
 
-      var refsPath = [linkSchema.model, value, '__rev'];
-      var refs = this.retrieve(refsPath);
-      if (!refs) {
-        refs = {};
-        refs[linkPath] = true;
-        this.transform(parentOperation.spawn({
-          op: 'add',
-          path: refsPath,
-          value: refs
-        }));
-
-      } else {
-        refsPath.push(linkPath);
-        refs = this.retrieve(refsPath);
-        if (!refs) {
-          this.transform(parentOperation.spawn({
-            op: 'add',
-            path: refsPath,
-            value: true
-          }));
-        }
-      }
+      var revLink = this._revLink(linkSchema.model, value);
+      revLink[linkPath] = true;
     }
   },
 
@@ -434,11 +416,11 @@ var Cache = Class.extend({
 
       if (path.length === 2) {
         // when a whole record is removed, remove any links that reference it
-        if (value.__rev) {
-          // console.log('removeRefs from deleted record', type, id, value.__rev);
-
+        if (this.maintainRevLinks) {
+          var revLink = this._revLink(type, id);
           var operation;
-          Object.keys(value.__rev).forEach(function(path) {
+
+          Object.keys(revLink).forEach(function(path) {
             path = _this._doc.deserializePath(path);
 
             if (path.length === 4) {
@@ -456,6 +438,8 @@ var Cache = Class.extend({
 
             _this.transform(operation);
           });
+
+          delete this._rev[type][id];
         }
 
         // when a whole record is removed, remove references corresponding to each link
@@ -466,11 +450,11 @@ var Cache = Class.extend({
 
             if (linkSchema.type === 'hasMany') {
               Object.keys(linkValue).forEach(function(v) {
-                _this._removeRevLink(linkSchema, type, id, link, v, parentOperation);
+                _this._removeRevLink(linkSchema, type, id, link, v);
               });
 
             } else {
-              _this._removeRevLink(linkSchema, type, id, link, linkValue, parentOperation);
+              _this._removeRevLink(linkSchema, type, id, link, linkValue);
             }
           });
         }
@@ -486,12 +470,12 @@ var Cache = Class.extend({
           linkValue = value;
         }
 
-        this._removeRevLink(linkSchema, type, id, link, linkValue, parentOperation);
+        this._removeRevLink(linkSchema, type, id, link, linkValue);
       }
     }
   },
 
-  _removeRevLink: function(linkSchema, type, id, link, value, parentOperation) {
+  _removeRevLink: function(linkSchema, type, id, link, value) {
     // console.log('_removeRevLink', linkSchema, type, id, link, value);
 
     if (value && typeof value === 'string') {
@@ -501,10 +485,8 @@ var Cache = Class.extend({
       }
       linkPath = linkPath.join('/');
 
-      this.transform(parentOperation.spawn({
-        op: 'remove',
-        path: [linkSchema.model, value, '__rev', linkPath]
-      }));
+      var revLink = this._revLink(linkSchema.model, id);
+      delete revLink[linkPath];
     }
   },
 

--- a/lib/orbit-common/schema.js
+++ b/lib/orbit-common/schema.js
@@ -340,9 +340,6 @@ var Schema = Class.extend({
     // set flag
     record.__normalized = true;
 
-    // init backward links
-    record.__rev = record.__rev || {};
-
     // init forward links
     record.__rel = record.__rel || {};
 

--- a/lib/orbit/transform-connector.js
+++ b/lib/orbit/transform-connector.js
@@ -116,7 +116,7 @@ var TransformConnector = Class.extend({
   },
 
   resolveConflicts: function(path, currentValue, updatedValue, operation) {
-    var ops = diffs(currentValue, updatedValue, {basePath: path, ignore: ['__rev']});
+    var ops = diffs(currentValue, updatedValue, { basePath: path });
 
     if (ops) {
       var spawnedOps = ops.map(function(op) {

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -117,7 +117,7 @@ test("#transform tracks refs by default, and clears them from hasOne relationshi
   cache.transform({op: 'add', path: 'moon/m1', value: io});
   cache.transform({op: 'add', path: 'moon/m2', value: europa});
 
-  deepEqual(cache.retrieve('planet/p1/__rev'),
+  deepEqual(cache._rev['planet']['p1'],
     {'moon/m1/__rel/planet': true,
      'moon/m2/__rel/planet': true});
 
@@ -143,7 +143,7 @@ test("#transform tracks refs by default, and clears them from hasMany relationsh
   cache.transform({op: 'add', path: 'moon/m2', value: europa});
   cache.transform({op: 'add', path: 'planet/p1', value: jupiter});
 
-  deepEqual(cache.retrieve('moon/m1/__rev'),
+  deepEqual(cache._rev['moon']['m1'],
     {'planet/p1/__rel/moons/m1': true});
 
   equal(cache.retrieve('/planet/p1/__rel/moons/m1'), true, 'Jupiter has been assigned to Io');


### PR DESCRIPTION
Polluting each record with `__rev` data leads to that data leaking
into `didTransform` events inappropriately. This data should be
maintained separately per-cache instead.

This also simplifies `Cache#transform`, which no longer needs special
logic for reverse link transforms.