### PR TITLE
Extract JSONAPIPatchSource from JSONAPISource.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -22,7 +22,8 @@ var packages = [
               /(orbit\-common\/.+.js)/],
     exclude: [/orbit-common\/local-storage-source.js/,
               /orbit-common\/jsonapi-serializer.js/,
-              /orbit-common\/jsonapi-source.js/]
+              /orbit-common\/jsonapi-source.js/,
+              /orbit-common\/jsonapi-patch-source.js/]
   },
   {
     name: 'orbit-common-local-storage',
@@ -31,7 +32,8 @@ var packages = [
   {
     name: 'orbit-common-jsonapi',
     include: [/orbit-common\/jsonapi-serializer.js/,
-              /orbit-common\/jsonapi-source.js/]
+              /orbit-common\/jsonapi-source.js/,
+              /orbit-common\/jsonapi-patch-source.js/]
   }
 ];
 

--- a/build-support/globalize-orbit-common-jsonapi.js
+++ b/build-support/globalize-orbit-common-jsonapi.js
@@ -1,2 +1,3 @@
 window.OC.JSONAPISource = requireModule("orbit-common/jsonapi-source")["default"];
+window.OC.JSONAPIPatchSource = requireModule("orbit-common/jsonapi-patch-source")["default"];
 window.OC.JSONAPISerializer = requireModule("orbit-common/jsonapi-serializer")["default"];

--- a/lib/orbit-common/jsonapi-patch-source.js
+++ b/lib/orbit-common/jsonapi-patch-source.js
@@ -1,0 +1,201 @@
+import { isArray, isObject } from 'orbit/lib/objects';
+import JSONAPISource from './jsonapi-source';
+
+/**
+ Source for accessing a JSON API compliant RESTful API with AJAX using the
+ official patch extension
+
+ @class JSONAPIPatchSource
+ @extends Source
+ @namespace OC
+ @param schema
+ @param options
+ @constructor
+ */
+export default JSONAPISource.extend({
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Internals
+  /////////////////////////////////////////////////////////////////////////////
+
+  _transformAdd: function(operation) {
+    var _this = this;
+    var type = operation.path[0];
+    var id = operation.path[1];
+
+    var remoteOp = {
+      op: 'add',
+      path: '/-',
+      value: this.serializer.serializeRecord(type, operation.value)
+    };
+
+    return this.ajax(this.resourceURL(type), 'PATCH', {data: [ remoteOp ]}).then(
+      function(raw) {
+        if (raw && isArray(raw)) {
+          _this.deserialize(type, id, raw[0], operation);
+        } else {
+          _this._transformCache(operation);
+        }
+      }
+    );
+  },
+
+  _transformReplace: function(operation) {
+    var _this = this;
+    var type = operation.path[0];
+    var id = operation.path[1];
+    var value = operation.value;
+
+    var remoteOp = {
+      op: 'replace',
+      path: '/',
+      value: this.serializer.serializeRecord(type, value)
+    };
+
+    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
+      function(raw) {
+        if (raw && isArray(raw)) {
+          _this.deserialize(type, id, raw[0], operation);
+        } else {
+          _this._transformCache(operation);
+        }
+      }
+    );
+  },
+
+  _transformRemove: function(operation) {
+    var _this = this;
+    var type = operation.path[0];
+    var id = operation.path[1];
+
+    var remoteOp = {
+      op: 'remove',
+      path: '/'
+    };
+
+    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
+      function() {
+        _this._transformCache(operation);
+      }
+    );
+  },
+
+  _transformAddLink: function(operation) {
+    var _this = this;
+
+    var type = operation.path[0];
+    var id = operation.path[1];
+    var link = operation.path[3];
+    var relId = operation.path[4] || operation.value;
+    var linkDef = this.schema.linkDefinition(type, link);
+    var relType = linkDef.model;
+    var relResourceId = this.serializer.resourceId(relType, relId);
+    var remoteOp;
+
+    if (linkDef.type === 'hasMany') {
+      remoteOp = {
+        op: 'add',
+        path: '/-',
+        value: relResourceId
+      };
+    } else {
+      remoteOp = {
+        op: 'replace',
+        path: '/',
+        value: relResourceId
+      };
+    }
+
+    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
+      function() {
+        _this._transformCache(operation);
+      }
+    );
+  },
+
+  _transformRemoveLink: function(operation) {
+    var _this = this;
+
+    var type = operation.path[0];
+    var id = operation.path[1];
+    var link = operation.path[3];
+    var linkDef = this.schema.linkDefinition(type, link);
+    var remoteOp;
+
+    if (linkDef.type === 'hasMany') {
+      var relId = operation.path[4];
+      var relType = linkDef.model;
+      var relResourceId = this.serializer.resourceId(relType, relId);
+
+      remoteOp = {
+        op: 'remove',
+        path: '/' + relResourceId
+      };
+    } else {
+      remoteOp = {
+        op: 'remove',
+        path: '/'
+      };
+    }
+
+    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
+      function() {
+        _this._transformCache(operation);
+      }
+    );
+  },
+
+  _transformReplaceLink: function(operation) {
+    var _this = this;
+
+    var type = operation.path[0];
+    var id = operation.path[1];
+    var link = operation.path[3];
+    var relId = operation.path[4] || operation.value;
+
+    // Convert a map of ids to an array
+    if (isObject(relId)) {
+      relId = Object.keys(relId);
+    }
+
+    var linkDef = this.schema.linkDefinition(type, link);
+    var relType = linkDef.model;
+    var relResourceId = this.serializer.resourceId(relType, relId);
+    var remoteOp;
+
+    remoteOp = {
+      op: 'replace',
+      path: '/',
+      value: relResourceId
+    };
+
+    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
+      function() {
+        _this._transformCache(operation);
+      }
+    );
+  },
+
+  _transformUpdateAttribute: function(operation) {
+    var _this = this;
+    var type = operation.path[0];
+    var id = operation.path[1];
+    var attr = operation.path[2];
+
+    var remoteOp = {
+      op: 'replace',
+      path: '/' + attr,
+      value: operation.value
+    };
+
+    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
+      function() {
+        _this._transformCache(operation);
+      }
+    );
+  },
+
+  ajaxContentType: function(url, method) {
+    return 'application/vnd.api+json; ext=jsonpatch; charset=utf-8';
+  }
+});

--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -29,7 +29,6 @@ var JSONAPISource = Source.extend({
     this.namespace        = options.namespace || this.namespace;
     this.host             = options.host || this.host;
     this.headers          = options.headers || this.headers;
-    this.usePatch         = options.usePatch !== undefined ? options.usePatch : this.usePatch;
     this.SerializerClass  = options.SerializerClass || this.SerializerClass;
 
     // If `SerializerClass` is obtained through the _super chain, dereference
@@ -50,7 +49,6 @@ var JSONAPISource = Source.extend({
   host: null,
   headers: null,
   SerializerClass: JSONAPISerializer,
-  usePatch: false,
 
   /////////////////////////////////////////////////////////////////////////////
   // Transformable interface implementation
@@ -155,14 +153,6 @@ var JSONAPISource = Source.extend({
   /////////////////////////////////////////////////////////////////////////////
 
   _transformAdd: function(operation) {
-    if (this.usePatch) {
-      return this._transformAddWithPatch(operation);
-    } else {
-      return this._transformAddStd(operation);
-    }
-  },
-
-  _transformAddStd: function(operation) {
     var _this = this;
     var type = operation.path[0];
     var id = operation.path[1];
@@ -175,37 +165,7 @@ var JSONAPISource = Source.extend({
     );
   },
 
-  _transformAddWithPatch: function(operation) {
-    var _this = this;
-    var type = operation.path[0];
-    var id = operation.path[1];
-
-    var remoteOp = {
-      op: 'add',
-      path: '/-',
-      value: this.serializer.serializeRecord(type, operation.value)
-    };
-
-    return this.ajax(this.resourceURL(type), 'PATCH', {data: [ remoteOp ]}).then(
-      function(raw) {
-        if (raw && isArray(raw)) {
-          _this.deserialize(type, id, raw[0], operation);
-        } else {
-          _this._transformCache(operation);
-        }
-      }
-    );
-  },
-
   _transformReplace: function(operation) {
-    if (this.usePatch) {
-      return this._transformReplaceWithPatch(operation);
-    } else {
-      return this._transformReplaceStd(operation);
-    }
-  },
-
-  _transformReplaceStd: function(operation) {
     var _this = this;
     var type = operation.path[0];
     var id = operation.path[1];
@@ -225,38 +185,7 @@ var JSONAPISource = Source.extend({
     );
   },
 
-  _transformReplaceWithPatch: function(operation) {
-    var _this = this;
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var value = operation.value;
-
-    var remoteOp = {
-      op: 'replace',
-      path: '/',
-      value: this.serializer.serializeRecord(type, value)
-    };
-
-    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
-      function(raw) {
-        if (raw && isArray(raw)) {
-          _this.deserialize(type, id, raw[0], operation);
-        } else {
-          _this._transformCache(operation);
-        }
-      }
-    );
-  },
-
   _transformRemove: function(operation) {
-    if (this.usePatch) {
-      return this._transformRemoveWithPatch(operation);
-    } else {
-      return this._transformRemoveStd(operation);
-    }
-  },
-
-  _transformRemoveStd: function(operation) {
     var _this = this;
     var type = operation.path[0];
     var id = operation.path[1];
@@ -266,32 +195,7 @@ var JSONAPISource = Source.extend({
     });
   },
 
-  _transformRemoveWithPatch: function(operation) {
-    var _this = this;
-    var type = operation.path[0];
-    var id = operation.path[1];
-
-    var remoteOp = {
-      op: 'remove',
-      path: '/'
-    };
-
-    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
   _transformAddLink: function(operation) {
-    if (this.usePatch) {
-      return this._transformAddLinkWithPatch(operation);
-    } else {
-      return this._transformAddLinkStd(operation);
-    }
-  },
-
-  _transformAddLinkStd: function(operation) {
     var _this = this;
 
     var type = operation.path[0];
@@ -315,48 +219,7 @@ var JSONAPISource = Source.extend({
     );
   },
 
-  _transformAddLinkWithPatch: function(operation) {
-    var _this = this;
-
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var link = operation.path[3];
-    var relId = operation.path[4] || operation.value;
-    var linkDef = this.schema.linkDefinition(type, link);
-    var relType = linkDef.model;
-    var relResourceId = this.serializer.resourceId(relType, relId);
-    var remoteOp;
-
-    if (linkDef.type === 'hasMany') {
-      remoteOp = {
-        op: 'add',
-        path: '/-',
-        value: relResourceId
-      };
-    } else {
-      remoteOp = {
-        op: 'replace',
-        path: '/',
-        value: relResourceId
-      };
-    }
-
-    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
   _transformRemoveLink: function(operation) {
-    if (this.usePatch) {
-      return this._transformRemoveLinkWithPatch(operation);
-    } else {
-      return this._transformRemoveLinkStd(operation);
-    }
-  },
-
-  _transformRemoveLinkStd: function(operation) {
     var _this = this;
 
     var type = operation.path[0];
@@ -371,47 +234,7 @@ var JSONAPISource = Source.extend({
     );
   },
 
-  _transformRemoveLinkWithPatch: function(operation) {
-    var _this = this;
-
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var link = operation.path[3];
-    var linkDef = this.schema.linkDefinition(type, link);
-    var remoteOp;
-
-    if (linkDef.type === 'hasMany') {
-      var relId = operation.path[4];
-      var relType = linkDef.model;
-      var relResourceId = this.serializer.resourceId(relType, relId);
-
-      remoteOp = {
-        op: 'remove',
-        path: '/' + relResourceId
-      };
-    } else {
-      remoteOp = {
-        op: 'remove',
-        path: '/'
-      };
-    }
-
-    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
   _transformReplaceLink: function(operation) {
-    if (this.usePatch) {
-      return this._transformReplaceLinkWithPatch(operation);
-    } else {
-      return this._transformReplaceLinkStd(operation);
-    }
-  },
-
-  _transformReplaceLinkStd: function(operation) {
     var _this = this;
 
     var type = operation.path[0];
@@ -440,46 +263,7 @@ var JSONAPISource = Source.extend({
     );
   },
 
-  _transformReplaceLinkWithPatch: function(operation) {
-    var _this = this;
-
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var link = operation.path[3];
-    var relId = operation.path[4] || operation.value;
-
-    // Convert a map of ids to an array
-    if (isObject(relId)) {
-      relId = Object.keys(relId);
-    }
-
-    var linkDef = this.schema.linkDefinition(type, link);
-    var relType = linkDef.model;
-    var relResourceId = this.serializer.resourceId(relType, relId);
-    var remoteOp;
-
-    remoteOp = {
-      op: 'replace',
-      path: '/',
-      value: relResourceId
-    };
-
-    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
   _transformUpdateAttribute: function(operation) {
-    if (this.usePatch) {
-      return this._transformUpdateAttributeWithPatch(operation);
-    } else {
-      return this._transformUpdateAttributeStd(operation);
-    }
-  },
-
-  _transformUpdateAttributeStd: function(operation) {
     var _this = this;
     var type = operation.path[0];
     var id = operation.path[1];
@@ -497,25 +281,6 @@ var JSONAPISource = Source.extend({
 
     return this.ajax(this.resourceURL(type, id), 'PUT', {data: json}).then(
       function(raw) {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
-  _transformUpdateAttributeWithPatch: function(operation) {
-    var _this = this;
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var attr = operation.path[2];
-
-    var remoteOp = {
-      op: 'replace',
-      path: '/' + attr,
-      value: operation.value
-    };
-
-    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
         _this._transformCache(operation);
       }
     );
@@ -632,14 +397,8 @@ var JSONAPISource = Source.extend({
       // console.log('ajax start', method, url);
 
       if (hash.data && method !== 'GET') {
-        // If contentType has not been specified, use the appropriate type
-        // according to the JSON API spec
         if (!hash.contentType) {
-          if (method === 'PATCH') {
-            hash.contentType = 'application/json-patch+json; charset=utf-8';
-          } else {
-            hash.contentType = 'application/vnd.api+json; charset=utf-8';
-          }
+          hash.contentType = _this.ajaxContentType(hash);
         }
         hash.data = JSON.stringify(hash.data);
       }
@@ -671,6 +430,10 @@ var JSONAPISource = Source.extend({
 
       Orbit.ajax(hash);
     });
+  },
+
+  ajaxContentType: function(url, method) {
+    return 'application/vnd.api+json; charset=utf-8';
   },
 
   ajaxHeaders: function() {

--- a/test/tests/orbit-common/unit/jsonapi-patch-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-patch-source-test.js
@@ -1,0 +1,224 @@
+import Orbit from 'orbit/main';
+import { uuid } from 'orbit/lib/uuid';
+import Schema from 'orbit-common/schema';
+import Source from 'orbit-common/source';
+import JSONAPISource from 'orbit-common/jsonapi-source';
+import JSONAPIPatchSource from 'orbit-common/jsonapi-patch-source';
+import { Promise } from 'rsvp';
+import jQuery from 'jquery';
+
+var server,
+    schema,
+    source;
+
+///////////////////////////////////////////////////////////////////////////////
+
+module("OC - JSONAPIPatchSource", {
+  setup: function() {
+    Orbit.Promise = Promise;
+    Orbit.ajax = jQuery.ajax;
+
+    // fake xhr
+    server = sinon.fakeServer.create();
+    server.autoRespond = true;
+
+    schema = new Schema({
+      modelDefaults: {
+        keys: {
+          '__id': {primaryKey: true, defaultValue: uuid},
+          'id': {}
+        }
+      },
+      models: {
+        planet: {
+          attributes: {
+            name: {type: 'string'},
+            classification: {type: 'string'}
+          },
+          links: {
+            moons: {type: 'hasMany', model: 'moon', inverse: 'planet'}
+          }
+        },
+        moon: {
+          attributes: {
+            name: {type: 'string'}
+          },
+          links: {
+            planet: {type: 'hasOne', model: 'planet', inverse: 'moons'}
+          }
+        }
+      }
+    });
+
+    source = new JSONAPIPatchSource(schema);
+  },
+
+  teardown: function() {
+    schema = null;
+    source = null;
+
+    server.restore();
+  }
+});
+
+test("it exists", function() {
+  ok(source);
+});
+
+test("its prototype chain is correct", function() {
+  ok(source instanceof Source, 'instanceof Source');
+  ok(source instanceof JSONAPISource, 'instanceof JSONAPISource');
+});
+
+test("#add - can insert records", function() {
+  expect(5);
+
+  server.respondWith('PATCH', '/planets', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), [{op: 'add', path: '/-', value: {name: 'Jupiter', classification: 'gas giant', links: {moons: []}}}], 'PATCH request');
+    xhr.respond(201,
+                {'Content-Type': 'application/json'},
+                JSON.stringify([{planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}]));
+  });
+
+  stop();
+  source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
+    start();
+    ok(planet.__id, 'orbit id should be defined');
+    equal(planet.id, 12345, 'server id should be defined');
+    equal(planet.name, 'Jupiter', 'name should match');
+    equal(planet.classification, 'gas giant', 'classification should match');
+  });
+});
+
+test("#update - can update records", function() {
+  expect(5);
+
+  server.respondWith('PATCH', '/planets/12345', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: {id: '12345', name: 'Jupiter', classification: 'gas giant', links: {moons: []}}}], 'PATCH request');
+    xhr.respond(200,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({}));
+  });
+
+  stop();
+  var data = {id: '12345', name: 'Jupiter', classification: 'gas giant'};
+  source.update('planet', data).then(function() {
+    start();
+    var planetId = source.getId('planet', data);
+    var planet = source.retrieve(['planet', planetId]);
+    equal(planet.__id, planetId, 'orbit id should be defined');
+    equal(planet.id, '12345', 'server id should be defined');
+    equal(planet.name, 'Jupiter', 'name should match');
+    equal(planet.classification, 'gas giant', 'classification should match');
+  });
+});
+
+test("#patch - can patch records", function() {
+  expect(2);
+
+  server.respondWith('PATCH', '/planets/12345', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/classification', value: 'gas giant'}], 'PATCH request');
+    xhr.respond(200,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({}));
+  });
+
+  stop();
+  source.patch('planet', {id: 12345}, 'classification', 'gas giant').then(function() {
+    start();
+    ok(true, 'record patched');
+  });
+});
+
+test("#remove - can delete records", function() {
+  expect(2);
+
+  server.respondWith('PATCH', '/planets/12345', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), [{op: 'remove', path: '/'}],
+              'PATCH request to remove record');
+    xhr.respond(200,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({}));
+  });
+
+  stop();
+  source.remove('planet', {id: '12345'}).then(function() {
+    start();
+    ok(true, 'record deleted');
+  });
+});
+
+test("#addLink - can add a hasMany relationship", function() {
+  expect(2);
+
+  server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), [{op: 'add', path: '/-', value: '987'}],
+              'PATCH request to add link to primary record');
+    xhr.respond(200,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({}));
+  });
+
+  stop();
+  source.addLink('planet', {id: '12345'}, 'moons', {id: '987'}).then(function() {
+    start();
+    ok(true, 'records linked');
+  });
+});
+
+test("#removeLink - can remove a relationship", function() {
+  expect(2);
+
+  server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), [{op: 'remove', path: '/987'}],
+              'PATCH request to remove link from primary record');
+    xhr.respond(200,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({}));
+  });
+
+  stop();
+  source.removeLink('planet', {id: 12345}, 'moons', {id: 987}).then(function() {
+    start();
+    ok(true, 'records unlinked');
+  });
+});
+
+test("#updateLink - can replace a hasOne relationship", function() {
+  expect(2);
+
+  server.respondWith('PATCH', '/moons/987/links/planet', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: '12345'}],
+              'PATCH request to replace link');
+    xhr.respond(200,
+                {'Content-Type': 'application/json'},
+                JSON.stringify({}));
+  });
+
+  stop();
+  source.updateLink('moon', {id: '987'}, 'planet', {id: '12345'}).then(function() {
+    start();
+    ok(true, 'records linked');
+  });
+});
+
+test("#updateLink - can replace a hasMany relationship (flagged as `actsAsSet`)", function() {
+  expect(2);
+
+  // Moons link must be flagged with `actsAsSet`
+  source.schema.models.planet.links.moons.actsAsSet = true;
+
+  server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: ['987']}],
+      'PATCH request to replace link');
+    xhr.respond(200,
+      {'Content-Type': 'application/json'},
+      JSON.stringify({}));
+  });
+
+  stop();
+  source.updateLink('planet', {id: '12345'}, 'moons', [{id: '987'}]).then(function() {
+    start();
+    ok(true, 'records linked');
+  });
+});


### PR DESCRIPTION
The jsonpatch extension warrants its own source, since it will typically
be used independently from the base JSONAPISource. This extraction
leads to a cleaner implementation of both sources.

----

_Coming soon_: Improved JSON API compliance for both sources.