### PR TITLE
Consolidate operation encoding and identification

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -6,6 +6,7 @@ import { OperationNotAllowed } from './lib/exceptions';
 import { eq } from 'orbit/lib/eq';
 import { deprecate } from 'orbit/lib/deprecate';
 import OperationEncoder from 'orbit-common/operation-encoder';
+import RelatedInverseLinksProcessor from 'orbit-common/operation-processors/related-inverse-links';
 
 /**
  `Cache` provides a thin wrapper over an internally maintained instance of a
@@ -58,6 +59,8 @@ var Cache = Class.extend({
         this._registerModel(model);
       }
     }
+
+    this._relatedInverseLinksProcessor = new RelatedInverseLinksProcessor(schema, this);
 
     // TODO - clean up listener
     this.schema.on('modelRegistered', this._registerModel, this);
@@ -492,140 +495,8 @@ var Cache = Class.extend({
     }
   },
 
-  _relatedInverseLinkOps: function(operation) {
-    var _this = this;
-    var op = operation.op;
-    var path = operation.path;
-    var value = operation.value;
-    var type = path[0];
-    var record;
-    var key;
-    var linkDef;
-    var linkValue;
-    var inverseLinkOp;
-    var relId;
-    var ops = [];
-    var schema = this.schema;
-    var operationType = this._operationEncoder.identify(operation);
-
-    function pushOps(newOps){
-      for(var i = 0; i < newOps.length; i++){
-        ops.push(newOps[i]);
-      }
-    }
-
-    function relatedAddLinkOps(linkValue, linkDef){
-      linkDef = linkDef || schema.linkDefinition(type, path[3]);
-      return _this._relatedAddLinkOps(linkDef, linkValue, path[1], operation);
-    }
-
-    function relatedRemoveLinkOps(linkValue, linkDef){
-      linkDef = linkDef || schema.linkDefinition(type, path[3]);
-      return _this._relatedRemoveLinkOps(linkDef, linkValue, path[1], operation);
-    }
-
-    function addRelatedLinksOpsForRecord(record){
-      if (!record.__rel) return;
-
-      Object.keys(record.__rel).forEach(function(link) {
-        linkDef = _this.schema.linkDefinition(type, link);
-
-        if (linkDef.inverse) {
-          var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
-          pushOps(relatedAddLinkOps(linkValue, linkDef));
-        }
-      });
-    }
-
-    function removeRelatedLinksOpsForRecord(record){
-      if (!record.__rel) return [];
-
-      Object.keys(record.__rel).forEach(function(link) {
-        linkDef = _this.schema.linkDefinition(type, link);
-
-        if (linkDef.inverse) {
-          var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
-          pushOps(relatedRemoveLinkOps(Object.keys(record.__rel[link]), linkDef));
-        }
-      });
-    }
-
-    if (operationType === 'addToHasMany') return relatedAddLinkOps(path[4]);
-    if (operationType === 'addHasOne') return relatedAddLinkOps(value);
-    if (operationType === 'addHasMany') return relatedAddLinkOps(Object.keys(operation.value));
-    if (operationType === 'removeHasOne') return relatedRemoveLinkOps(this.retrieve(path));
-    if (operationType === 'removeHasMany') return relatedRemoveLinkOps(Object.keys(this.retrieve(path)));
-    if (operationType === 'removeFromHasMany') return relatedRemoveLinkOps(path[4]);
-
-    // if (operationType === 'replaceHasOne') throw new Error('not implemented');
-    // if (operationType === 'replaceRecord') throw new Error('not implemented');
-    // if (operationType === 'replaceHasMany') throw new Error('not implemented');
-
-    if (operationType === 'addRecord') {
-      addRelatedLinksOpsForRecord(operation.value);
-
-    } else if (operationType === 'removeRecord') {
-      removeRelatedLinksOpsForRecord(this.retrieve(path));
-
-    }
-
-    return ops;
-  },
-
-  _relatedAddLinkOps: function(linkDef, linkValue, value, operation){
-    if(isNone(linkValue)) return [];
-    var relIds = isArray(linkValue) ? linkValue : [linkValue];
-    var linkOps = [];
-    var linkOp;
-
-    if (linkDef.inverse) {
-      for(var i = 0; i < relIds.length; i++){
-        linkOp = this._relatedAddLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, operation);
-        linkOps.push(linkOp);
-      }
-    }
-
-    return linkOps;
-  },
-
-  _relatedAddLinkOp: function(type, id, link, value, parentOperation) {
-    // console.log('_relatedAddLinkOp', type, id, link, value);
-
-    if (this.retrieve([type, id])) {
-      var op = this._operationEncoder.addLinkOp(type, id, link, value);
-
-      // Apply operation only if necessary
-      if (this.retrieve(op.path) !== op.value) {
-        return parentOperation.spawn(op);
-      }
-    }
-  },
-
-  _relatedRemoveLinkOps: function(linkDef, linkValue, value, operation){
-    if(isNone(linkValue)) return [];
-    var relIds = isArray(linkValue) ? linkValue : [linkValue];
-    var linkOps = [];
-    var linkOp;
-
-    if (linkDef.inverse) {
-      for(var i = 0; i < relIds.length; i++){
-        linkOp = this._relatedRemoveLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, operation);
-        linkOps.push(linkOp);
-      }
-    }
-
-    return linkOps;
-  },
-
-  _relatedRemoveLinkOp: function(type, id, key, value, parentOperation) {
-    // console.log('_relatedRemoveLinkOp', type, id, key, value);
-
-    var op = this._operationEncoder.removeLinkOp(type, id, key, value);
-
-    // Apply operation only if necessary
-    if (this.retrieve(op.path) && !this._isMarkedForRemoval(op.path)) {
-      return parentOperation.spawn(op);
-    }
+  _relatedInverseLinkOps: function(operation){
+    return this._relatedInverseLinksProcessor.process(operation, this._pathsToRemove);
   }
 });
 

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -505,168 +505,116 @@ var Cache = Class.extend({
     var inverseLinkOp;
     var relId;
     var ops = [];
+    var schema = this.schema;
+    var operationType = this._operationEncoder.identify(operation);
 
-    if (op === 'add') {
-      if (path.length > 3 && path[2] === '__rel') {
-
-        key = path[3];
-        linkDef = this.schema.models[type].links[key];
-
-        if (linkDef.inverse) {
-          if (path.length > 4) {
-            relId = path[4];
-          } else {
-            relId = value;
-          }
-
-          if (isObject(relId)) {
-            Object.keys(relId).forEach(function(id) {
-              ops.push(_this._relatedAddLinkOp(
-                linkDef.model,
-                id,
-                linkDef.inverse,
-                path[1],
-                operation
-              ));
-            });
-
-          } else {
-            ops.push(_this._relatedAddLinkOp(
-              linkDef.model,
-              relId,
-              linkDef.inverse,
-              path[1],
-              operation
-            ));
-          }
-        }
-
-      } else if (path.length === 2) {
-
-        record = operation.value;
-        if (record.__rel) {
-          Object.keys(record.__rel).forEach(function(key) {
-            linkDef = _this.schema.models[type].links[key];
-
-            if (linkDef.inverse) {
-              if (linkDef.type === 'hasMany') {
-                Object.keys(record.__rel[key]).forEach(function(id) {
-                  ops.push(_this._relatedAddLinkOp(
-                    linkDef.model,
-                    id,
-                    linkDef.inverse,
-                    path[1],
-                    operation
-                  ));
-                });
-
-              } else {
-                var id = record.__rel[key];
-
-                if (!isNone(id)) {
-                  ops.push(_this._relatedAddLinkOp(
-                    linkDef.model,
-                    id,
-                    linkDef.inverse,
-                    path[1],
-                    operation
-                  ));
-                }
-              }
-            }
-          });
-        }
-      }
-
-    } else if (op === 'remove') {
-
-      if (path.length > 3 && path[2] === '__rel') {
-
-        key = path[3];
-        linkDef = this.schema.models[type].links[key];
-
-        if (linkDef.inverse) {
-          if (path.length > 4) {
-            relId = path[4];
-          } else {
-            relId = this.retrieve(path);
-          }
-
-          if (relId) {
-            if (isObject(relId)) {
-              Object.keys(relId).forEach(function(id) {
-                ops.push(_this._relatedRemoveLinkOp(
-                  linkDef.model,
-                  id,
-                  linkDef.inverse,
-                  path[1],
-                  operation
-                ));
-              });
-
-            } else {
-              ops.push(_this._relatedRemoveLinkOp(
-                linkDef.model,
-                relId,
-                linkDef.inverse,
-                path[1],
-                operation
-              ));
-            }
-          }
-        }
-
-      } else if (path.length === 2) {
-
-        record = this.retrieve(path);
-        if (record.__rel) {
-          Object.keys(record.__rel).forEach(function(key) {
-            linkDef = _this.schema.models[type].links[key];
-
-            if (linkDef.inverse) {
-              if (linkDef.type === 'hasMany') {
-                Object.keys(record.__rel[key]).forEach(function(id) {
-                  ops.push(_this._relatedRemoveLinkOp(
-                    linkDef.model,
-                    id,
-                    linkDef.inverse,
-                    path[1],
-                    operation
-                  ));
-                });
-
-              } else {
-                var id = record.__rel[key];
-
-                if (!isNone(id)) {
-                  ops.push(_this._relatedRemoveLinkOp(
-                    linkDef.model,
-                    id,
-                    linkDef.inverse,
-                    path[1],
-                    operation
-                  ));
-                }
-              }
-            }
-          });
-        }
+    function pushOps(newOps){
+      for(var i = 0; i < newOps.length; i++){
+        ops.push(newOps[i]);
       }
     }
+
+    function relatedAddLinkOps(linkValue, linkDef){
+      linkDef = linkDef || schema.linkDefinition(type, path[3]);
+      return _this._relatedAddLinkOps(linkDef, linkValue, path[1], operation);
+    }
+
+    function relatedRemoveLinkOps(linkValue, linkDef){
+      linkDef = linkDef || schema.linkDefinition(type, path[3]);
+      return _this._relatedRemoveLinkOps(linkDef, linkValue, path[1], operation);
+    }
+
+    function addRelatedLinksOpsForRecord(record){
+      if (!record.__rel) return;
+
+      Object.keys(record.__rel).forEach(function(link) {
+        linkDef = _this.schema.linkDefinition(type, link);
+
+        if (linkDef.inverse) {
+          var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
+          pushOps(relatedAddLinkOps(linkValue, linkDef));
+        }
+      });
+    }
+
+    function removeRelatedLinksOpsForRecord(record){
+      if (!record.__rel) return [];
+
+      Object.keys(record.__rel).forEach(function(link) {
+        linkDef = _this.schema.linkDefinition(type, link);
+
+        if (linkDef.inverse) {
+          var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
+          pushOps(relatedRemoveLinkOps(Object.keys(record.__rel[link]), linkDef));
+        }
+      });
+    }
+
+    if (operationType === 'addToHasMany') return relatedAddLinkOps(path[4]);
+    if (operationType === 'addHasOne') return relatedAddLinkOps(value);
+    if (operationType === 'addHasMany') return relatedAddLinkOps(Object.keys(operation.value));
+    if (operationType === 'removeHasOne') return relatedRemoveLinkOps(this.retrieve(path));
+    if (operationType === 'removeHasMany') return relatedRemoveLinkOps(Object.keys(this.retrieve(path)));
+    if (operationType === 'removeFromHasMany') return relatedRemoveLinkOps(path[4]);
+
+    // if (operationType === 'replaceHasOne') throw new Error('not implemented');
+    // if (operationType === 'replaceRecord') throw new Error('not implemented');
+    // if (operationType === 'replaceHasMany') throw new Error('not implemented');
+
+    if (operationType === 'addRecord') {
+      addRelatedLinksOpsForRecord(operation.value);
+
+    } else if (operationType === 'removeRecord') {
+      removeRelatedLinksOpsForRecord(this.retrieve(path));
+
+    }
+
     return ops;
   },
 
-  _relatedAddLinkOp: function(type, id, key, value, parentOperation) {
-    // console.log('_relatedAddLinkOp', type, id, key, value);
+  _relatedAddLinkOps: function(linkDef, linkValue, value, operation){
+    if(isNone(linkValue)) return [];
+    var relIds = isArray(linkValue) ? linkValue : [linkValue];
+    var linkOps = [];
+    var linkOp;
+
+    if (linkDef.inverse) {
+      for(var i = 0; i < relIds.length; i++){
+        linkOp = this._relatedAddLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, operation);
+        linkOps.push(linkOp);
+      }
+    }
+
+    return linkOps;
+  },
+
+  _relatedAddLinkOp: function(type, id, link, value, parentOperation) {
+    // console.log('_relatedAddLinkOp', type, id, link, value);
 
     if (this.retrieve([type, id])) {
-      var op = this._operationEncoder.addLinkOp(type, id, key, value);
+      var op = this._operationEncoder.addLinkOp(type, id, link, value);
 
       // Apply operation only if necessary
       if (this.retrieve(op.path) !== op.value) {
         return parentOperation.spawn(op);
       }
     }
+  },
+
+  _relatedRemoveLinkOps: function(linkDef, linkValue, value, operation){
+    if(isNone(linkValue)) return [];
+    var relIds = isArray(linkValue) ? linkValue : [linkValue];
+    var linkOps = [];
+    var linkOp;
+
+    if (linkDef.inverse) {
+      for(var i = 0; i < relIds.length; i++){
+        linkOp = this._relatedRemoveLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, operation);
+        linkOps.push(linkOp);
+      }
+    }
+
+    return linkOps;
   },
 
   _relatedRemoveLinkOp: function(type, id, key, value, parentOperation) {

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -414,73 +414,75 @@ var Cache = Class.extend({
 
   _removeRevLinks: function(path, parentOperation) {
     // console.log('_removeRevLinks', path);
-
     var value = this.retrieve(path);
     if (value) {
-      var _this = this,
-          type = path[0],
+      var type = path[0],
           id = path[1],
-          linkSchema,
-          linkValue;
+          operationType = this._operationEncoder.identify(parentOperation);
 
-      if (path.length === 2) {
-        // when a whole record is removed, remove any links that reference it
-        if (this.maintainRevLinks) {
-          var revLink = this._revLink(type, id);
-          var operation;
-
-          Object.keys(revLink).forEach(function(path) {
-            path = _this._doc.deserializePath(path);
-
-            if (path.length === 4) {
-              operation = parentOperation.spawn({
-                op: 'replace',
-                path: path,
-                value: null
-              });
-            } else {
-              operation = parentOperation.spawn({
-                op: 'remove',
-                path: path
-              });
-            }
-
-            _this.transform(operation);
-          });
-
-          delete this._rev[type][id];
-        }
-
-        // when a whole record is removed, remove references corresponding to each link
-        if (value.__rel) {
-          Object.keys(value.__rel).forEach(function(link) {
-            linkSchema = _this.schema.linkDefinition(type, link);
-            linkValue = value.__rel[link];
-
-            if (linkSchema.type === 'hasMany') {
-              Object.keys(linkValue).forEach(function(v) {
-                _this._removeRevLink(linkSchema, type, id, link, v);
-              });
-
-            } else {
-              _this._removeRevLink(linkSchema, type, id, link, linkValue);
-            }
-          });
-        }
-
-      } else if (path.length > 3) {
-        var link = path[3];
-
-        linkSchema = _this.schema.linkDefinition(type, link);
-
-        if (path.length === 5) {
-          linkValue = path[4];
-        } else {
-          linkValue = value;
-        }
-
-        this._removeRevLink(linkSchema, type, id, link, linkValue);
+      switch(operationType) {
+        case 'removeRecord': return this._removeRecordRevLinks(type, id, value, parentOperation);
+        case 'replaceRecord': return this._removeRecordRevLinks(type, id, value, parentOperation);
+        case 'removeHasOne': return this._removeLinkRevLink(type, id, path[3], path[4]);
+        case 'replaceHasOne': return this._removeLinkRevLink(type, id, path[3], path[4]);
+        case 'removeHasMany': return this._removeLinkRevLink(type, id, path[3], value);
+        case 'replaceHasMany': return this._removeLinkRevLink(type, id, path[3], value);
+        case 'removeFromHasMany': return this._removeLinkRevLink(type, id, path[3], path[4]);
       }
+    }
+  },
+
+  _removeLinkRevLink: function(type, id, link, linkValue){
+    var linkSchema = this.schema.linkDefinition(type, link);
+    this._removeRevLink(linkSchema, type, id, link, linkValue);
+  },
+
+  _removeRecordRevLinks: function(type, id, value, parentOperation){
+    // when a whole record is removed, remove any links that reference it
+    if (this.maintainRevLinks) {
+      var _this = this;
+      var revLink = this._revLink(type, id);
+      var operation;
+      var linkSchema;
+      var linkValue;
+
+      Object.keys(revLink).forEach(function(path) {
+        path = _this._doc.deserializePath(path);
+
+        if (path.length === 4) {
+          operation = parentOperation.spawn({
+            op: 'replace',
+            path: path,
+            value: null
+          });
+        } else {
+          operation = parentOperation.spawn({
+            op: 'remove',
+            path: path
+          });
+        }
+
+        _this.transform(operation);
+      });
+
+      delete this._rev[type][id];
+    }
+
+    // when a whole record is removed, remove references corresponding to each link
+    if (value.__rel) {
+      Object.keys(value.__rel).forEach(function(link) {
+        linkSchema = _this.schema.linkDefinition(type, link);
+        linkValue = value.__rel[link];
+
+        if (linkSchema.type === 'hasMany') {
+          Object.keys(linkValue).forEach(function(v) {
+            _this._removeRevLink(linkSchema, type, id, link, v);
+          });
+
+        } else {
+          _this._removeRevLink(linkSchema, type, id, link, linkValue);
+        }
+      });
     }
   },
 

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -337,47 +337,50 @@ var Cache = Class.extend({
     return operations;
   },
 
-  _addRevLinks: function(path, value) {
+  _addRevLinks: function(path, value, operation) {
     // console.log('_addRevLinks', path, value);
-
     if (value) {
-      var _this = this,
-          type = path[0],
+      var type = path[0],
           id = path[1],
-          linkSchema,
-          linkValue;
+          operationType = this._operationEncoder.identify(operation);
 
-      if (path.length === 2) {
-        // when a whole record is added, add inverse links for every link
-        if (value.__rel) {
-          Object.keys(value.__rel).forEach(function(link) {
-            linkSchema = _this.schema.linkDefinition(type, link);
-            linkValue = value.__rel[link];
-
-            if (linkSchema.type === 'hasMany') {
-              Object.keys(linkValue).forEach(function(v) {
-                _this._addRevLink(linkSchema, type, id, link, v);
-              });
-
-            } else {
-              _this._addRevLink(linkSchema, type, id, link, linkValue);
-            }
-          });
-        }
-
-      } else if (path.length > 3) {
-        var link = path[3];
-
-        linkSchema = _this.schema.linkDefinition(type, link);
-
-        if (path.length === 5) {
-          linkValue = path[4];
-        } else {
-          linkValue = value;
-        }
-
-        this._addRevLink(linkSchema, type, id, link, linkValue);
+      switch(operationType) {
+        case 'addRecord': return this._addRecordRevLinks(type, value);
+        case 'replaceRecord': return this._addRecordRevLinks(type, value);
+        case 'addHasOne': return this._addLinkRevLink(type, id, path[3], value);
+        case 'replaceHasOne': return this._addLinkRevLink(type, id, path[3], value);
+        case 'addToHasMany': return this._addLinkRevLink(type, id, path[3], path[4]);
+        case 'addHasMany': return this._addLinkRevLink(type, id, path[3], value);
+        case 'replaceHasMany': return this._addLinkRevLink(type, id, path[3], value);
       }
+    }
+  },
+
+  _addLinkRevLink: function(type, id, link, linkValue) {
+    var linkSchema = this.schema.linkDefinition(type, link);
+    this._addRevLink(linkSchema, type, id, link, linkValue);
+  },
+
+  _addRecordRevLinks: function(type, record) {
+    var id = record.id;
+    var linkValue;
+    var linkSchema;
+    var _this = this;
+
+    if (record.__rel) {
+      Object.keys(record.__rel).forEach(function(link) {
+        linkSchema = _this.schema.linkDefinition(type, link);
+        linkValue = record.__rel[link];
+
+        if (linkSchema.type === 'hasMany') {
+          Object.keys(linkValue).forEach(function(relId) {
+            _this._addRevLink(linkSchema, type, id, link, relId);
+          });
+
+        } else {
+          _this._addRevLink(linkSchema, type, id, link, linkValue);
+        }
+      });
     }
   },
 

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -5,6 +5,7 @@ import { Class, clone, expose, isArray, isObject, isNone } from 'orbit/lib/objec
 import { OperationNotAllowed } from './lib/exceptions';
 import { eq } from 'orbit/lib/eq';
 import { deprecate } from 'orbit/lib/deprecate';
+import OperationEncoder from 'orbit-common/operation-encoder';
 
 /**
  `Cache` provides a thin wrapper over an internally maintained instance of a
@@ -51,6 +52,7 @@ var Cache = Class.extend({
     Evented.extend(this);
 
     this.schema = schema;
+    this._operationEncoder = new OperationEncoder(schema);
     for (var model in schema.models) {
       if (schema.models.hasOwnProperty(model)) {
         this._registerModel(model);
@@ -674,7 +676,7 @@ var Cache = Class.extend({
     // console.log('_relatedAddLinkOp', type, id, key, value);
 
     if (this.retrieve([type, id])) {
-      var op = this._addLinkOp(type, id, key, value);
+      var op = this._operationEncoder.addLinkOp(type, id, key, value);
 
       // Apply operation only if necessary
       if (this.retrieve(op.path) !== op.value) {
@@ -686,72 +688,12 @@ var Cache = Class.extend({
   _relatedRemoveLinkOp: function(type, id, key, value, parentOperation) {
     // console.log('_relatedRemoveLinkOp', type, id, key, value);
 
-    var op = this._removeLinkOp(type, id, key, value);
+    var op = this._operationEncoder.removeLinkOp(type, id, key, value);
 
     // Apply operation only if necessary
     if (this.retrieve(op.path) && !this._isMarkedForRemoval(op.path)) {
       return parentOperation.spawn(op);
     }
-  },
-
-  _addLinkOp: function(type, id, key, value) {
-    var linkDef = this.schema.linkDefinition(type, key);
-    var path = [type, id, '__rel', key];
-    var op;
-
-    if (linkDef.type === 'hasMany') {
-      path.push(value);
-      value = true;
-      op = 'add';
-    } else {
-      op = 'replace';
-    }
-
-    return new Operation({
-      op: op,
-      path: path,
-      value: value
-    });
-  },
-
-  _removeLinkOp: function(type, id, key, value) {
-    var linkDef = this.schema.models[type].links[key];
-    var path = [type, id, '__rel', key];
-    var op;
-
-    if (linkDef.type === 'hasMany') {
-      path.push(value);
-      op = 'remove';
-    } else {
-      op = 'replace';
-      value = null;
-    }
-
-    return new Operation({
-      op: op,
-      path: path,
-      value: value
-    });
-  },
-
-  _updateLinkOp: function(type, id, key, value) {
-    var linkDef = this.schema.models[type].links[key];
-    var path = [type, id, '__rel', key];
-
-    if (linkDef.type === 'hasMany' &&
-        isArray(value)) {
-      var obj = {};
-      for (var i = 0, l = value.length; i < l; i++) {
-        obj[value[i]] = true;
-      }
-      value = obj;
-    }
-
-    return new Operation({
-      op: 'replace',
-      path: path,
-      value: value
-    });
   }
 });
 

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -301,22 +301,6 @@ var Cache = Class.extend({
     return (this._pathsToRemove.indexOf(path) > -1);
   },
 
-  _isOperationRequired: function(operation) {
-    if (operation.op === 'remove') {
-      if (this._isMarkedForRemoval(operation.path)) {
-        // console.log('remove op not required because marked for removal', operation.path);
-        return false;
-      }
-    }
-
-    var currentValue = this.retrieve(operation.path);
-    var desiredValue = operation.value;
-
-    // console.log('op required', !eq(currentValue, desiredValue), operation);
-
-    return !eq(currentValue, desiredValue);
-  },
-
   _dependentOps: function(operation) {
     var operations = [];
     if (operation.op === 'remove' && operation.path.length === 2) {

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -305,8 +305,9 @@ var Cache = Class.extend({
   },
 
   _dependentOps: function(operation) {
+    var operationType = this._operationEncoder.identify(operation);
     var operations = [];
-    if (operation.op === 'remove' && operation.path.length === 2) {
+    if (operationType === 'removeRecord') {
       var _this = this,
         type = operation.path[0],
         id = operation.path[1],

--- a/lib/orbit-common/lib/exceptions.js
+++ b/lib/orbit-common/lib/exceptions.js
@@ -14,6 +14,10 @@ import { Exception } from 'orbit/lib/exceptions';
  */
 var OperationNotAllowed = Exception.extend({
   name: 'OC.OperationNotAllowed',
+  init: function(message, operation){
+    this.operation = operation;
+    this._super(message);
+  }
 });
 
 var ModelNotRegisteredException = Exception.extend({

--- a/lib/orbit-common/operation-encoder.js
+++ b/lib/orbit-common/operation-encoder.js
@@ -14,6 +14,7 @@ export default Class.extend({
 
     if(['add', 'replace', 'remove'].indexOf(op) === -1) throw new OperationNotAllowed("Op must be add, replace or remove (was " + op + ")", operation);
 
+    if(path.length < 2) throw new OperationNotAllowed("Path must have at least 2 segments");
     if(path.length === 2) return op + "Record";
     if(path.length === 3) return op + "Attribute";
 

--- a/lib/orbit-common/operation-encoder.js
+++ b/lib/orbit-common/operation-encoder.js
@@ -41,6 +41,23 @@ export default Class.extend({
     throw new OperationNotAllowed("Invalid operation", operation);
   },
 
+  addRecordOp: function(type, id, record){
+    return new Operation({op: 'add', path: [type, id], value: record});
+  },
+
+  replaceRecordOp: function(type, id, record){
+    return new Operation({op: 'replace', path: [type, id], value: record});
+  },
+
+  removeRecordOp: function(type, id){
+    return new Operation({op: 'remove', path: [type, id]});
+  },
+
+  replaceAttributeOp: function(type, id, attribute, value){
+    var path = [type, id, attribute];
+    return new Operation({op: 'replace', path: path, value: value});
+  },
+
   addLinkOp: function(type, id, key, value) {
     var linkType = this._schema.linkDefinition(type, key).type;
     var path = [type, id, '__rel', key];
@@ -52,6 +69,26 @@ export default Class.extend({
       op = 'add';
     } else {
       op = 'replace';
+    }
+
+    return new Operation({
+      op: op,
+      path: path,
+      value: value
+    });
+  },
+
+  removeLinkOp: function(type, id, key, value) {
+    var linkType = this._schema.linkDefinition(type, key).type;
+    var path = [type, id, '__rel', key];
+    var op;
+
+    if (linkType === 'hasMany') {
+      path.push(value);
+      op = 'remove';
+    } else {
+      op = 'replace';
+      value = null;
     }
 
     return new Operation({
@@ -79,5 +116,5 @@ export default Class.extend({
       path: path,
       value: value
     });
-  }
+  },
 });

--- a/lib/orbit-common/operation-encoder.js
+++ b/lib/orbit-common/operation-encoder.js
@@ -38,7 +38,7 @@ export default Class.extend({
       }
     }
 
-    throw new OperationNotAllowed("Invalid operation", operation);
+    throw new OperationNotAllowed("Invalid operation " + operation.op + ":" + operation.path.join("/") + ":" + operation.value);
   },
 
   addRecordOp: function(type, id, record){
@@ -82,27 +82,7 @@ export default Class.extend({
     });
   },
 
-  removeLinkOp: function(type, id, key, value) {
-    var linkType = this._schema.linkDefinition(type, key).type;
-    var path = [type, id, '__rel', key];
-    var op;
-
-    if (linkType === 'hasMany') {
-      path.push(value);
-      op = 'remove';
-    } else {
-      op = 'replace';
-      value = null;
-    }
-
-    return new Operation({
-      op: op,
-      path: path,
-      value: value
-    });
-  },
-
-  updateLinkOp: function(type, id, key, value) {
+  replaceLinkOp: function(type, id, key, value) {
     var linkType = this._schema.linkDefinition(type, key).type;
     var path = [type, id, '__rel', key];
 
@@ -121,4 +101,24 @@ export default Class.extend({
       value: value
     });
   },
+
+  removeLinkOp: function(type, id, key, value) {
+    var linkType = this._schema.linkDefinition(type, key).type;
+    var path = [type, id, '__rel', key];
+    var op;
+
+    if (linkType === 'hasMany') {
+      path.push(value);
+      op = 'remove';
+    } else {
+      op = 'replace';
+      value = null;
+    }
+
+    return new Operation({
+      op: op,
+      path: path,
+      value: value
+    });
+  }
 });

--- a/lib/orbit-common/operation-encoder.js
+++ b/lib/orbit-common/operation-encoder.js
@@ -1,5 +1,6 @@
-import { Class, isObject } from 'orbit/lib/objects';
+import { Class, isObject, isArray } from 'orbit/lib/objects';
 import { OperationNotAllowed } from 'orbit-common/lib/exceptions';
+import Operation from 'orbit/operation';
 
 export default Class.extend({
   init: function(schema){
@@ -38,5 +39,45 @@ export default Class.extend({
     }
 
     throw new OperationNotAllowed("Invalid operation", operation);
+  },
+
+  addLinkOp: function(type, id, key, value) {
+    var linkType = this._schema.linkDefinition(type, key).type;
+    var path = [type, id, '__rel', key];
+    var op;
+
+    if (linkType === 'hasMany') {
+      path.push(value);
+      value = true;
+      op = 'add';
+    } else {
+      op = 'replace';
+    }
+
+    return new Operation({
+      op: op,
+      path: path,
+      value: value
+    });
+  },
+
+  updateLinkOp: function(type, id, key, value) {
+    var linkType = this._schema.linkDefinition(type, key).type;
+    var path = [type, id, '__rel', key];
+
+    if (linkType === 'hasMany' &&
+        isArray(value)) {
+      var obj = {};
+      for (var i = 0, l = value.length; i < l; i++) {
+        obj[value[i]] = true;
+      }
+      value = obj;
+    }
+
+    return new Operation({
+      op: 'replace',
+      path: path,
+      value: value
+    });
   }
 });

--- a/lib/orbit-common/operation-encoder.js
+++ b/lib/orbit-common/operation-encoder.js
@@ -58,6 +58,10 @@ export default Class.extend({
     return new Operation({op: 'replace', path: path, value: value});
   },
 
+  linkOp: function(op, type, id, key, value){
+    return this[op + 'LinkOp'](type, id, key, value);
+  },
+
   addLinkOp: function(type, id, key, value) {
     var linkType = this._schema.linkDefinition(type, key).type;
     var path = [type, id, '__rel', key];

--- a/lib/orbit-common/operation-encoder.js
+++ b/lib/orbit-common/operation-encoder.js
@@ -1,0 +1,42 @@
+import { Class, isObject } from 'orbit/lib/objects';
+import { OperationNotAllowed } from 'orbit-common/lib/exceptions';
+
+export default Class.extend({
+  init: function(schema){
+    this._schema = schema;
+  },
+
+  identify: function(operation){
+    var op = operation.op;
+    var path = operation.path;
+    var value = operation.value;
+
+    if(['add', 'replace', 'remove'].indexOf(op) === -1) throw new OperationNotAllowed("Op must be add, replace or remove (was " + op + ")", operation);
+
+    if(path.length === 2) return op + "Record";
+    if(path.length === 3) return op + "Attribute";
+
+    if(path[2] === '__rel'){
+      var linkType = this._schema.linkDefinition(path[0], path[3]).type;
+
+      if(linkType === 'hasMany'){
+        if(path.length === 4){
+          if(isObject(value) && ['add', 'replace'].indexOf(op) !== -1) return op + 'HasMany';
+          if(op === 'remove') return 'removeHasMany';
+        }
+        else if(path.length === 5){
+          if(op === 'add') return 'addToHasMany';
+          if(op === 'remove') return 'removeFromHasMany';
+        }
+      }
+      else if (linkType === 'hasOne'){
+        if(op === 'replace') return 'replaceHasOne';
+      }
+      else {
+        throw new OperationNotAllowed("Only hasMany and hasOne links area supported (was " + linkType + ")", operation);
+      }
+    }
+
+    throw new OperationNotAllowed("Invalid operation", operation);
+  }
+});

--- a/lib/orbit-common/operation-encoder.js
+++ b/lib/orbit-common/operation-encoder.js
@@ -31,7 +31,7 @@ export default Class.extend({
         }
       }
       else if (linkType === 'hasOne'){
-        if(op === 'replace') return 'replaceHasOne';
+        return op + 'HasOne';
       }
       else {
         throw new OperationNotAllowed("Only hasMany and hasOne links area supported (was " + linkType + ")", operation);

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -11,16 +11,9 @@ export default Class.extend({
   process: function(operation, condemnedPaths) {
     var _this = this;
     condemnedPaths = condemnedPaths || [];
-    var op = operation.op;
     var path = operation.path;
     var value = operation.value;
     var type = path[0];
-    var record;
-    var key;
-    var linkDef;
-    var linkValue;
-    var inverseLinkOp;
-    var relId;
     var ops = [];
     var schema = this._schema;
     var operationType = this._operationEncoder.identify(operation);
@@ -43,6 +36,7 @@ export default Class.extend({
 
     function addRelatedLinksOpsForRecord(record){
       if (!record.__rel) return;
+      var linkDef;
 
       Object.keys(record.__rel).forEach(function(link) {
         linkDef = schema.linkDefinition(type, link);
@@ -56,6 +50,7 @@ export default Class.extend({
 
     function removeRelatedLinksOpsForRecord(record){
       if (!record.__rel) return [];
+      var linkDef;
 
       Object.keys(record.__rel).forEach(function(link) {
         linkDef = schema.linkDefinition(type, link);
@@ -79,7 +74,7 @@ export default Class.extend({
     // if (operationType === 'replaceHasMany') throw new Error('not implemented');
 
     if (operationType === 'addRecord') {
-      addRelatedLinksOpsForRecord(operation.value);
+      addRelatedLinksOpsForRecord(value);
 
     } else if (operationType === 'removeRecord') {
       removeRelatedLinksOpsForRecord(this._retrieve(path));

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -14,15 +14,8 @@ export default Class.extend({
     var path = operation.path;
     var value = operation.value;
     var type = path[0];
-    var ops = [];
     var schema = this._schema;
     var operationType = this._operationEncoder.identify(operation);
-
-    function pushOps(newOps){
-      for(var i = 0; i < newOps.length; i++){
-        ops.push(newOps[i]);
-      }
-    }
 
     function relatedLinkOps(linkValue, linkDef){
       linkDef = linkDef || schema.linkDefinition(type, path[3]);
@@ -34,50 +27,61 @@ export default Class.extend({
     function addRelatedLinksOpsForRecord(record){
       if (!record.__rel) return;
       var linkDef;
+      var ops = [];
 
       Object.keys(record.__rel).forEach(function(link) {
         linkDef = schema.linkDefinition(type, link);
 
         if (linkDef.inverse) {
           var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
-          pushOps(relatedLinkOps(linkValue, linkDef));
+          var linkOps = relatedLinkOps(linkValue, linkDef);
+
+          for(var i = 0; i < linkOps.length; i++){
+            ops.push(linkOps[i]);
+          }
         }
       });
+
+      return ops;
     }
 
     function removeRelatedLinksOpsForRecord(record){
       if (!record.__rel) return [];
       var linkDef;
+      var ops = [];
 
       Object.keys(record.__rel).forEach(function(link) {
         linkDef = schema.linkDefinition(type, link);
 
         if (linkDef.inverse) {
           var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
-          pushOps(relatedLinkOps(Object.keys(record.__rel[link]), linkDef));
+          var linkOps = relatedLinkOps(Object.keys(record.__rel[link]), linkDef);
+
+          for(var i = 0; i < linkOps.length; i++){
+            ops.push(linkOps[i]);
+          }
         }
       });
+
+      return ops;
     }
 
-    if (operationType === 'addHasOne') return relatedLinkOps(value);
-    if (operationType === 'replaceHasOne') return relatedLinkOps(value);
-    if (operationType === 'removeHasOne') return relatedLinkOps(this._retrieve(path));
+    switch (operationType) {
+      case 'addHasOne': return relatedLinkOps(value);
+      case 'replaceHasOne': return relatedLinkOps(value);
+      case 'removeHasOne': return relatedLinkOps(this._retrieve(path));
 
-    if (operationType === 'addHasMany') return relatedLinkOps(Object.keys(operation.value));
-    if (operationType === 'replaceHasMany') return relatedLinkOps(Object.keys(operation.value));
-    if (operationType === 'removeHasMany') return relatedLinkOps(Object.keys(this._retrieve(path)));
-    if (operationType === 'addToHasMany') return relatedLinkOps(path[4]);
-    if (operationType === 'removeFromHasMany') return relatedLinkOps(path[4]);
+      case 'addHasMany': return relatedLinkOps(Object.keys(operation.value));
+      case 'replaceHasMany': return relatedLinkOps(Object.keys(operation.value));
+      case 'removeHasMany': return relatedLinkOps(Object.keys(this._retrieve(path)));
+      case 'addToHasMany': return relatedLinkOps(path[4]);
+      case 'removeFromHasMany': return relatedLinkOps(path[4]);
 
-    if (operationType === 'addRecord') {
-      addRelatedLinksOpsForRecord(value);
+      case 'addRecord': return addRelatedLinksOpsForRecord(value);
+      case 'removeRecord': return removeRelatedLinksOpsForRecord(this._retrieve(path));
 
-    } else if (operationType === 'removeRecord') {
-      removeRelatedLinksOpsForRecord(this._retrieve(path));
-
+      default: return [];
     }
-
-    return ops;
   },
 
   _relatedLinkOps: function(linkDef, linkValue, value, parentOperation, ignoredPaths){

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -1,0 +1,152 @@
+import { Class, isArray, isObject, isNone } from 'orbit/lib/objects';
+import OperationEncoder from 'orbit-common/operation-encoder';
+
+export default Class.extend({
+  init: function(schema, cache){
+    this._schema = schema;
+    this._cache = cache;
+    this._operationEncoder = new OperationEncoder(schema);
+  },
+
+  process: function(operation, condemnedPaths) {
+    var _this = this;
+    var op = operation.op;
+    var path = operation.path;
+    var value = operation.value;
+    var type = path[0];
+    var record;
+    var key;
+    var linkDef;
+    var linkValue;
+    var inverseLinkOp;
+    var relId;
+    var ops = [];
+    var schema = this._schema;
+    var operationType = this._operationEncoder.identify(operation);
+
+    function pushOps(newOps){
+      for(var i = 0; i < newOps.length; i++){
+        ops.push(newOps[i]);
+      }
+    }
+
+    function relatedAddLinkOps(linkValue, linkDef){
+      linkDef = linkDef || schema.linkDefinition(type, path[3]);
+      return _this._relatedAddLinkOps(linkDef, linkValue, path[1], operation);
+    }
+
+    function relatedRemoveLinkOps(linkValue, linkDef){
+      linkDef = linkDef || schema.linkDefinition(type, path[3]);
+      return _this._relatedRemoveLinkOps(linkDef, linkValue, path[1], operation, condemnedPaths);
+    }
+
+    function addRelatedLinksOpsForRecord(record){
+      if (!record.__rel) return;
+
+      Object.keys(record.__rel).forEach(function(link) {
+        linkDef = schema.linkDefinition(type, link);
+
+        if (linkDef.inverse) {
+          var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
+          pushOps(relatedAddLinkOps(linkValue, linkDef));
+        }
+      });
+    }
+
+    function removeRelatedLinksOpsForRecord(record){
+      if (!record.__rel) return [];
+
+      Object.keys(record.__rel).forEach(function(link) {
+        linkDef = schema.linkDefinition(type, link);
+
+        if (linkDef.inverse) {
+          var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
+          pushOps(relatedRemoveLinkOps(Object.keys(record.__rel[link]), linkDef));
+        }
+      });
+    }
+
+    if (operationType === 'addToHasMany') return relatedAddLinkOps(path[4]);
+    if (operationType === 'addHasOne') return relatedAddLinkOps(value);
+    if (operationType === 'addHasMany') return relatedAddLinkOps(Object.keys(operation.value));
+    if (operationType === 'removeHasOne') return relatedRemoveLinkOps(this._retrieve(path));
+    if (operationType === 'removeHasMany') return relatedRemoveLinkOps(Object.keys(this._retrieve(path)));
+    if (operationType === 'removeFromHasMany') return relatedRemoveLinkOps(path[4]);
+
+    // if (operationType === 'replaceHasOne') throw new Error('not implemented');
+    // if (operationType === 'replaceRecord') throw new Error('not implemented');
+    // if (operationType === 'replaceHasMany') throw new Error('not implemented');
+
+    if (operationType === 'addRecord') {
+      addRelatedLinksOpsForRecord(operation.value);
+
+    } else if (operationType === 'removeRecord') {
+      removeRelatedLinksOpsForRecord(this._retrieve(path));
+
+    }
+
+    return ops;
+  },
+
+  _relatedAddLinkOps: function(linkDef, linkValue, value, operation){
+    if(isNone(linkValue)) return [];
+    var relIds = isArray(linkValue) ? linkValue : [linkValue];
+    var linkOps = [];
+    var linkOp;
+
+    if (linkDef.inverse) {
+      for(var i = 0; i < relIds.length; i++){
+        linkOp = this._relatedAddLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, operation);
+        linkOps.push(linkOp);
+      }
+    }
+
+    return linkOps;
+  },
+
+  _relatedAddLinkOp: function(type, id, link, value, parentOperation) {
+    // console.log('_relatedAddLinkOp', type, id, link, value);
+
+    if (this._retrieve([type, id])) {
+      var op = this._operationEncoder.addLinkOp(type, id, link, value);
+
+      // Apply operation only if necessary
+      if (this._retrieve(op.path) !== op.value) {
+        return parentOperation.spawn(op);
+      }
+    }
+  },
+
+  _relatedRemoveLinkOps: function(linkDef, linkValue, value, operation, condemnedPaths){
+    if(isNone(linkValue)) return [];
+    var relIds = isArray(linkValue) ? linkValue : [linkValue];
+    var linkOps = [];
+    var linkOp;
+
+    if (linkDef.inverse) {
+      for(var i = 0; i < relIds.length; i++){
+        linkOp = this._relatedRemoveLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, operation, condemnedPaths);
+        linkOps.push(linkOp);
+      }
+    }
+
+    return linkOps;
+  },
+
+  _relatedRemoveLinkOp: function(type, id, key, value, parentOperation, condemnedPaths) {
+    // console.log('_relatedRemoveLinkOp', type, id, key, value);
+
+    var op = this._operationEncoder.removeLinkOp(type, id, key, value);
+    var path = op.path.join("/");
+    var isCondemnedPath = condemnedPaths.indexOf(path) > -1;
+
+    // Apply operation only if necessary
+    if (this._retrieve(op.path) && !isCondemnedPath) {
+      return parentOperation.spawn(op);
+    }
+  },
+
+  _retrieve: function(path){
+    return this._cache.retrieve(path);
+  }
+});

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -10,6 +10,7 @@ export default Class.extend({
 
   process: function(operation, condemnedPaths) {
     var _this = this;
+    condemnedPaths = condemnedPaths || [];
     var op = operation.op;
     var path = operation.path;
     var value = operation.value;
@@ -105,8 +106,6 @@ export default Class.extend({
   },
 
   _relatedAddLinkOp: function(type, id, link, value, parentOperation) {
-    // console.log('_relatedAddLinkOp', type, id, link, value);
-
     if (this._retrieve([type, id])) {
       var op = this._operationEncoder.addLinkOp(type, id, link, value);
 

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -59,16 +59,15 @@ export default Class.extend({
       });
     }
 
-    if (operationType === 'addToHasMany') return relatedLinkOps(path[4]);
     if (operationType === 'addHasOne') return relatedLinkOps(value);
-    if (operationType === 'addHasMany') return relatedLinkOps(Object.keys(operation.value));
+    if (operationType === 'replaceHasOne') return relatedLinkOps(value);
     if (operationType === 'removeHasOne') return relatedLinkOps(this._retrieve(path));
-    if (operationType === 'removeHasMany') return relatedLinkOps(Object.keys(this._retrieve(path)));
-    if (operationType === 'removeFromHasMany') return relatedLinkOps(path[4]);
 
-    // if (operationType === 'replaceHasOne') throw new Error('not implemented');
-    // if (operationType === 'replaceRecord') throw new Error('not implemented');
-    // if (operationType === 'replaceHasMany') throw new Error('not implemented');
+    if (operationType === 'addHasMany') return relatedLinkOps(Object.keys(operation.value));
+    if (operationType === 'replaceHasMany') return relatedLinkOps(Object.keys(operation.value));
+    if (operationType === 'removeHasMany') return relatedLinkOps(Object.keys(this._retrieve(path)));
+    if (operationType === 'addToHasMany') return relatedLinkOps(path[4]);
+    if (operationType === 'removeFromHasMany') return relatedLinkOps(path[4]);
 
     if (operationType === 'addRecord') {
       addRelatedLinksOpsForRecord(value);
@@ -88,19 +87,25 @@ export default Class.extend({
     var linkOp;
 
     if (linkDef.inverse) {
+      var relatedOp = this._relatedOp(parentOperation.op, linkDef);
       for(var i = 0; i < relIds.length; i++){
-        linkOp = this._relatedLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, parentOperation, ignoredPaths);
-        linkOps.push(linkOp);
+        linkOp = this._relatedLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, parentOperation, relatedOp, ignoredPaths);
+        if(linkOp) linkOps.push(linkOp);
       }
     }
 
     return linkOps;
   },
 
-  _relatedLinkOp: function(type, id, link, value, parentOperation, ignoredPaths){
+  _relatedOp: function(op, linkDef){
+    var relatedLinkDef = this._schema.linkDefinition(linkDef.model, linkDef.inverse);
+    if(relatedLinkDef.type === 'hasMany' && op === 'replace') return 'add';
+    return op;
+  },
+
+  _relatedLinkOp: function(type, id, link, value, parentOperation, relatedOp, ignoredPaths){
     if (this._retrieve([type, id])) {
-      var op = parentOperation.op;
-      var operation = this._operationEncoder.linkOp(op, type, id, link, value);
+      var operation = this._operationEncoder.linkOp(relatedOp, type, id, link, value);
       var path = operation.path.join("/");
       var isIgnoredPath = ignoredPaths.indexOf(path) > -1;
 

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -55,7 +55,7 @@ export default Class.extend({
 
         if (linkDef.inverse) {
           var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
-          var linkOps = relatedLinkOps(Object.keys(record.__rel[link]), linkDef);
+          var linkOps = relatedLinkOps(linkValue, linkDef);
 
           for(var i = 0; i < linkOps.length; i++){
             ops.push(linkOps[i]);

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -24,14 +24,11 @@ export default Class.extend({
       }
     }
 
-    function relatedAddLinkOps(linkValue, linkDef){
+    function relatedLinkOps(linkValue, linkDef){
       linkDef = linkDef || schema.linkDefinition(type, path[3]);
-      return _this._relatedAddLinkOps(linkDef, linkValue, path[1], operation);
-    }
-
-    function relatedRemoveLinkOps(linkValue, linkDef){
-      linkDef = linkDef || schema.linkDefinition(type, path[3]);
-      return _this._relatedRemoveLinkOps(linkDef, linkValue, path[1], operation, condemnedPaths);
+      var op = operation.op;
+      var ignoredPaths = op === 'remove' ? condemnedPaths : [];
+      return _this._relatedLinkOps(linkDef, linkValue, path[1], operation, ignoredPaths);
     }
 
     function addRelatedLinksOpsForRecord(record){
@@ -43,7 +40,7 @@ export default Class.extend({
 
         if (linkDef.inverse) {
           var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
-          pushOps(relatedAddLinkOps(linkValue, linkDef));
+          pushOps(relatedLinkOps(linkValue, linkDef));
         }
       });
     }
@@ -57,17 +54,17 @@ export default Class.extend({
 
         if (linkDef.inverse) {
           var linkValue = linkDef.type === 'hasMany' ? Object.keys(record.__rel[link]) : record.__rel[link];
-          pushOps(relatedRemoveLinkOps(Object.keys(record.__rel[link]), linkDef));
+          pushOps(relatedLinkOps(Object.keys(record.__rel[link]), linkDef));
         }
       });
     }
 
-    if (operationType === 'addToHasMany') return relatedAddLinkOps(path[4]);
-    if (operationType === 'addHasOne') return relatedAddLinkOps(value);
-    if (operationType === 'addHasMany') return relatedAddLinkOps(Object.keys(operation.value));
-    if (operationType === 'removeHasOne') return relatedRemoveLinkOps(this._retrieve(path));
-    if (operationType === 'removeHasMany') return relatedRemoveLinkOps(Object.keys(this._retrieve(path)));
-    if (operationType === 'removeFromHasMany') return relatedRemoveLinkOps(path[4]);
+    if (operationType === 'addToHasMany') return relatedLinkOps(path[4]);
+    if (operationType === 'addHasOne') return relatedLinkOps(value);
+    if (operationType === 'addHasMany') return relatedLinkOps(Object.keys(operation.value));
+    if (operationType === 'removeHasOne') return relatedLinkOps(this._retrieve(path));
+    if (operationType === 'removeHasMany') return relatedLinkOps(Object.keys(this._retrieve(path)));
+    if (operationType === 'removeFromHasMany') return relatedLinkOps(path[4]);
 
     // if (operationType === 'replaceHasOne') throw new Error('not implemented');
     // if (operationType === 'replaceRecord') throw new Error('not implemented');
@@ -84,7 +81,7 @@ export default Class.extend({
     return ops;
   },
 
-  _relatedAddLinkOps: function(linkDef, linkValue, value, operation){
+  _relatedLinkOps: function(linkDef, linkValue, value, parentOperation, ignoredPaths){
     if(isNone(linkValue)) return [];
     var relIds = isArray(linkValue) ? linkValue : [linkValue];
     var linkOps = [];
@@ -92,7 +89,7 @@ export default Class.extend({
 
     if (linkDef.inverse) {
       for(var i = 0; i < relIds.length; i++){
-        linkOp = this._relatedAddLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, operation);
+        linkOp = this._relatedLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, parentOperation, ignoredPaths);
         linkOps.push(linkOp);
       }
     }
@@ -100,43 +97,17 @@ export default Class.extend({
     return linkOps;
   },
 
-  _relatedAddLinkOp: function(type, id, link, value, parentOperation) {
+  _relatedLinkOp: function(type, id, link, value, parentOperation, ignoredPaths){
     if (this._retrieve([type, id])) {
-      var op = this._operationEncoder.addLinkOp(type, id, link, value);
+      var op = parentOperation.op;
+      var operation = this._operationEncoder.linkOp(op, type, id, link, value);
+      var path = operation.path.join("/");
+      var isIgnoredPath = ignoredPaths.indexOf(path) > -1;
 
       // Apply operation only if necessary
-      if (this._retrieve(op.path) !== op.value) {
-        return parentOperation.spawn(op);
+      if (this._retrieve(operation.path) !== operation.value && !isIgnoredPath) {
+        return parentOperation.spawn(operation);
       }
-    }
-  },
-
-  _relatedRemoveLinkOps: function(linkDef, linkValue, value, operation, condemnedPaths){
-    if(isNone(linkValue)) return [];
-    var relIds = isArray(linkValue) ? linkValue : [linkValue];
-    var linkOps = [];
-    var linkOp;
-
-    if (linkDef.inverse) {
-      for(var i = 0; i < relIds.length; i++){
-        linkOp = this._relatedRemoveLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, operation, condemnedPaths);
-        linkOps.push(linkOp);
-      }
-    }
-
-    return linkOps;
-  },
-
-  _relatedRemoveLinkOp: function(type, id, key, value, parentOperation, condemnedPaths) {
-    // console.log('_relatedRemoveLinkOp', type, id, key, value);
-
-    var op = this._operationEncoder.removeLinkOp(type, id, key, value);
-    var path = op.path.join("/");
-    var isCondemnedPath = condemnedPaths.indexOf(path) > -1;
-
-    // Apply operation only if necessary
-    if (this._retrieve(op.path) && !isCondemnedPath) {
-      return parentOperation.spawn(op);
     }
   },
 

--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -137,7 +137,7 @@ var Source = Class.extend({
     id = this._normalizeId(type, id);
     value = this._normalizeLink(type, key, value);
 
-    var op = this._operationEncoder.updateLinkOp(type, id, key, value);
+    var op = this._operationEncoder.replaceLinkOp(type, id, key, value);
     return this.transform(op);
   },
 

--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -8,6 +8,7 @@ import { Class, expose, isArray, isObject, isNone } from 'orbit/lib/objects';
 import Cache from './cache';
 import Operation from 'orbit/operation';
 import { LinkNotFoundException } from './lib/exceptions';
+import OperationEncoder from 'orbit-common/operation-encoder';
 
 /**
  `Source` is an abstract base class to be extended by other sources.
@@ -28,9 +29,10 @@ var Source = Class.extend({
 
     // Create an internal cache and expose some elements of its interface
     this._cache = new Cache(schema);
-    expose(this, this._cache,
-           'length', 'reset', 'retrieve', 'retrieveLink',
-           '_addLinkOp', '_removeLinkOp', '_updateLinkOp');
+    expose(this, this._cache, 'length', 'reset', 'retrieve', 'retrieveLink');
+
+    this._operationEncoder = new OperationEncoder(schema);
+
     // TODO - clean up listener
     this._cache.on('didTransform', this._cacheDidTransform, this);
 
@@ -89,7 +91,7 @@ var Source = Class.extend({
         path = [type, id],
         _this = this;
 
-    return this.transform({op: 'add', path: path, value: record}).then(function() {
+    return this.transform(this._operationEncoder.addRecordOp(type, id, record)).then(function() {
       return _this.retrieve(path);
     });
   },
@@ -97,37 +99,33 @@ var Source = Class.extend({
   _update: function(type, data) {
     var record = this.normalize(type, data);
     var id = this.getId(type, record);
-    var path = [type, id];
 
-    return this.transform({op: 'replace', path: path, value: record});
+    return this.transform(this._operationEncoder.replaceRecordOp(type, id, record));
   },
 
-  _patch: function(type, id, property, value) {
+  _patch: function(type, id, attribute, value) {
     id = this._normalizeId(type, id);
-    var path = [type, id].concat(Document.prototype.deserializePath(property));
-
-    return this.transform({op: 'replace', path: path, value: value});
+    // todo - confirm this simplification is valid (i.e. don't attempt to deserialize attribute path)
+    return this.transform(this._operationEncoder.replaceAttributeOp(type, id, attribute, value));
   },
 
   _remove: function(type, id) {
     id = this._normalizeId(type, id);
-    var path = [type, id];
-
-    return this.transform({op: 'remove', path: path});
+    return this.transform(this._operationEncoder.removeRecordOp(type, id));
   },
 
   _addLink: function(type, id, key, value) {
     id = this._normalizeId(type, id);
     value = this._normalizeLink(type, key, value);
 
-    return this.transform(this._addLinkOp(type, id, key, value));
+    return this.transform(this._operationEncoder.addLinkOp(type, id, key, value));
   },
 
   _removeLink: function(type, id, key, value) {
     id = this._normalizeId(type, id);
     value = this._normalizeLink(type, key, value);
 
-    return this.transform(this._removeLinkOp(type, id, key, value));
+    return this.transform(this._operationEncoder.removeLinkOp(type, id, key, value));
   },
 
   _updateLink: function(type, id, key, value) {
@@ -139,7 +137,7 @@ var Source = Class.extend({
     id = this._normalizeId(type, id);
     value = this._normalizeLink(type, key, value);
 
-    var op = this._updateLinkOp(type, id, key, value);
+    var op = this._operationEncoder.updateLinkOp(type, id, key, value);
     return this.transform(op);
   },
 

--- a/test/tests/orbit-common/unit/memory-source-test.js
+++ b/test/tests/orbit-common/unit/memory-source-test.js
@@ -5,6 +5,7 @@ import Source from 'orbit-common/source';
 import { all, Promise } from 'rsvp';
 import { RecordNotFoundException, LinkNotFoundException } from 'orbit-common/lib/exceptions';
 import { spread } from 'orbit/lib/functions';
+import 'tests/test-helper';
 
 var source;
 

--- a/test/tests/orbit-common/unit/operation-encoder-test.js
+++ b/test/tests/orbit-common/unit/operation-encoder-test.js
@@ -1,0 +1,169 @@
+import { Promise } from 'rsvp';
+import Schema from 'orbit-common/schema';
+import OperationEncoder from 'orbit-common/operation-encoder';
+import Orbit from 'orbit/main';
+import { op } from 'tests/test-helper';
+import { OperationNotAllowed } from 'orbit-common/lib/exceptions';
+
+var schemaDefinition = {
+  models: {
+    planet: {
+      attributes: {
+        name: {type: 'string'},
+        classification: {type: 'string'}
+      },
+      links: {
+        moons: {type: 'hasMany', model: 'moon', inverse: 'planet'}
+      }
+    },
+    moon: {
+      attributes: {
+        name: {type: 'string'}
+      },
+      links: {
+        planet: {type: 'hasOne', model: 'planet', inverse: 'moons'}
+      }
+    }
+  }
+};
+
+var operationEncoder;
+
+module("OC - OperationEncoder", {
+  setup: function() {
+    Orbit.Promise = Promise;
+
+    var schema = new Schema(schemaDefinition);
+    operationEncoder = new OperationEncoder(schema);
+  },
+
+  teardown: function(){
+    operationEncoder = null;
+  }
+});
+
+function identifiesAsInvalid(operation){
+  try {
+    operationEncoder.identify(operation);
+    ok(false, "should have identified operation as invalid");
+  }
+  catch(exception){
+    if (exception instanceof OperationNotAllowed) {
+      ok(true, "invalid operation");
+    } else {
+      throw exception;
+    }
+  }
+}
+
+function identifies(operation, operationType){
+  equal(
+    operationEncoder.identify(operation),
+    operationType,
+    "identified " + operationType
+  );
+}
+
+test("identifies addRecord", function(){
+  identifies(op('add', 'planet/planet1', {id: 'planet1', name: "Europa"}), 'addRecord');
+});
+
+test("identifies replaceRecord", function(){
+  identifies(op('replace', 'planet/planet1', {id: 'planet1', name: "Europa"}), 'replaceRecord');
+});
+
+test("identifies removeRecord", function(){
+  identifies(op('remove', 'planet/planet1', {id: 'planet1', name: "Europa"}), 'removeRecord');
+});
+
+test('identifies addHasMany with populated value', function(){
+  identifies(op('add', 'planet/planet1/__rel/moons', {'moon1': true, 'moon2': true}), 'addHasMany');
+});
+
+test('identifies addHasMany with empty value', function(){
+  identifies(op('add', 'planet/planet1/__rel/moons', {}), 'addHasMany');
+});
+
+test('identifies addHasMany with null value as invalid', function(){
+  identifiesAsInvalid(op('add', 'planet/planet1/__rel/moons', null));
+});
+
+test('identifies addHasMany with undefined value as invalid', function(){
+  identifiesAsInvalid(op('add', 'planet/planet1/__rel/moons', undefined));
+});
+
+test('identifies replaceHasMany with populated value', function(){
+  identifies(op('add', 'planet/planet1/__rel/moons', {'moon1': true, 'moon2': true}), 'addHasMany');
+});
+
+test('identifies replaceHasMany with null value as invalid', function(){
+  identifiesAsInvalid(op('replace', 'planet/planet1/__rel/moons', null));
+});
+
+test('identifies replaceHasMany with undefined value as invalid', function(){
+  identifiesAsInvalid(op('replace', 'planet/planet1/__rel/moons', undefined));
+});
+
+test('identifies removeHasMany', function(){
+  identifies(op('remove', 'planet/planet1/__rel/moons'), 'removeHasMany');
+});
+
+test("identifies addToHasMany", function(){
+  identifies(op('add', 'planet/planet1/__rel/moons/moon1', true), 'addToHasMany');
+});
+
+test("identifies removeFromHasMany", function(){
+  identifies(op('remove', 'planet/planet1/__rel/moons/moon1'), 'removeFromHasMany');
+});
+
+test("identifies addHasOne as invalid", function(){
+  identifiesAsInvalid(op('add', 'moon/moon1/__rel/planet', 'planet1'));
+});
+
+test("identifies replaceHasOne", function(){
+  identifies(op('replace', 'moon/moon1/__rel/planet', 'planet1'), 'replaceHasOne');
+});
+
+test("identifies removeHasOne as invalid", function(){
+  identifiesAsInvalid(op('remove', 'moon/moon1/__rel/planet'));
+});
+
+test("identifies addAttribute", function(){
+  identifies(op('add', 'planet/planet1/name', 'Jupiter'), 'addAttribute');
+});
+
+test("identifies replaceAttribute", function(){
+  identifies(op('replace', 'planet/planet1/name', 'Jupiter'), 'replaceAttribute');
+});
+
+test("identifies removeAttribute", function(){
+  identifies(op('remove', 'planet/planet1/name'), 'removeAttribute');
+});
+
+test("generates addToHasMany", function(){
+  deepEqual(
+    operationEncoder.addLinkOp('planet', 'planet1', 'moons', 'moon1').serialize(),
+    op('add', 'planet/planet1/__rel/moons/moon1', true).serialize()
+  );
+});
+
+test("generates replaceHasOne (via addLinkOp)", function(){
+  deepEqual(
+    operationEncoder.addLinkOp('moon', 'moon1', 'planet', 'planet1').serialize(),
+    op('replace', 'moon/moon1/__rel/planet', 'planet1').serialize()
+  );
+});
+
+test("generates replaceHasOne (via updateLinkOp)", function(){
+  deepEqual(
+    operationEncoder.updateLinkOp('moon', 'moon1', 'planet', 'planet1').serialize(),
+    op('replace', 'moon/moon1/__rel/planet', 'planet1').serialize()
+  );
+});
+
+test("generates replaceHasMany", function(){
+  deepEqual(
+    operationEncoder.updateLinkOp('planet', 'planet1', 'moons', ['moon1', 'moon2']).serialize(),
+    op('replace', 'planet/planet1/__rel/moons', {'moon1': true, 'moon2': true}).serialize()
+  );
+});

--- a/test/tests/orbit-common/unit/operation-encoder-test.js
+++ b/test/tests/orbit-common/unit/operation-encoder-test.js
@@ -116,16 +116,16 @@ test("identifies removeFromHasMany", function(){
   identifies(op('remove', 'planet/planet1/__rel/moons/moon1'), 'removeFromHasMany');
 });
 
-test("identifies addHasOne as invalid", function(){
-  identifiesAsInvalid(op('add', 'moon/moon1/__rel/planet', 'planet1'));
+test("identifies addHasOne", function(){
+  identifies(op('add', 'moon/moon1/__rel/planet', 'planet1'), 'addHasOne');
 });
 
 test("identifies replaceHasOne", function(){
   identifies(op('replace', 'moon/moon1/__rel/planet', 'planet1'), 'replaceHasOne');
 });
 
-test("identifies removeHasOne as invalid", function(){
-  identifiesAsInvalid(op('remove', 'moon/moon1/__rel/planet'));
+test("identifies removeHasOne", function(){
+  identifies(op('remove', 'moon/moon1/__rel/planet'), 'removeHasOne');
 });
 
 test("identifies addAttribute", function(){

--- a/test/tests/orbit-common/unit/operation-encoder-test.js
+++ b/test/tests/orbit-common/unit/operation-encoder-test.js
@@ -140,30 +140,69 @@ test("identifies removeAttribute", function(){
   identifies(op('remove', 'planet/planet1/name'), 'removeAttribute');
 });
 
-test("generates addToHasMany", function(){
+test("encodes addRecord", function(){
+  var record = {id: 'planet1', name: "Europa"};
+
+  deepEqual(
+    operationEncoder.addRecordOp('planet', 'planet1', record).serialize(),
+    op('add', 'planet/planet1', record).serialize()
+  );
+});
+
+test("encodes replaceRecord", function(){
+  var record = {id: 'planet1', name: "Europa"};
+
+  deepEqual(
+    operationEncoder.replaceRecordOp('planet', 'planet1', record).serialize(),
+    op('replace', 'planet/planet1', record).serialize()
+  );
+});
+
+test("encodes removeRecord", function(){
+  deepEqual(
+    operationEncoder.removeRecordOp('planet', 'planet1').serialize(),
+    op('remove', 'planet/planet1').serialize()
+  );
+});
+
+test("encodes addToHasMany", function(){
   deepEqual(
     operationEncoder.addLinkOp('planet', 'planet1', 'moons', 'moon1').serialize(),
     op('add', 'planet/planet1/__rel/moons/moon1', true).serialize()
   );
 });
 
-test("generates replaceHasOne (via addLinkOp)", function(){
+test("encodes replaceHasOne (via addLinkOp)", function(){
   deepEqual(
     operationEncoder.addLinkOp('moon', 'moon1', 'planet', 'planet1').serialize(),
     op('replace', 'moon/moon1/__rel/planet', 'planet1').serialize()
   );
 });
 
-test("generates replaceHasOne (via updateLinkOp)", function(){
+test("encodes replaceHasOne (via updateLinkOp)", function(){
   deepEqual(
     operationEncoder.updateLinkOp('moon', 'moon1', 'planet', 'planet1').serialize(),
     op('replace', 'moon/moon1/__rel/planet', 'planet1').serialize()
   );
 });
 
-test("generates replaceHasMany", function(){
+test("encodes replaceHasOne (via removeLinkOp)", function(){
+  deepEqual(
+    operationEncoder.removeLinkOp('moon', 'moon1', 'planet', 'planet1').serialize(),
+    op('replace', 'moon/moon1/__rel/planet', null).serialize()
+  );
+});
+
+test("encodes replaceHasMany", function(){
   deepEqual(
     operationEncoder.updateLinkOp('planet', 'planet1', 'moons', ['moon1', 'moon2']).serialize(),
     op('replace', 'planet/planet1/__rel/moons', {'moon1': true, 'moon2': true}).serialize()
+  );
+});
+
+test("encodes removeFromHasMany", function(){
+  deepEqual(
+    operationEncoder.removeLinkOp('planet', 'planet1', 'moons', 'moon1').serialize(),
+    op('remove', 'planet/planet1/__rel/moons/moon1').serialize()
   );
 });

--- a/test/tests/orbit-common/unit/operation-encoder-test.js
+++ b/test/tests/orbit-common/unit/operation-encoder-test.js
@@ -179,9 +179,9 @@ test("encodes replaceHasOne (via addLinkOp)", function(){
   );
 });
 
-test("encodes replaceHasOne (via updateLinkOp)", function(){
+test("encodes replaceHasOne (via replaceLinkOp)", function(){
   deepEqual(
-    operationEncoder.updateLinkOp('moon', 'moon1', 'planet', 'planet1').serialize(),
+    operationEncoder.replaceLinkOp('moon', 'moon1', 'planet', 'planet1').serialize(),
     op('replace', 'moon/moon1/__rel/planet', 'planet1').serialize()
   );
 });
@@ -195,7 +195,7 @@ test("encodes replaceHasOne (via removeLinkOp)", function(){
 
 test("encodes replaceHasMany", function(){
   deepEqual(
-    operationEncoder.updateLinkOp('planet', 'planet1', 'moons', ['moon1', 'moon2']).serialize(),
+    operationEncoder.replaceLinkOp('planet', 'planet1', 'moons', ['moon1', 'moon2']).serialize(),
     op('replace', 'planet/planet1/__rel/moons', {'moon1': true, 'moon2': true}).serialize()
   );
 });

--- a/test/tests/orbit-common/unit/operation-processors/related-inverse-links-test.js
+++ b/test/tests/orbit-common/unit/operation-processors/related-inverse-links-test.js
@@ -1,0 +1,316 @@
+import Schema from 'orbit-common/schema';
+import RelatedInverseLinksProcessor from 'orbit-common/operation-processors/related-inverse-links';
+import { uuid } from 'orbit/lib/uuid';
+import Operation from 'orbit/operation';
+import { op } from 'tests/test-helper';
+import Cache from 'orbit-common/cache';
+import Orbit from 'orbit/main';
+import { Promise } from 'rsvp';
+
+var schemaDefinition = {
+  modelDefaults: {
+    keys: {
+      '__id': {primaryKey: true, defaultValue: uuid}
+    }
+  },
+  models: {
+    planet: {
+      attributes: {
+        name: {type: 'string'},
+        classification: {type: 'string'}
+      },
+      links: {
+        moons: {type: 'hasMany', model: 'moon', inverse: 'planet', actsAsSet: true},
+        races: {type: 'hasMany', model: 'race', inverse: 'planets'},
+        next: {type: 'hasOne', model: 'planet', inverse: 'previous'},
+        previous: {type: 'hasOne', model: 'planet', inverse: 'next'}
+      }
+    },
+    moon: {
+      attributes: {
+        name: {type: 'string'}
+      },
+      links: {
+        planet: {type: 'hasOne', model: 'planet', inverse: 'moons'}
+      }
+    },
+    race: {
+      attributes: {
+        name: {type: 'string'},
+      },
+      links: {
+        planets: {type: 'hasMany', model: 'planet', inverse: 'races'}
+      }
+    }
+  }
+};
+
+var schema,
+    cache,
+    processor;
+
+module('OC - OperationProcessors - RelatedInverseLinks', {
+  setup: function(){
+    Orbit.Promise = Promise;
+
+    schema = new Schema(schemaDefinition);
+    cache = new Cache(schema);
+    processor = new RelatedInverseLinksProcessor(schema, cache);
+  },
+
+  teardown: function(){
+    schema = null;
+    cache = null;
+    processor = null;
+  }
+});
+
+function operationsShouldMatch(actualOperations, expectedOperations){
+  equal(actualOperations.length, expectedOperations.length, 'Same number of operations');
+
+  for(var i = 0; i < actualOperations.length; i++){
+    var actual = actualOperations[i];
+    var expected = expectedOperations[i];
+    deepEqual(actual.serialize(), expected.serialize(), "Operation " + i + " matches");
+  }
+}
+
+
+test('add to hasOne => hasMany', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: { 'titan': true } } };
+  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: { 'europa': true } } };
+  var titan = { id: 'titan', name: "Titan", __rel: { planet: 'saturn' } };
+  var europa = { id: 'europa', name: "Europa", __rel: { planet: 'jupiter' } };
+
+  cache.reset({
+    planet: { saturn: saturn, jupiter: jupiter },
+    moon: { titan: titan, europa: europa }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('add', ['moon', europa.id, '__rel', 'planet'], saturn.id)
+    ),
+    [
+      // op('remove', ['planet', jupiter.id, '__rel', 'moons', europa.id]),
+      op('add', ['planet', saturn.id, '__rel', 'moons', europa.id], true)
+    ]
+  );
+});
+
+test('replace hasMany => hasOne with empty array', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: { 'titan': true } } };
+  var titan = { id: 'titan', name: "Titan", __rel: { planet: 'saturn' } };
+
+  cache.reset({
+    planet: { saturn: saturn },
+    moon: { titan: titan }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('replace', ['planet', saturn.id, '__rel', 'moons'], {})
+    ),
+    [
+      // op('remove', ['moon', titan.id, '__rel', 'planet'])
+    ]
+  );
+});
+
+test('replace hasMany => hasOne with empty array', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: { 'titan': true } } };
+  var titan = { id: 'titan', name: "Titan", __rel: { planet: 'saturn' } };
+
+  cache.reset({
+    planet: { saturn: saturn },
+    moon: { titan: titan }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('replace', ['planet', saturn.id, '__rel', 'moons'], {})
+    ),
+    [
+      // op('remove', ['moon', titan.id, '__rel', 'planet'])
+    ]
+  );
+});
+
+test('replace hasMany => hasOne with populated array', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: { 'titan': true } } };
+  var titan = { id: 'titan', name: "Titan", __rel: { planet: 'saturn' } };
+  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: {} } };
+
+  cache.reset({
+    planet: { saturn: saturn, jupiter: jupiter },
+    moon: { titan: titan }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('replace', ['planet', jupiter.id, '__rel', 'moons'], {titan: true})
+    ),
+    [
+      // op('add', ['moon', titan.id, '__rel', 'planet'], jupiter.id),
+      // op('remove', ['planet', saturn.id, '__rel', 'moons', titan.id])
+    ]
+  );
+});
+
+test('replace hasMany => hasMany', function(){
+  var human = { id: 'human', __rel: { planets: { earth: true } }};
+  var earth = { id: 'earth', __rel: { races: { human: true}  }};
+
+  cache.reset({
+    race: { human: human },
+    planet: { earth: earth }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('replace', ['planet', earth.id, '__rel', 'races'], {})
+    ),
+    [
+      // op('replace', ['planet', earth.id, '__rel', 'races'], {})
+    ]
+  );
+});
+
+test('remove hasOne => hasMany', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: { 'titan': true } } };
+  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: { 'europa': true } } };
+  var titan = { id: 'titan', name: "Titan", __rel: { planet: 'saturn' } };
+  var europa = { id: 'europa', name: "Europa", __rel: { planet: 'jupiter' } };
+
+  cache.reset({
+    planet: { saturn: saturn, jupiter: jupiter },
+    moon: { titan: titan, europa: europa }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('remove', ['moon', europa.id, '__rel', 'planet'])
+    ),
+    [
+      op('remove', ['planet', jupiter.id, '__rel', 'moons', europa.id])
+    ]
+  );
+});
+
+test('add to hasOne => hasOne', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: {}, next: 'jupiter' } };
+  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: {}, previous: 'saturn' } };
+  var earth = { id: 'earth', name: "Earth", __rel: { moons: {} } };
+
+  cache.reset({
+    planet: { saturn: saturn, jupiter: jupiter, earth: earth }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('add', ['planet', earth.id, '__rel', 'next'], saturn.id)
+    ),
+    [
+      op('replace', ['planet', saturn.id, '__rel', 'previous'], earth.id)
+    ]
+  );
+});
+
+test('add to hasOne => hasOne with existing value', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: {}, next: 'jupiter' } };
+  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: {}, previous: 'saturn' } };
+  var earth = { id: 'earth', name: "Earth", __rel: { moons: {} } };
+
+  cache.reset({
+    planet: { saturn: saturn, jupiter: jupiter, earth: earth }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('add', ['planet', earth.id, '__rel', 'next'], jupiter.id)
+    ),
+    [
+      op('replace', ['planet', jupiter.id, '__rel', 'previous'], earth.id),
+      // op('remove', ['planet', saturn.id, '__rel', 'next'])
+    ]
+  );
+});
+
+test('replace hasOne => hasOne with existing value', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: {}, next: 'jupiter' } };
+  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: {}, previous: 'saturn' } };
+  var earth = { id: 'earth', name: "Earth", __rel: { moons: {} } };
+
+  cache.reset({
+    planet: { saturn: saturn, jupiter: jupiter, earth: earth }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('replace', ['planet', earth.id, '__rel', 'next'], jupiter.id)
+    ),
+    [
+      // op('add', ['planet', jupiter.id, '__rel', 'previous'], earth.id),
+      // op('remove', ['planet', saturn.id, '__rel', 'next'])
+    ]
+  );
+});
+
+test('replace hasOne => hasOne with existing value', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: {}, next: 'jupiter' } };
+  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: {}, previous: 'saturn' } };
+  var earth = { id: 'earth', name: "Earth", __rel: { moons: {} } };
+
+  cache.reset({
+    planet: { saturn: saturn, jupiter: jupiter, earth: earth }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('replace', ['planet', earth.id, '__rel', 'next'], jupiter.id)
+    ),
+    [
+      // op('add', ['planet', jupiter.id, '__rel', 'previous'], earth.id),
+      // op('remove', ['planet', saturn.id, '__rel', 'next'])
+    ]
+  );
+});
+
+test('add to hasMany => hasMany', function(){
+  var earth = { id: 'earth' };
+  var human = { id: 'human' };
+
+  cache.reset({
+    planet: { earth: earth },
+    race: { human: human}
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('add', ['race', human.id, '__rel', 'planets', earth.id], true)
+    ),
+    [
+      op('add', ['planet', earth.id, '__rel','races', human.id], true)
+    ]
+  );
+});
+
+test('remove from hasMany => hasMany', function(){
+  var earth = { id: 'earth', __rel: { races: { human: true } } };
+  var human = { id: 'human', __rel: { planets: { earth: true} } };
+
+  cache.reset({
+    planet: { earth: earth },
+    race: { human: human }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('remove', ['race', human.id, '__rel', 'planets', earth.id])
+    ),
+    [
+      op('remove', ['planet', earth.id, '__rel','races', human.id])
+    ]
+  );
+});
+

--- a/test/tests/orbit-common/unit/operation-processors/related-inverse-links-test.js
+++ b/test/tests/orbit-common/unit/operation-processors/related-inverse-links-test.js
@@ -66,6 +66,7 @@ module('OC - OperationProcessors - RelatedInverseLinks', {
 });
 
 function operationsShouldMatch(actualOperations, expectedOperations){
+  console.log("actual", actualOperations);
   equal(actualOperations.length, expectedOperations.length, 'Same number of operations');
 
   for(var i = 0; i < actualOperations.length; i++){
@@ -90,6 +91,28 @@ test('add to hasOne => hasMany', function(){
   operationsShouldMatch(
     processor.process(
       op('add', ['moon', europa.id, '__rel', 'planet'], saturn.id)
+    ),
+    [
+      // op('remove', ['planet', jupiter.id, '__rel', 'moons', europa.id]),
+      op('add', ['planet', saturn.id, '__rel', 'moons', europa.id], true)
+    ]
+  );
+});
+
+test('replace hasOne => hasMany', function(){
+  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: { 'titan': true } } };
+  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: { 'europa': true } } };
+  var titan = { id: 'titan', name: "Titan", __rel: { planet: 'saturn' } };
+  var europa = { id: 'europa', name: "Europa", __rel: { planet: 'jupiter' } };
+
+  cache.reset({
+    planet: { saturn: saturn, jupiter: jupiter },
+    moon: { titan: titan, europa: europa }
+  });
+
+  operationsShouldMatch(
+    processor.process(
+      op('replace', ['moon', europa.id, '__rel', 'planet'], saturn.id)
     ),
     [
       // op('remove', ['planet', jupiter.id, '__rel', 'moons', europa.id]),
@@ -151,7 +174,7 @@ test('replace hasMany => hasOne with populated array', function(){
       op('replace', ['planet', jupiter.id, '__rel', 'moons'], {titan: true})
     ),
     [
-      // op('add', ['moon', titan.id, '__rel', 'planet'], jupiter.id),
+      op('replace', ['moon', titan.id, '__rel', 'planet'], jupiter.id),
       // op('remove', ['planet', saturn.id, '__rel', 'moons', titan.id])
     ]
   );
@@ -250,27 +273,7 @@ test('replace hasOne => hasOne with existing value', function(){
       op('replace', ['planet', earth.id, '__rel', 'next'], jupiter.id)
     ),
     [
-      // op('add', ['planet', jupiter.id, '__rel', 'previous'], earth.id),
-      // op('remove', ['planet', saturn.id, '__rel', 'next'])
-    ]
-  );
-});
-
-test('replace hasOne => hasOne with existing value', function(){
-  var saturn = { id: 'saturn', name: "Saturn", __rel: { moons: {}, next: 'jupiter' } };
-  var jupiter = { id: 'jupiter', name: "Jupiter", __rel: { moons: {}, previous: 'saturn' } };
-  var earth = { id: 'earth', name: "Earth", __rel: { moons: {} } };
-
-  cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter, earth: earth }
-  });
-
-  operationsShouldMatch(
-    processor.process(
-      op('replace', ['planet', earth.id, '__rel', 'next'], jupiter.id)
-    ),
-    [
-      // op('add', ['planet', jupiter.id, '__rel', 'previous'], earth.id),
+      op('replace', ['planet', jupiter.id, '__rel', 'previous'], earth.id),
       // op('remove', ['planet', saturn.id, '__rel', 'next'])
     ]
   );

--- a/test/tests/test-helper.js
+++ b/test/tests/test-helper.js
@@ -1,4 +1,10 @@
 import Operation from 'orbit/operation';
+import { on } from 'rsvp';
+
+on('error', function(reason){
+  console.log(reason);
+  console.error(reason.message, reason.stack);
+});
 
 var verifyLocalStorageContainsRecord = function(namespace, type, id, record, ignoreFields) {
   var expected = {};

--- a/test/tests/test-helper.js
+++ b/test/tests/test-helper.js
@@ -36,7 +36,7 @@ var equalOps = function(result, expected, msg) {
 
 function op(opType, path, value){
   var operation = new Operation({op: opType, path: path});
-  if(value) operation.value = value;
+  if(value !== undefined) operation.value = value;
   return operation;
 }
 


### PR DESCRIPTION
This PR pulls together operation encoding and identification into a single class, OperationEncoder. The intention is to ensure that operations are created and identified consistently. I've moved the terminology towards that of the schema but I think it could be made even closer (see below).

#### Operation identification

Currently this is handled by various conditions throughout the code such as operation.path.length === 4. This can cause problems however, e.g. I wanted to set a hasMany with

    {op: `add`, path: `planet/planet1/__rel/moons`, value: {}}

but it was being misidentified as an add hasOne.

The operationEncoder introduces an `identify(operation)` method which will respond with one of the following: `addRecord`, `replaceRecord`, `removeRecord`, `addHasMany`, `replaceHasMany`, `removeHasMany`, `addToHasMany`, `removeFromHasMany`, `addHasOne`, `replaceHasOne`, `removeHasOne`, `addAttribute`, `replaceAttribute`, `removeAttribute`.

If the operation can't be identified it will throw an OperationNotAllowed error.


#### Operation generation

The operationEncoder introduces the following methods: `addRecordOp()`, `replaceRecordOp()`, `removeRecordOp()`, `replaceAttributeOp()`, `addLinkOp()`, `removeLinkOp()` and `updateLinkOp()`. The intention is to match the schema semantics as far as possible, the exception being the link operations which I`d perhaps prefer to mirror the identifiers returned by operationEncoder.identify(). This seems like a good place to start though.
    

I'm going to continue this PR by swapping out conditionals where appropriate to make use of the identification provided by `operationEncoder.identify()` but I'm keen to hear what people think about the general direction.