### PR TITLE
Removing Errors creation in the Exception Class for massive performance improvements

### DIFF
--- a/lib/orbit-common/lib/exceptions.js
+++ b/lib/orbit-common/lib/exceptions.js
@@ -13,7 +13,7 @@ import { Exception } from 'orbit/lib/exceptions';
  @constructor
  */
 var OperationNotAllowed = Exception.extend({
-  name: 'OC.OperationNotAllowed',
+  name: 'OC.OperationNotAllowed'
 });
 
 var ModelNotRegisteredException = Exception.extend({
@@ -21,7 +21,7 @@ var ModelNotRegisteredException = Exception.extend({
   init: function(model) {
     this.model = model;
     this._super('model "' + model + '" not found');
-  },
+  }
 });
 
 var LinkNotRegisteredException = Exception.extend({
@@ -58,7 +58,7 @@ var _RecordException = Exception.extend({
  @constructor
  */
 var RecordNotFoundException = _RecordException.extend({
-  name: 'OC.RecordNotFoundException',
+  name: 'OC.RecordNotFoundException'
 });
 
 /**
@@ -71,7 +71,7 @@ var RecordNotFoundException = _RecordException.extend({
  @constructor
  */
 var LinkNotFoundException = _RecordException.extend({
-  name: 'OC.LinkNotFoundException',
+  name: 'OC.LinkNotFoundException'
 });
 
 /**
@@ -84,7 +84,7 @@ var LinkNotFoundException = _RecordException.extend({
  @constructor
  */
 var RecordAlreadyExistsException = _RecordException.extend({
-  name: 'OC.RecordAlreadyExistsException',
+  name: 'OC.RecordAlreadyExistsException'
 });
 
 export { OperationNotAllowed, RecordNotFoundException, LinkNotFoundException, RecordAlreadyExistsException, ModelNotRegisteredException };

--- a/lib/orbit/lib/exceptions.js
+++ b/lib/orbit/lib/exceptions.js
@@ -10,15 +10,15 @@ import { Class } from './objects';
 var Exception = Class.extend({
   init: function(message) {
     this.message = message;
-    this.error = new Error(this.toString());
-    this.stack = this.error.stack;
+    /*this.error = new Error(this.toString());
+    this.stack = this.error.stack;*/
   },
 
   name: 'Orbit.Exception',
 
   toString: function() {
     return this.name + ': ' + this.message;
-  },
+  }
 });
 
 /**
@@ -35,7 +35,7 @@ var PathNotFoundException = Exception.extend({
     this._super(path.join('/'));
   },
 
-  name: 'Orbit.PathNotFoundException',
+  name: 'Orbit.PathNotFoundException'
 });
 
 export { Exception, PathNotFoundException };


### PR DESCRIPTION
The creation of errors in the Exception Class takes around 20% of all processing power while loading data types after types, because of numerous PathNotFoundExceptions that are not displayed.

Removing it is a huge performance bonus, but maybe there are better alternatives to keep the stack trace when needed without the overhead the rest of the time.