### PR TITLE
Remove concept of ignored / condemned paths from Cache#transform.

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -45,8 +45,6 @@ var Cache = Class.extend({
       this._rev = {};
     }
 
-    this._pathsToRemove = [];
-
     this.schema = schema;
     this._operationEncoder = new OperationEncoder(schema);
     for (var model in schema.models) {
@@ -149,14 +147,12 @@ var Cache = Class.extend({
 
    Currently limited to `add`, `remove` and `replace` operations.
 
-   Throws `PathNotFoundException` if the path does not exist in the document.
-
    @method transform
    @param {Object} operation
    @param {String} operation.op Must be "add", "remove", or "replace"
    @param {Array or String} operation.path Path to target location
    @param {Object} operation.value Value to set. Required for "add" and "replace"
-   @returns {Boolean} true if operation is applied or false
+   @returns {Array or undefined} Array of inverse operations
    */
   transform: function(operation) {
     var normalizedOperation;
@@ -207,12 +203,6 @@ var Cache = Class.extend({
       if (!this.exists(path.slice(0, path.length - 1))) {
         return;
       }
-
-    } else if (op === 'remove') {
-      if (this._isMarkedForRemoval(path)) {
-        // console.log('remove op not required because marked for removal', path);
-        return;
-      }
     }
 
     if (eq(currentValue, value)) return;
@@ -222,8 +212,6 @@ var Cache = Class.extend({
     }
 
     if (op === 'remove' || op === 'replace') {
-      this._markForRemoval(path);
-
       if (this.maintainInverseLinks) {
         if (op === 'replace') {
           pushOps(this._relatedInverseLinkOps(normalizedOperation.spawn({
@@ -243,10 +231,6 @@ var Cache = Class.extend({
     inverse = this._doc.transform(normalizedOperation, true);
 
     performDependentOps();
-
-    if (op === 'remove' || op === 'replace') {
-      this._unmarkForRemoval(path);
-    }
 
     if (op === 'add' || op === 'replace') {
       if (this.maintainRevLinks) {
@@ -270,25 +254,6 @@ var Cache = Class.extend({
     performDependentOps();
 
     return inverse;
-  },
-
-  _markForRemoval: function(path) {
-    path = path.join('/');
-    // console.log('_markForRemoval', path);
-    this._pathsToRemove.push(path);
-  },
-
-  _unmarkForRemoval: function(path) {
-    path = path.join('/');
-    var i = this._pathsToRemove.indexOf(path);
-    // console.log('_unmarkForRemoval', path, i);
-    if (i > -1) this._pathsToRemove.splice(i, 1);
-  },
-
-  _isMarkedForRemoval: function(path) {
-    path = path.join('/');
-    // console.log('_isMarkedForRemoval', path);
-    return (this._pathsToRemove.indexOf(path) > -1);
   },
 
   _dependentOps: function(operation) {
@@ -489,7 +454,7 @@ var Cache = Class.extend({
   },
 
   _relatedInverseLinkOps: function(operation) {
-    return this._relatedInverseLinksProcessor.process(operation, this._pathsToRemove);
+    return this._relatedInverseLinksProcessor.process(operation);
   }
 });
 

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -8,9 +8,8 @@ export default Class.extend({
     this._operationEncoder = new OperationEncoder(schema);
   },
 
-  process: function(operation, condemnedPaths) {
+  process: function(operation) {
     var _this = this;
-    condemnedPaths = condemnedPaths || [];
     var path = operation.path;
     var value = operation.value;
     var type = path[0];
@@ -20,8 +19,7 @@ export default Class.extend({
     function relatedLinkOps(linkValue, linkDef) {
       linkDef = linkDef || schema.linkDefinition(type, path[3]);
       var op = operation.op;
-      var ignoredPaths = op === 'remove' ? condemnedPaths : [];
-      return _this._relatedLinkOps(linkDef, linkValue, path[1], operation, ignoredPaths);
+      return _this._relatedLinkOps(linkDef, linkValue, path[1], operation);
     }
 
     function addRelatedLinksOpsForRecord(record) {
@@ -84,7 +82,7 @@ export default Class.extend({
     }
   },
 
-  _relatedLinkOps: function(linkDef, linkValue, value, parentOperation, ignoredPaths) {
+  _relatedLinkOps: function(linkDef, linkValue, value, parentOperation) {
     if (isNone(linkValue)) return [];
     var relIds = isArray(linkValue) ? linkValue : [linkValue];
     var linkOps = [];
@@ -93,7 +91,7 @@ export default Class.extend({
     if (linkDef.inverse) {
       var relatedOp = this._relatedOp(parentOperation.op, linkDef);
        for (var i = 0; i < relIds.length; i++) {
-        linkOp = this._relatedLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, parentOperation, relatedOp, ignoredPaths);
+        linkOp = this._relatedLinkOp(linkDef.model, relIds[i], linkDef.inverse, value, parentOperation, relatedOp);
         if (linkOp) linkOps.push(linkOp);
       }
     }
@@ -107,14 +105,13 @@ export default Class.extend({
     return op;
   },
 
-  _relatedLinkOp: function(type, id, link, value, parentOperation, relatedOp, ignoredPaths) {
+  _relatedLinkOp: function(type, id, link, value, parentOperation, relatedOp) {
     if (this._retrieve([type, id])) {
       var operation = this._operationEncoder.linkOp(relatedOp, type, id, link, value);
       var path = operation.path.join("/");
-      var isIgnoredPath = ignoredPaths.indexOf(path) > -1;
 
       // Apply operation only if necessary
-      if (this._retrieve(operation.path) !== operation.value && !isIgnoredPath) {
+      if (this._retrieve(operation.path) !== operation.value) {
         return parentOperation.spawn(operation);
       }
     }


### PR DESCRIPTION
This additional complexity is no longer necessary now that 
`didTransform` events are no longer being emitted from the Cache
when related inverse ops are applied.