### PR TITLE
Cache no longer tracks changes and emits events.

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -1,5 +1,4 @@
 import Document from 'orbit/document';
-import Evented from 'orbit/evented';
 import Operation from 'orbit/operation';
 import { Class, clone, expose, isArray, isObject, isNone } from 'orbit/lib/objects';
 import { OperationNotAllowed } from './lib/exceptions';
@@ -22,7 +21,6 @@ import RelatedInverseLinksProcessor from 'orbit-common/operation-processors/rela
  @namespace OC
  @param {OC.Schema} schema
  @param {Object}  [options]
- @param {Boolean} [options.trackChanges=true] Should the `didTransform` event be triggered after calls to `transform`?
  @param {Boolean} [options.maintainRevLinks=true] Should reverse links be maintained for each record, indicating which other records reference them?
  @param {Boolean} [options.maintainInverseLinks=true] Should inverse links be maintained for relationships?
  @param {Boolean} [options.maintainDependencies=true] Should dependencies between related records (e.g. `dependent: 'remove'`) be maintained?
@@ -37,7 +35,6 @@ var Cache = Class.extend({
       options.maintainRevLinks = options.trackRevLinks;
     }
 
-    this.trackChanges = options.trackChanges !== undefined ? options.trackChanges : true;
     this.maintainRevLinks = options.maintainRevLinks !== undefined ? options.maintainRevLinks : true;
     this.maintainInverseLinks = options.maintainInverseLinks !== undefined ? options.maintainRevLinks : true;
     this.maintainDependencies = options.maintainDependencies !== undefined ? options.maintainDependencies : true;
@@ -49,8 +46,6 @@ var Cache = Class.extend({
     }
 
     this._pathsToRemove = [];
-
-    Evented.extend(this);
 
     this.schema = schema;
     this._operationEncoder = new OperationEncoder(schema);
@@ -210,17 +205,17 @@ var Cache = Class.extend({
 
     if (op === 'add' || op === 'replace') {
       if (!this.exists(path.slice(0, path.length - 1))) {
-        return false;
+        return;
       }
 
     } else if (op === 'remove') {
       if (this._isMarkedForRemoval(path)) {
         // console.log('remove op not required because marked for removal', path);
-        return false;
+        return;
       }
     }
 
-    if (eq(currentValue, value)) return false;
+    if (eq(currentValue, value)) return;
 
     if (this.maintainDependencies) {
       pushOps(this._dependentOps(normalizedOperation));
@@ -245,15 +240,7 @@ var Cache = Class.extend({
       }
     }
 
-    if (this.trackChanges) {
-      inverse = this._doc.transform(normalizedOperation, true);
-      this.emit('didTransform',
-                normalizedOperation,
-                inverse);
-
-    } else {
-      this._doc.transform(normalizedOperation, false);
-    }
+    inverse = this._doc.transform(normalizedOperation, true);
 
     performDependentOps();
 
@@ -282,7 +269,7 @@ var Cache = Class.extend({
 
     performDependentOps();
 
-    return true;
+    return inverse;
   },
 
   _markForRemoval: function(path) {

--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -355,21 +355,23 @@ var JSONAPISource = Source.extend({
     if (this.retrieve(pathToVerify) !== undefined) {
       // transforming the cache will trigger a call to `_cacheDidTransform`,
       // which will then trigger `didTransform`
-      this._cache.transform(operation);
+      inverse = this._cache.transform(operation);
 
     } else if (operation.op === 'replace') {
       // try adding instead of replacing if the cache does not yet contain
       // the data
       operation.op = 'add';
-      this._transformCache(operation);
+      inverse = this._transformCache(operation);
 
     } else {
       // if the cache can't be transformed because, still trigger `didTransform`
       //
       // NOTE: this is not an error condition, since the local cache will often
       // be sparsely populated compared with the remote store
-      this.didTransform(operation, []);
+      inverse = [];
     }
+
+    this.didTransform(operation, []);
   },
 
   _resourceIdURLSegment: function(type, id) {

--- a/lib/orbit-common/memory-source.js
+++ b/lib/orbit-common/memory-source.js
@@ -28,7 +28,9 @@ var MemorySource = Source.extend({
     // Transform the cache
     // Note: the cache's didTransform event will trigger this source's
     // didTransform event.
-    this._cache.transform(operation);
+    var inverse = this._cache.transform(operation);
+
+    this.didTransform(operation, inverse);
   },
 
   /////////////////////////////////////////////////////////////////////////////

--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -33,9 +33,6 @@ var Source = Class.extend({
 
     this._operationEncoder = new OperationEncoder(schema);
 
-    // TODO - clean up listener
-    this._cache.on('didTransform', this._cacheDidTransform, this);
-
     Transformable.extend(this);
     Requestable.extend(this, ['find', 'add', 'update', 'patch', 'remove',
                               'findLink', 'addLink', 'removeLink', 'updateLink',

--- a/test/tests/integration/three-memory-source-blocking-connector-test.js
+++ b/test/tests/integration/three-memory-source-blocking-connector-test.js
@@ -77,7 +77,7 @@ test('Spontaneous information from sources', function() {
       id: id,
       name: planetName
     });
-    source._cache.transform({
+    source._transform({
       op: "add",
       path: ["planet", id],
       value: data

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -95,12 +95,12 @@ test("#reset overrides the cache completely with the value specified", function(
   deepEqual(cache.retrieve(), newData);
 });
 
-test("#transform returns false when an operation is not necessary", function() {
+test("#transform returns undefined when an operation is a noop", function() {
   cache = new Cache(schema, {allowNoOps: true});
 
-  equal(cache.transform({op: 'add', path: 'planet/1', value: {name: 'Earth'}}), true, 'add was successful');
+  cache.transform({op: 'add', path: 'planet/1', value: {name: 'Earth'}});
 
-  equal(cache.transform({op: 'remove', path: 'planet/2'}), false, 'remove was not successful');
+  equal(cache.transform({op: 'remove', path: 'planet/2'}), undefined, 'operation was a noop');
 });
 
 test("#transform tracks refs by default, and clears them from hasOne relationships when a referenced record is removed", function() {


### PR DESCRIPTION
The `Cache#trackChanges` option has been removed.

Cache is longer evented and no longer emits `didTransform` events.
Transform notifications are now the responsibility of the cache's
owner (i.e. the caller of `Cache#transform`).

As a result, any ancillary changes to the cache (such as reverse
and inverse link maintenance) will not bubble out of the cache.