### PR TITLE
Add support for diffing dates

### DIFF
--- a/lib/orbit/lib/diffs.js
+++ b/lib/orbit/lib/diffs.js
@@ -91,6 +91,10 @@ var diffs = function(a, b, options) {
               bi++;
             }
           }
+        } else if (a instanceof Date) {
+          if (a.getTime() === b.getTime()) return;
+          if (d === undefined) d = [];
+          d.push({op: 'replace', path: basePath, value: clone(b)});
 
         } else { // general (non-array) object
           for (i in b) {

--- a/test/tests/orbit/unit/lib/diffs-test.js
+++ b/test/tests/orbit/unit/lib/diffs-test.js
@@ -130,3 +130,21 @@ test("#diffs ignores specified items with `ignore` option", function() {
             [{op: 'replace', path: 'planets/1/name', value: 'Saturn'}],
             'specified items are ignored in delta');
 });
+
+test("#diffs generates `replace` patch when comparing two dates", function() {
+  var a = new Date(1428555600000),
+      b = new Date(1428555601000);
+
+  deepEqual(diffs(a,b, {basePath: 'planets/1/birthDate'}),
+            [{op: 'replace', path: 'planets/1/birthDate', value: b}],
+            'dates are replaced');
+});
+
+test("#diffs generates undefined patch when comparing two equal dates", function() {
+  var a = new Date(1428555600000),
+      b = new Date(1428555600000);
+
+  deepEqual(diffs(a,b, {basePath: 'planets/1/birthDate'}),
+            undefined,
+            'dates are the same');
+});


### PR DESCRIPTION
Currently diffing dates always returns undefined for diffs(dateA, dateB). This PR will generate the expected replace operation.