### PR TITLE
Better errors when link not found

### DIFF
--- a/lib/orbit-common.js
+++ b/lib/orbit-common.js
@@ -4,7 +4,7 @@ import Schema from 'orbit-common/schema';
 import Serializer from 'orbit-common/serializer';
 import Source from 'orbit-common/source';
 import MemorySource from 'orbit-common/memory-source';
-import { OperationNotAllowed, RecordNotFoundException, LinkNotFoundException, RecordAlreadyExistsException, ModelNotRegisteredException } from 'orbit-common/lib/exceptions';
+import { OperationNotAllowed, RecordNotFoundException, LinkNotFoundException, RecordAlreadyExistsException, ModelNotRegisteredException, LinkNotRegisteredException } from 'orbit-common/lib/exceptions';
 
 OC.Cache = Cache;
 OC.Schema = Schema;
@@ -16,6 +16,7 @@ OC.OperationNotAllowed = OperationNotAllowed;
 OC.RecordNotFoundException = RecordNotFoundException;
 OC.LinkNotFoundException = LinkNotFoundException;
 OC.ModelNotRegisteredException = ModelNotRegisteredException;
+OC.LinkNotRegisteredException = LinkNotRegisteredException;
 OC.RecordAlreadyExistsException = RecordAlreadyExistsException;
 
 export default OC;

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -362,7 +362,7 @@ var Cache = Class.extend({
         // when a whole record is added, add inverse links for every link
         if (value.__rel) {
           Object.keys(value.__rel).forEach(function(link) {
-            linkSchema = _this.schema.models[type].links[link];
+            linkSchema = _this.schema.linkPropertiesFor(type, link);
             linkValue = value.__rel[link];
 
             if (linkSchema.type === 'hasMany') {
@@ -379,7 +379,7 @@ var Cache = Class.extend({
       } else if (path.length > 3) {
         var link = path[3];
 
-        linkSchema = _this.schema.models[type].links[link];
+        linkSchema = _this.schema.linkPropertiesFor(type, link);
 
         if (path.length === 5) {
           linkValue = path[4];
@@ -461,7 +461,7 @@ var Cache = Class.extend({
         // when a whole record is removed, remove references corresponding to each link
         if (value.__rel) {
           Object.keys(value.__rel).forEach(function(link) {
-            linkSchema = _this.schema.models[type].links[link];
+            linkSchema = _this.schema.linkPropertiesFor(type, link);
             linkValue = value.__rel[link];
 
             if (linkSchema.type === 'hasMany') {
@@ -478,7 +478,7 @@ var Cache = Class.extend({
       } else if (path.length > 3) {
         var link = path[3];
 
-        linkSchema = _this.schema.models[type].links[link];
+        linkSchema = _this.schema.linkPropertiesFor(type, link);
 
         if (path.length === 5) {
           linkValue = path[4];
@@ -695,7 +695,7 @@ var Cache = Class.extend({
   },
 
   _addLinkOp: function(type, id, key, value) {
-    var linkDef = this.schema.models[type].links[key];
+    var linkDef = this.schema.linkPropertiesFor(type, key);
     var path = [type, id, '__rel', key];
     var op;
 

--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -120,7 +120,7 @@ var JSONAPISource = Source.extend({
     var _this = this;
     return this.ajax(this.resourceLinkURL(type, id, link), 'GET').then(
       function(raw) {
-        var linkDef = _this.schema.models[type].links[link];
+        var linkDef = _this.schema.linkPropertiesFor(type, link);
         var relId = _this.serializer.deserializeLink(linkDef.model, raw);
 
         return _this.settleTransforms().then(function() {
@@ -299,7 +299,7 @@ var JSONAPISource = Source.extend({
     var link = operation.path[3];
     var relId = operation.path[4] || operation.value;
 
-    var linkDef = this.schema.models[type].links[link];
+    var linkDef = this.schema.linkPropertiesFor(type, link);
     var relType = linkDef.model;
     var relResourceType = this.serializer.resourceType(relType);
     var relResourceId = this.serializer.resourceId(relType, relId);
@@ -322,7 +322,7 @@ var JSONAPISource = Source.extend({
     var id = operation.path[1];
     var link = operation.path[3];
     var relId = operation.path[4] || operation.value;
-    var linkDef = this.schema.models[type].links[link];
+    var linkDef = this.schema.linkPropertiesFor(type, link);
     var relType = linkDef.model;
     var relResourceId = this.serializer.resourceId(relType, relId);
     var remoteOp;
@@ -377,7 +377,7 @@ var JSONAPISource = Source.extend({
     var type = operation.path[0];
     var id = operation.path[1];
     var link = operation.path[3];
-    var linkDef = this.schema.models[type].links[link];
+    var linkDef = this.schema.linkPropertiesFor(type, link);
     var remoteOp;
 
     if (linkDef.type === 'hasMany') {
@@ -424,7 +424,7 @@ var JSONAPISource = Source.extend({
       relId = Object.keys(relId);
     }
 
-    var linkDef = this.schema.models[type].links[link];
+    var linkDef = this.schema.linkPropertiesFor(type, link);
     var relType = linkDef.model;
     var relResourceType = this.serializer.resourceType(relType);
     var relResourceId = this.serializer.resourceId(relType, relId);
@@ -453,7 +453,7 @@ var JSONAPISource = Source.extend({
       relId = Object.keys(relId);
     }
 
-    var linkDef = this.schema.models[type].links[link];
+    var linkDef = this.schema.linkPropertiesFor(type, link);
     var relType = linkDef.model;
     var relResourceId = this.serializer.resourceId(relType, relId);
     var remoteOp;
@@ -713,7 +713,7 @@ var JSONAPISource = Source.extend({
     url += '/links/' + this.serializer.resourceLink(type, link);
 
     if (relId) {
-      var linkDef = this.schema.models[type].links[link];
+      var linkDef = this.schema.linkPropertiesFor(type, link);
 
       url += '/' + this._resourceIdURLSegment(linkDef.model, relId);
     }

--- a/lib/orbit-common/lib/exceptions.js
+++ b/lib/orbit-common/lib/exceptions.js
@@ -24,6 +24,15 @@ var ModelNotRegisteredException = Exception.extend({
   },
 });
 
+var LinkNotRegisteredException = Exception.extend({
+  name: 'OC.LinkNotRegisteredException',
+  init: function(model, link) {
+    this.model = model;
+    this.link = link;
+    this._super('link "' + model + "#" + link + '" not registered');
+  },
+});
+
 
 var _RecordException = Exception.extend({
   init: function(type, record, key) {

--- a/lib/orbit-common/memory-source.js
+++ b/lib/orbit-common/memory-source.js
@@ -105,7 +105,7 @@ var MemorySource = Source.extend({
           relId = record.__rel[link];
 
           if (relId) {
-            var linkDef = _this.schema.models[type].links[link];
+            var linkDef = _this.schema.linkPropertiesFor(type, link);
             if (linkDef.type === 'hasMany') {
               relId = Object.keys(relId);
             }

--- a/lib/orbit-common/schema.js
+++ b/lib/orbit-common/schema.js
@@ -1,6 +1,6 @@
 import { Class, clone, extend } from 'orbit/lib/objects';
 import { uuid } from 'orbit/lib/uuid';
-import { OperationNotAllowed, ModelNotRegisteredException } from './lib/exceptions';
+import { OperationNotAllowed, ModelNotRegisteredException, LinkNotRegisteredException } from './lib/exceptions';
 import Evented from 'orbit/evented';
 
 /**
@@ -492,6 +492,16 @@ var Schema = Class.extend({
     } else {
       return word;
     }
+  },
+
+  linkPropertiesFor: function(type, link){
+    var model = this.models[type];
+    if(!model) throw new ModelNotRegisteredException(type);
+
+    var linkProperties = model.links[link];
+    if(!linkProperties) throw new LinkNotRegisteredException(type, link);
+
+    return linkProperties;
   },
 
   _defaultValue: function(record, value, defaultValue) {

--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -70,7 +70,7 @@ var Source = Class.extend({
 
   _findLinked: function(type, id, link, relId) {
     var _this = this;
-    var linkDef = _this.schema.models[type].links[link];
+    var linkDef = _this.schema.linkPropertiesFor(type, link);
     var relType = linkDef.model;
 
     id = this.getId(type, id);


### PR DESCRIPTION
Added schema.linkPropertiesFor(type, link) which throws the following errors:

    Type 'planet' not found for 'planet.moons'
    Link 'moons' not found for 'planet.moons'

I've swapped out any calls of the form this.schema.models[type].links[link] to use this method instead.