### PR TITLE
Optimize local storage source writing speed

### DIFF
--- a/lib/orbit-common/local-storage-source.js
+++ b/lib/orbit-common/local-storage-source.js
@@ -26,23 +26,25 @@ var LocalStorageSource = MemorySource.extend({
     this._super.apply(this, arguments);
 
     options = options || {};
-    this.namespace = options['namespace'] || 'orbit'; // local storage key
+    this.namespace = options['namespace'] || 'orbit'; // local storage namespace
+    this.delimiter = options['delimiter'] || '/'; // local storage key
     this._autosave = options['autosave'] !== undefined ? options['autosave'] : true;
     var autoload = options['autoload'] !== undefined ? options['autoload'] : true;
 
     this._isDirty = false;
 
-    this.on('didTransform', function() {
-      this._saveData();
-    }, this);
+    this.on('didTransform', this._saveData, this);
 
     if (autoload) this.load();
   },
 
   load: function() {
-    var storage = window.localStorage.getItem(this.namespace);
-    if (storage) {
-      this.reset(JSON.parse(storage));
+    for (var key in window.localStorage) {
+      if (key.indexOf(this.namespace) === 0) {
+        var path = key.split(this.delimiter);
+        var item = JSON.parse(window.localStorage.getItem(key));
+        this._cache._doc._data[path[1]][path[2]] = item;
+      }
     }
   },
 
@@ -59,16 +61,28 @@ var LocalStorageSource = MemorySource.extend({
     }
   },
 
+  getKey: function(path) {
+    return [this.namespace, path[0], path[1]].join(this.delimiter);
+  },
+
+
   /////////////////////////////////////////////////////////////////////////////
   // Internals
   /////////////////////////////////////////////////////////////////////////////
 
-  _saveData: function(forceSave) {
-    if (!this._autosave && !forceSave) {
+  _saveData: function(operation) {
+    if (!this._autosave && !operation) {
       this._isDirty = true;
       return;
     }
-    window.localStorage.setItem(this.namespace, JSON.stringify(this.retrieve()));
+    var obj = this.retrieve([operation.path[0], operation.path[1]]);
+
+    if (operation.op === 'add' || operation.op === 'replace') {
+      window.localStorage.setItem(this.getKey(operation.path), JSON.stringify(obj));
+    }
+    if (operation.op === 'remove') {
+      window.localStorage.removeItem(this.getKey(operation.path));
+    }
     this._isDirty = false;
   }
 });

--- a/test/tests/test-helper.js
+++ b/test/tests/test-helper.js
@@ -1,11 +1,9 @@
 import Operation from 'orbit/operation';
 
 var verifyLocalStorageContainsRecord = function(namespace, type, id, record, ignoreFields) {
-  var expected = {};
-  expected[id] = record;
+  var recordKey = [namespace, type, id].join('/');
 
-  var actual = JSON.parse(window.localStorage.getItem(namespace));
-  if (type) actual = actual[type];
+  var actual = JSON.parse(window.localStorage.getItem(recordKey));
 
   if (ignoreFields) {
     for (var i = 0, l = ignoreFields.length, field; i < l; i++) {
@@ -15,7 +13,7 @@ var verifyLocalStorageContainsRecord = function(namespace, type, id, record, ign
   }
 
   deepEqual(actual,
-            expected,
+            record,
             'data in local storage matches expectations');
 };
 


### PR DESCRIPTION
### Problem with current solution

For example, in my case I have around 9000 objects which are added from memory source to local storage source. With the current implementation when adding a new object to localsource it needs to `JSON.parse` and `JSON.stringify` the same object over and over again and it gets really slow. In my case it will crash the browser because it uses tens of gigabytes of memory.

### Solution proposal

Use locale storage as real key value storage. Each key in storage represents an orbit object. Prefix all keys with a namespace and then make it unique. For example key format could be `namespace/orbit-model-name/orbit-model-primarykey`. 

### Pros

- Adding object to locale storage gets way faster. In my case from crashing the browser to ~ 9 secods. 

### Cons

- Loading the data from local storage to the source takes a bit longer. Still it took only 200ms with my data.

