### PR TITLE
OC.ModelNotRegisteredException

### DIFF
--- a/lib/orbit-common.js
+++ b/lib/orbit-common.js
@@ -4,7 +4,7 @@ import Schema from 'orbit-common/schema';
 import Serializer from 'orbit-common/serializer';
 import Source from 'orbit-common/source';
 import MemorySource from 'orbit-common/memory-source';
-import { OperationNotAllowed, RecordNotFoundException, LinkNotFoundException, RecordAlreadyExistsException } from 'orbit-common/lib/exceptions';
+import { OperationNotAllowed, RecordNotFoundException, LinkNotFoundException, RecordAlreadyExistsException, ModelNotRegisteredException } from 'orbit-common/lib/exceptions';
 
 OC.Cache = Cache;
 OC.Schema = Schema;
@@ -15,6 +15,7 @@ OC.MemorySource = MemorySource;
 OC.OperationNotAllowed = OperationNotAllowed;
 OC.RecordNotFoundException = RecordNotFoundException;
 OC.LinkNotFoundException = LinkNotFoundException;
+OC.ModelNotRegisteredException = ModelNotRegisteredException;
 OC.RecordAlreadyExistsException = RecordAlreadyExistsException;
 
 export default OC;

--- a/lib/orbit-common/lib/exceptions.js
+++ b/lib/orbit-common/lib/exceptions.js
@@ -16,6 +16,14 @@ var OperationNotAllowed = Exception.extend({
   name: 'OC.OperationNotAllowed',
 });
 
+var ModelNotRegisteredException = Exception.extend({
+  name: 'OC.ModelNotRegisteredException',
+  init: function(model) {
+    this.model = model;
+    this._super('model "' + model + '" not found');
+  },
+});
+
 
 var _RecordException = Exception.extend({
   init: function(type, record, key) {
@@ -70,4 +78,4 @@ var RecordAlreadyExistsException = _RecordException.extend({
   name: 'OC.RecordAlreadyExistsException',
 });
 
-export { OperationNotAllowed, RecordNotFoundException, LinkNotFoundException, RecordAlreadyExistsException };
+export { OperationNotAllowed, RecordNotFoundException, LinkNotFoundException, RecordAlreadyExistsException, ModelNotRegisteredException };

--- a/lib/orbit-common/schema.js
+++ b/lib/orbit-common/schema.js
@@ -1,6 +1,6 @@
 import { Class, clone, extend } from 'orbit/lib/objects';
 import { uuid } from 'orbit/lib/uuid';
-import { OperationNotAllowed } from './lib/exceptions';
+import { OperationNotAllowed, ModelNotRegisteredException } from './lib/exceptions';
 import Evented from 'orbit/evented';
 
 /**
@@ -351,12 +351,20 @@ var Schema = Class.extend({
     return record;
   },
 
+  schemaFor: function(model) {
+    var modelSchema = this.models[model];
+    if (!modelSchema) {
+      throw new ModelNotRegisteredException(model);
+    }
+    return modelSchema;
+  },
+
   initDefaults: function(model, record) {
     if (!record.__normalized) {
       throw new OperationNotAllowed('Schema.initDefaults requires a normalized record');
     }
 
-    var modelSchema = this.models[model],
+    var modelSchema = this.schemaFor(model),
         keys = modelSchema.keys,
         attributes = modelSchema.attributes,
         links = modelSchema.links;
@@ -395,7 +403,7 @@ var Schema = Class.extend({
   },
 
   primaryToSecondaryKey: function(model, secondaryKeyName, primaryKeyValue, autoGenerate) {
-    var modelSchema = this.models[model];
+    var modelSchema = this.schemaFor(model);
     var secondaryKey = modelSchema.keys[secondaryKeyName];
 
     var value = secondaryKey.primaryToSecondaryKeyMap[primaryKeyValue];
@@ -410,7 +418,7 @@ var Schema = Class.extend({
   },
 
   secondaryToPrimaryKey: function(model, secondaryKeyName, secondaryKeyValue, autoGenerate) {
-    var modelSchema = this.models[model];
+    var modelSchema = this.schemaFor(model);
     var secondaryKey = modelSchema.keys[secondaryKeyName];
 
     var value = secondaryKey.secondaryToPrimaryKeyMap[secondaryKeyValue];

--- a/test/tests/orbit-common/unit/schema-test.js
+++ b/test/tests/orbit-common/unit/schema-test.js
@@ -2,6 +2,7 @@ import Orbit from 'orbit/main';
 import Schema from 'orbit-common/schema';
 import { Promise } from 'rsvp';
 import { uuid } from 'orbit/lib/uuid';
+import { ModelNotRegisteredException } from 'orbit-common/lib/exceptions';
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -193,6 +194,20 @@ test("#normalize initializes a record with a unique primary key", function() {
   ok(earth.id, 'id has been set');
   ok(mars.id, 'id has been set');
   notEqual(earth.id, mars.id, 'ids are unique');
+});
+
+test("#normalize throws a ModelNotRegisteredException error for missing models", function() {
+  var schema = new Schema({
+    models: {
+      planet: {}
+    }
+  });
+
+  expect(1);
+
+  throws(function() {
+    var earth = schema.normalize('not-planet', {});
+  }, ModelNotRegisteredException, 'threw a OC.ModelNotRegisteredException');
 });
 
 test("#normalize - local and remote ids can be mapped", function() {


### PR DESCRIPTION
Added this because I was having quite a few "attempt to read keys of undefined" errors
cropping up from this function.  I'd rather throw an exception with a known error message.

cc @opsb maybe you want to reuse this `schemaFor` in #139 ?