### PR TITLE
JSON API 1.0 compliance

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -22,8 +22,7 @@ var packages = [
               /(orbit\-common\/.+.js)/],
     exclude: [/orbit-common\/local-storage-source.js/,
               /orbit-common\/jsonapi-serializer.js/,
-              /orbit-common\/jsonapi-source.js/,
-              /orbit-common\/jsonapi-patch-source.js/]
+              /orbit-common\/jsonapi-source.js/]
   },
   {
     name: 'orbit-common-local-storage',
@@ -32,8 +31,7 @@ var packages = [
   {
     name: 'orbit-common-jsonapi',
     include: [/orbit-common\/jsonapi-serializer.js/,
-              /orbit-common\/jsonapi-source.js/,
-              /orbit-common\/jsonapi-patch-source.js/]
+              /orbit-common\/jsonapi-source.js/]
   }
 ];
 

--- a/build-support/globalize-orbit-common-jsonapi.js
+++ b/build-support/globalize-orbit-common-jsonapi.js
@@ -1,3 +1,2 @@
 window.OC.JSONAPISource = requireModule("orbit-common/jsonapi-source")["default"];
-window.OC.JSONAPIPatchSource = requireModule("orbit-common/jsonapi-patch-source")["default"];
 window.OC.JSONAPISerializer = requireModule("orbit-common/jsonapi-serializer")["default"];

--- a/lib/orbit-common/jsonapi-patch-source.js
+++ b/lib/orbit-common/jsonapi-patch-source.js
@@ -1,201 +1,201 @@
-import { isArray, isObject } from 'orbit/lib/objects';
-import JSONAPISource from './jsonapi-source';
-
-/**
- Source for accessing a JSON API compliant RESTful API with AJAX using the
- official patch extension
-
- @class JSONAPIPatchSource
- @extends Source
- @namespace OC
- @param schema
- @param options
- @constructor
- */
-export default JSONAPISource.extend({
-
-  /////////////////////////////////////////////////////////////////////////////
-  // Internals
-  /////////////////////////////////////////////////////////////////////////////
-
-  _transformAdd: function(operation) {
-    var _this = this;
-    var type = operation.path[0];
-    var id = operation.path[1];
-
-    var remoteOp = {
-      op: 'add',
-      path: '/-',
-      value: this.serializer.serializeRecord(type, operation.value)
-    };
-
-    return this.ajax(this.resourceURL(type), 'PATCH', {data: [ remoteOp ]}).then(
-      function(raw) {
-        if (raw && isArray(raw)) {
-          _this.deserialize(type, id, raw[0], operation);
-        } else {
-          _this._transformCache(operation);
-        }
-      }
-    );
-  },
-
-  _transformReplace: function(operation) {
-    var _this = this;
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var value = operation.value;
-
-    var remoteOp = {
-      op: 'replace',
-      path: '/',
-      value: this.serializer.serializeRecord(type, value)
-    };
-
-    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
-      function(raw) {
-        if (raw && isArray(raw)) {
-          _this.deserialize(type, id, raw[0], operation);
-        } else {
-          _this._transformCache(operation);
-        }
-      }
-    );
-  },
-
-  _transformRemove: function(operation) {
-    var _this = this;
-    var type = operation.path[0];
-    var id = operation.path[1];
-
-    var remoteOp = {
-      op: 'remove',
-      path: '/'
-    };
-
-    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
-  _transformAddLink: function(operation) {
-    var _this = this;
-
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var link = operation.path[3];
-    var relId = operation.path[4] || operation.value;
-    var linkDef = this.schema.linkDefinition(type, link);
-    var relType = linkDef.model;
-    var relResourceId = this.serializer.resourceId(relType, relId);
-    var remoteOp;
-
-    if (linkDef.type === 'hasMany') {
-      remoteOp = {
-        op: 'add',
-        path: '/-',
-        value: relResourceId
-      };
-    } else {
-      remoteOp = {
-        op: 'replace',
-        path: '/',
-        value: relResourceId
-      };
-    }
-
-    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
-  _transformRemoveLink: function(operation) {
-    var _this = this;
-
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var link = operation.path[3];
-    var linkDef = this.schema.linkDefinition(type, link);
-    var remoteOp;
-
-    if (linkDef.type === 'hasMany') {
-      var relId = operation.path[4];
-      var relType = linkDef.model;
-      var relResourceId = this.serializer.resourceId(relType, relId);
-
-      remoteOp = {
-        op: 'remove',
-        path: '/' + relResourceId
-      };
-    } else {
-      remoteOp = {
-        op: 'remove',
-        path: '/'
-      };
-    }
-
-    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
-  _transformReplaceLink: function(operation) {
-    var _this = this;
-
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var link = operation.path[3];
-    var relId = operation.path[4] || operation.value;
-
-    // Convert a map of ids to an array
-    if (isObject(relId)) {
-      relId = Object.keys(relId);
-    }
-
-    var linkDef = this.schema.linkDefinition(type, link);
-    var relType = linkDef.model;
-    var relResourceId = this.serializer.resourceId(relType, relId);
-    var remoteOp;
-
-    remoteOp = {
-      op: 'replace',
-      path: '/',
-      value: relResourceId
-    };
-
-    return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
-  _transformUpdateAttribute: function(operation) {
-    var _this = this;
-    var type = operation.path[0];
-    var id = operation.path[1];
-    var attr = operation.path[2];
-
-    var remoteOp = {
-      op: 'replace',
-      path: '/' + attr,
-      value: operation.value
-    };
-
-    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
-      function() {
-        _this._transformCache(operation);
-      }
-    );
-  },
-
-  ajaxContentType: function(url, method) {
-    return 'application/vnd.api+json; ext=jsonpatch; charset=utf-8';
-  }
-});
+// import { isArray, isObject } from 'orbit/lib/objects';
+// import JSONAPISource from './jsonapi-source';
+//
+// /**
+//  Source for accessing a JSON API compliant RESTful API with AJAX using the
+//  official patch extension
+//
+//  @class JSONAPIPatchSource
+//  @extends Source
+//  @namespace OC
+//  @param schema
+//  @param options
+//  @constructor
+//  */
+// export default JSONAPISource.extend({
+//
+//   /////////////////////////////////////////////////////////////////////////////
+//   // Internals
+//   /////////////////////////////////////////////////////////////////////////////
+//
+//   _transformAdd: function(operation) {
+//     var _this = this;
+//     var type = operation.path[0];
+//     var id = operation.path[1];
+//
+//     var remoteOp = {
+//       op: 'add',
+//       path: '/-',
+//       value: this.serializer.serializeRecord(type, operation.value)
+//     };
+//
+//     return this.ajax(this.resourceURL(type), 'PATCH', {data: [ remoteOp ]}).then(
+//       function(raw) {
+//         if (raw && isArray(raw)) {
+//           _this.deserialize(type, id, raw[0], operation);
+//         } else {
+//           _this._transformCache(operation);
+//         }
+//       }
+//     );
+//   },
+//
+//   _transformReplace: function(operation) {
+//     var _this = this;
+//     var type = operation.path[0];
+//     var id = operation.path[1];
+//     var value = operation.value;
+//
+//     var remoteOp = {
+//       op: 'replace',
+//       path: '/',
+//       value: this.serializer.serializeRecord(type, value)
+//     };
+//
+//     return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
+//       function(raw) {
+//         if (raw && isArray(raw)) {
+//           _this.deserialize(type, id, raw[0], operation);
+//         } else {
+//           _this._transformCache(operation);
+//         }
+//       }
+//     );
+//   },
+//
+//   _transformRemove: function(operation) {
+//     var _this = this;
+//     var type = operation.path[0];
+//     var id = operation.path[1];
+//
+//     var remoteOp = {
+//       op: 'remove',
+//       path: '/'
+//     };
+//
+//     return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
+//       function() {
+//         _this._transformCache(operation);
+//       }
+//     );
+//   },
+//
+//   _transformAddLink: function(operation) {
+//     var _this = this;
+//
+//     var type = operation.path[0];
+//     var id = operation.path[1];
+//     var link = operation.path[3];
+//     var relId = operation.path[4] || operation.value;
+//     var linkDef = this.schema.linkDefinition(type, link);
+//     var relType = linkDef.model;
+//     var relResourceId = this.serializer.resourceId(relType, relId);
+//     var remoteOp;
+//
+//     if (linkDef.type === 'hasMany') {
+//       remoteOp = {
+//         op: 'add',
+//         path: '/-',
+//         value: relResourceId
+//       };
+//     } else {
+//       remoteOp = {
+//         op: 'replace',
+//         path: '/',
+//         value: relResourceId
+//       };
+//     }
+//
+//     return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
+//       function() {
+//         _this._transformCache(operation);
+//       }
+//     );
+//   },
+//
+//   _transformRemoveLink: function(operation) {
+//     var _this = this;
+//
+//     var type = operation.path[0];
+//     var id = operation.path[1];
+//     var link = operation.path[3];
+//     var linkDef = this.schema.linkDefinition(type, link);
+//     var remoteOp;
+//
+//     if (linkDef.type === 'hasMany') {
+//       var relId = operation.path[4];
+//       var relType = linkDef.model;
+//       var relResourceId = this.serializer.resourceId(relType, relId);
+//
+//       remoteOp = {
+//         op: 'remove',
+//         path: '/' + relResourceId
+//       };
+//     } else {
+//       remoteOp = {
+//         op: 'remove',
+//         path: '/'
+//       };
+//     }
+//
+//     return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
+//       function() {
+//         _this._transformCache(operation);
+//       }
+//     );
+//   },
+//
+//   _transformReplaceLink: function(operation) {
+//     var _this = this;
+//
+//     var type = operation.path[0];
+//     var id = operation.path[1];
+//     var link = operation.path[3];
+//     var relId = operation.path[4] || operation.value;
+//
+//     // Convert a map of ids to an array
+//     if (isObject(relId)) {
+//       relId = Object.keys(relId);
+//     }
+//
+//     var linkDef = this.schema.linkDefinition(type, link);
+//     var relType = linkDef.model;
+//     var relResourceId = this.serializer.resourceId(relType, relId);
+//     var remoteOp;
+//
+//     remoteOp = {
+//       op: 'replace',
+//       path: '/',
+//       value: relResourceId
+//     };
+//
+//     return this.ajax(this.resourceLinkURL(type, id, link), 'PATCH', {data: [ remoteOp ]}).then(
+//       function() {
+//         _this._transformCache(operation);
+//       }
+//     );
+//   },
+//
+//   _transformUpdateAttribute: function(operation) {
+//     var _this = this;
+//     var type = operation.path[0];
+//     var id = operation.path[1];
+//     var attr = operation.path[2];
+//
+//     var remoteOp = {
+//       op: 'replace',
+//       path: '/' + attr,
+//       value: operation.value
+//     };
+//
+//     return this.ajax(this.resourceURL(type, id), 'PATCH', {data: [ remoteOp ]}).then(
+//       function() {
+//         _this._transformCache(operation);
+//       }
+//     );
+//   },
+//
+//   ajaxContentType: function(url, method) {
+//     return 'application/vnd.api+json; ext=jsonpatch; charset=utf-8';
+//   }
+// });

--- a/lib/orbit-common/jsonapi-serializer.js
+++ b/lib/orbit-common/jsonapi-serializer.js
@@ -98,20 +98,20 @@ var JSONAPISerializer = Serializer.extend({
   serializeRecord: function(type, record) {
     var json = {};
 
-    this.serializeKeys(type, record, json);
+    this.serializeId(type, record, json);
     this.serializeAttributes(type, record, json);
     this.serializeLinks(type, record, json);
 
     return json;
   },
 
-  serializeKeys: function(type, record, json) {
+  serializeId: function(type, record, json) {
     var modelSchema = this.schema.models[type];
     var resourceKey = this.resourceKey(type);
     var value = record[resourceKey];
 
     if (value) {
-      json[resourceKey] = value;
+      json.id = value;
     }
   },
 

--- a/lib/orbit-common/jsonapi-serializer.js
+++ b/lib/orbit-common/jsonapi-serializer.js
@@ -1,7 +1,7 @@
 import Serializer from './serializer';
 import { clone, isArray, isObject } from 'orbit/lib/objects';
 
-var JSONAPISerializer = Serializer.extend({
+export default Serializer.extend({
   resourceKey: function(type) {
     return 'id';
   },
@@ -20,6 +20,14 @@ var JSONAPISerializer = Serializer.extend({
 
   typeFromResourceType: function(resourceType) {
     return this.schema.singularize(resourceType);
+  },
+
+  attrFromResourceAttr: function(type, resourceAttr) {
+    return resourceAttr;
+  },
+
+  linkFromResourceLink: function(type, resourceLink) {
+    return resourceLink;
   },
 
   resourceId: function(type, id) {
@@ -73,13 +81,12 @@ var JSONAPISerializer = Serializer.extend({
   },
 
   serialize: function(type, records) {
-    var json = {},
-        resourceType = this.resourceType(type);
+    var json = {};
 
     if (isArray(records)) {
-      json[resourceType] = this.serializeRecords(type, records);
+      json.data = this.serializeRecords(type, records);
     } else {
-      json[resourceType] = this.serializeRecord(type, records);
+      json.data = this.serializeRecord(type, records);
     }
 
     return json;
@@ -99,6 +106,7 @@ var JSONAPISerializer = Serializer.extend({
     var json = {};
 
     this.serializeId(type, record, json);
+    this.serializeType(type, record, json);
     this.serializeAttributes(type, record, json);
     this.serializeLinks(type, record, json);
 
@@ -106,17 +114,19 @@ var JSONAPISerializer = Serializer.extend({
   },
 
   serializeId: function(type, record, json) {
-    var modelSchema = this.schema.models[type];
-    var resourceKey = this.resourceKey(type);
-    var value = record[resourceKey];
+    json.id = this.resourceId(type, record);
+  },
 
-    if (value) {
-      json.id = value;
-    }
+  serializeType: function(type, record, json) {
+    json.type = this.resourceType(type);
   },
 
   serializeAttributes: function(type, record, json) {
     var modelSchema = this.schema.models[type];
+
+    if (json.attributes === undefined) {
+      json.attributes = {};
+    }
 
     Object.keys(modelSchema.attributes).forEach(function(attr) {
       this.serializeAttribute(type, record, attr, json);
@@ -124,15 +134,15 @@ var JSONAPISerializer = Serializer.extend({
   },
 
   serializeAttribute: function(type, record, attr, json) {
-    json[this.resourceAttr(type, attr)] = record[attr];
+    json.attributes[this.resourceAttr(type, attr)] = record[attr];
   },
 
   serializeLinks: function(type, record, json) {
     var modelSchema = this.schema.models[type];
     var linkNames = Object.keys(modelSchema.links);
 
-    if (linkNames.length > 0) {
-      json.links = {};
+    if (linkNames.length > 0 && record.__rel) {
+      json.relationships = {};
 
       linkNames.forEach(function (link) {
         var linkDef = modelSchema.links[link];
@@ -142,37 +152,39 @@ var JSONAPISerializer = Serializer.extend({
           value = Object.keys(value);
         }
 
-        json.links[link] = value;
+        json.relationships[link] = {
+          data: value
+        };
 
       }, this);
     }
   },
 
+  serializeRelationshipIdentifier: function(type, id) {
+    return {
+      type: this.resourceType(type),
+      id: this.resourceId(type, id)
+    };
+  },
+
   deserialize: function(type, id, data) {
     var records = {};
-    var schema = this.schema;
-    var resourceType = this.resourceType(type);
-    var primaryData = data[resourceType];
 
-    if (isArray(primaryData)) {
-      records[type] = this.deserializeRecords(type, id, primaryData);
+    if (isArray(data.data)) {
+      records.primary = this.deserializeRecords(type, id, data.data);
     } else {
-      records[type] = this.deserializeRecord(type, id, primaryData);
+      records.primary = this.deserializeRecord(type, id, data.data);
     }
 
-    var linkedData = data.linked;
+    if (data.included) {
+      records.included = {};
 
-    if (linkedData) {
-      var relType;
-      var relKey;
-      var relData;
-
-      records.linked = {};
-
-      Object.keys(linkedData).forEach(function(linkedResourceType) {
-        relType = this.typeFromResourceType(linkedResourceType);
-        relData = linkedData[linkedResourceType];
-        records.linked[relType] = this.deserializeRecords(relType, null, relData);
+      data.included.forEach(function(recordData) {
+        var recordType = this.typeFromResourceType(recordData.type);
+        if (records.included[recordType] === undefined) {
+          records.included[recordType] = [];
+        }
+        records.included[recordType].push(this.deserializeRecord(recordType, null, recordData));
       }, this);
     }
 
@@ -181,55 +193,100 @@ var JSONAPISerializer = Serializer.extend({
     return records;
   },
 
-  deserializeLink: function(type, data) {
-    var resourceType = this.resourceType(type);
-    return data[resourceType];
+  deserializeLink: function(data) {
+    if (isObject(data)) {
+      if (isArray(data)) {
+        return data.map(function(linkData) {
+          return this.deserializeRelationshipIdentifier(linkData);
+        }, this);
+      } else {
+        return this.deserializeRelationshipIdentifier(data);
+      }
+
+    } else {
+      return data;
+    }
+  },
+
+  deserializeRelationshipIdentifier: function(data) {
+    var type = this.typeFromResourceType(data.type);
+    return {
+      type: type,
+      id: this.idFromResourceId(type, data.id)
+    };
   },
 
   deserializeRecords: function(type, ids, data) {
-    var records = [];
-
-    data.forEach(function(recordData, i) {
+    return data.map(function(recordData, i) {
       var id = ids && ids[i] ? ids[i] : null;
-
-      records.push(this.deserializeRecord(type, id, recordData));
+      return this.deserializeRecord(type, id, recordData);
     }, this);
-
-    return records;
   },
 
   deserializeRecord: function(type, id, data) {
+    var record = {};
+    var attributes;
+    var relationships;
+    var pk = this.schema.models[type].primaryKey.name;
+
     if (id) {
-      data[this.schema.models[type].primaryKey.name] = id;
+      record[pk] = id;
     }
-    return this.schema.normalize(type, data);
+
+    if (pk !== 'id') {
+      record.id = data.id;
+    }
+
+    if (data.attributes) {
+      attributes = data.attributes;
+      this.deserializeAttributes(type, record, attributes);
+    }
+
+    if (data.relationships) {
+      // temporarily assign relationships as __relationships
+      record.__relationships = data.relationships;
+    }
+
+    return this.schema.normalize(type, record);
   },
 
-  assignLinks: function(type, data) {
-    var primaryData = data[type];
-    var linkedData = data.linked;
+  deserializeAttributes: function(type, record, json) {
+    var modelSchema = this.schema.models[type];
+    Object.keys(modelSchema.attributes).forEach(function(attr) {
+      var resourceAttr = this.resourceAttr(type, attr);
+      var value = json[resourceAttr];
+      if (value !== undefined) {
+        this.deserializeAttribute(type, record, attr, value);
+      }
+    }, this);
+  },
 
-    if (isArray(primaryData)) {
-      this.assignLinksToRecords(type, primaryData);
+  deserializeAttribute: function(type, record, attr, value) {
+    record[attr] = value;
+  },
+
+  assignLinks: function(type, records) {
+    if (isArray(records.primary)) {
+      this.assignLinksToRecords(type, records.primary);
     } else {
-      this.assignLinksToRecord(type, primaryData);
+      this.assignLinksToRecord(type, records.primary);
     }
 
-    if (linkedData) {
-      Object.keys(linkedData).forEach(function(linkedType) {
-        this.assignLinksToRecords(linkedType, linkedData[linkedType]);
+    if (records.included) {
+      Object.keys(records.included).forEach(function(includedType) {
+        this.assignLinksToRecords(includedType, records.included[includedType]);
       }, this);
     }
   },
 
-  assignLinksToRecords: function(model, records) {
+  assignLinksToRecords: function(type, records) {
     records.forEach(function(record) {
-      this.assignLinksToRecord(model, record);
+      this.assignLinksToRecord(type, record);
     }, this);
   },
 
-  assignLinksToRecord: function(model, record) {
-    if (record.links) {
+  assignLinksToRecord: function(type, record) {
+    if (record.__relationships) {
       record.__meta.links = record.__meta.links || {};
 
       var meta = record.__meta.links;
@@ -238,9 +295,9 @@ var JSONAPISerializer = Serializer.extend({
       var linkValue;
       var id;
 
-      Object.keys(record.links).forEach(function(link) {
-        linkValue = record.links[link];
-        linkSchema = schema.models[model].links[link];
+      Object.keys(record.__relationships).forEach(function(link) {
+        linkValue = record.__relationships[link].data;
+        linkSchema = schema.models[type].links[link];
 
         if (!linkSchema) return;
 
@@ -249,12 +306,12 @@ var JSONAPISerializer = Serializer.extend({
 
           var rels = record.__rel[link];
           linkValue.forEach(function(resourceId) {
-            id = this.idFromResourceId(linkSchema.model, resourceId);
+            id = this.idFromResourceId(linkSchema.model, resourceId.id);
             record.__rel[link][id] = true;
           }, this);
 
-        } else if (linkSchema.type === 'hasOne' && (typeof linkValue === 'string' || typeof linkValue === 'number')) {
-          id = this.idFromResourceId(linkSchema.model, linkValue);
+        } else if (linkSchema.type === 'hasOne' && isObject(linkValue)) {
+          id = this.idFromResourceId(linkSchema.model, linkValue.id);
           record.__rel[link] = id;
 
         } else {
@@ -263,9 +320,7 @@ var JSONAPISerializer = Serializer.extend({
 
       }, this);
 
-      delete record.links;
+      delete record.__relationships;
     }
   }
 });
-
-export default JSONAPISerializer;

--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -17,7 +17,7 @@ import { OperationNotAllowed, RecordNotFoundException, RecordAlreadyExistsExcept
  @param options
  @constructor
  */
-var JSONAPISource = Source.extend({
+export default Source.extend({
 
   init: function(schema, options) {
     assert('JSONAPISource requires Orbit.Promise be defined', Orbit.Promise);
@@ -118,9 +118,7 @@ var JSONAPISource = Source.extend({
     var _this = this;
     return this.ajax(this.resourceLinkURL(type, id, link), 'GET').then(
       function(raw) {
-        var linkDef = _this.schema.linkDefinition(type, link);
-        var relId = _this.serializer.deserializeLink(linkDef.model, raw);
-
+        var relId = _this.serializer.deserializeLink(raw.data);
         return _this.settleTransforms().then(function() {
           return relId;
         });
@@ -128,25 +126,25 @@ var JSONAPISource = Source.extend({
     );
   },
 
-// TODO - Override `_findLinked` to use meta-data stored about links
-//
-//  _findLinked: function(type, id, link, relId) {
-//    if (relId === undefined) {
-//      id = this.getId(type, id);
-//
-//      var record = this.retrieve([type, id]);
-//      if (record) {
-//        relId = record.__rel[link];
-//        if (record.__meta.links && record.__meta.links[link]) {
-//          var linkMeta = record.__meta.links[link];
-//
-//          // find linked from meta
-//        }
-//      }
-//    }
-//
-//    return this._super.apply(this, arguments);
-//  },
+ _findLinked: function(type, id, link, relId) {
+   var _this = this;
+
+   if (relId === undefined) {
+     return this.ajax(this.resourceLinkedURL(type, id, link), 'GET').then(
+       function(raw) {
+         var linkDef = _this.schema.linkDefinition(type, link);
+
+         var records = _this.deserialize(linkDef.model, null, raw);
+
+         return _this.settleTransforms().then(function() {
+           return isArray(records) ? records : [records];
+         });
+       }
+     );
+   } else {
+     return this._super.apply(this, arguments);
+   }
+ },
 
   /////////////////////////////////////////////////////////////////////////////
   // Internals
@@ -173,7 +171,7 @@ var JSONAPISource = Source.extend({
 
     var json = this.serializer.serialize(type, value);
 
-    return this.ajax(this.resourceURL(type, id), 'PUT', {data: json}).then(
+    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: json}).then(
       function(raw) {
         // TODO - better 204 (no content) checking
         if (raw && Object.keys(raw).length > 0) {
@@ -202,15 +200,11 @@ var JSONAPISource = Source.extend({
     var id = operation.path[1];
     var link = operation.path[3];
     var relId = operation.path[4] || operation.value;
-
-    var linkDef = this.schema.linkDefinition(type, link);
-    var relType = linkDef.model;
-    var relResourceType = this.serializer.resourceType(relType);
-    var relResourceId = this.serializer.resourceId(relType, relId);
-
+    var relType = this.schema.linkDefinition(type, link).model;
     var method = 'POST';
-    var json = {};
-    json[relResourceType] = relResourceId;
+    var json = {
+      data: [this.serializer.serializeRelationshipIdentifier(relType, relId)]
+    };
 
     return this.ajax(this.resourceLinkURL(type, id, link), method, {data: json}).then(
       function() {
@@ -226,8 +220,13 @@ var JSONAPISource = Source.extend({
     var id = operation.path[1];
     var link = operation.path[3];
     var relId = operation.path[4];
+    var relType = this.schema.linkDefinition(type, link).model;
+    var method = 'DELETE';
+    var json = {
+      data: [this.serializer.serializeRelationshipIdentifier(relType, relId)]
+    };
 
-    return this.ajax(this.resourceLinkURL(type, id, link, relId), 'DELETE').then(
+    return this.ajax(this.resourceLinkURL(type, id, link), method, {data: json}).then(
       function() {
         _this._transformCache(operation);
       }
@@ -241,20 +240,27 @@ var JSONAPISource = Source.extend({
     var id = operation.path[1];
     var link = operation.path[3];
     var relId = operation.path[4] || operation.value;
-
-    // Convert a map of ids to an array
-    if (isObject(relId)) {
-      relId = Object.keys(relId);
-    }
-
     var linkDef = this.schema.linkDefinition(type, link);
     var relType = linkDef.model;
-    var relResourceType = this.serializer.resourceType(relType);
-    var relResourceId = this.serializer.resourceId(relType, relId);
+    var data;
 
-    var method = 'PUT';
-    var json = {};
-    json[relResourceType] = relResourceId;
+    if (linkDef.type === 'hasMany') {
+      // Convert a map of ids to an array
+      if (isObject(relId)) {
+        data = Object.keys(relId).map(function(id) {
+          return this.serializer.serializeRelationshipIdentifier(relType, id);
+        }, this);
+      } else {
+        data = [this.serializer.serializeRelationshipIdentifier(relType, relId)];
+      }
+    } else {
+      data = this.serializer.serializeRelationshipIdentifier(relType, relId);
+    }
+
+    var method = 'PATCH';
+    var json = {
+      data: data
+    };
 
     return this.ajax(this.resourceLinkURL(type, id, link), method, {data: json}).then(
       function() {
@@ -268,18 +274,15 @@ var JSONAPISource = Source.extend({
     var type = operation.path[0];
     var id = operation.path[1];
     var attr = operation.path[2];
+    var modelSchema = this.schema.models[type];
 
     var record = {};
     record[attr] = operation.value;
+    record[modelSchema.primaryKey.name] = id;
 
-    var serialized = {};
-    this.serializer.serializeAttribute(type, record, attr, serialized);
+    var json = this.serializer.serialize(type, record);
 
-    var json = {};
-    var resourceType = this.serializer.resourceType(type);
-    json[resourceType] = serialized;
-
-    return this.ajax(this.resourceURL(type, id), 'PUT', {data: json}).then(
+    return this.ajax(this.resourceURL(type, id), 'PATCH', {data: json}).then(
       function(raw) {
         _this._transformCache(operation);
       }
@@ -332,7 +335,7 @@ var JSONAPISource = Source.extend({
   _findQuery: function(type, query) {
     var _this = this;
 
-    return this.ajax(this.resourceURL(type), 'GET', {data: query}).then(
+    return this.ajax(this.resourceURL(type), 'GET', {data: {filter: query}}).then(
       function(raw) {
         var records = _this.deserialize(type, null, raw);
         return _this.settleTransforms().then(function() {
@@ -475,7 +478,7 @@ var JSONAPISource = Source.extend({
 
   resourceLinkURL: function(type, id, link, relId) {
     var url = this.resourceURL(type, id);
-    url += '/links/' + this.serializer.resourceLink(type, link);
+    url += '/relationships/' + this.serializer.resourceLink(type, link);
 
     if (relId) {
       var linkDef = this.schema.linkDefinition(type, link);
@@ -486,9 +489,15 @@ var JSONAPISource = Source.extend({
     return url;
   },
 
+  resourceLinkedURL: function(type, id, link) {
+    var url = this.resourceURL(type, id);
+    url += '/' + this.serializer.resourceLink(type, link);
+    return url;
+  },
+
   deserialize: function(type, id, data, parentOperation) {
-    var deserialized = this.serializer.deserialize(type, id, data);
-    var primaryRecords = deserialized[type];
+    var records = this.serializer.deserialize(type, id, data);
+    var primaryRecords = records.primary;
 
     // Create a new parent operation, if necessary, to ensure that subsequent
     // operations are related and will be settled together in the same
@@ -507,9 +516,9 @@ var JSONAPISource = Source.extend({
         this._addRecordToCache(type, primaryRecords, parentOperation);
       }
 
-      if (deserialized.linked) {
-        Object.keys(deserialized.linked).forEach(function(relType) {
-          var relRecords = deserialized.linked[relType];
+      if (records.included) {
+        Object.keys(records.included).forEach(function(relType) {
+          var relRecords = records.included[relType];
           this._addRecordsToCache(relType, relRecords, parentOperation);
         }, this);
       }
@@ -518,5 +527,3 @@ var JSONAPISource = Source.extend({
     return primaryRecords;
   }
 });
-
-export default JSONAPISource;

--- a/test/tests/integration/rest-memory-local-blocking-transforms-test.js
+++ b/test/tests/integration/rest-memory-local-blocking-transforms-test.js
@@ -76,7 +76,7 @@ test("single records found with rest should be inserted into memory and local st
       ok(true, 'GET request');
       xhr.respond(200,
                   {'Content-Type': 'application/json'},
-                  JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                  JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
   stop();
   restSource.find('planet', {id: '12345'}).then(function(planets) {
@@ -93,9 +93,9 @@ test("multiple records found with rest should be inserted into memory and local 
       ok(true, 'GET request');
       xhr.respond(200,
                   {'Content-Type': 'application/json'},
-                  JSON.stringify({planets: [
-                    {id: '12345', name: 'Jupiter', classification: 'gas giant'},
-                    {id: '12346', name: 'Earth', classification: 'terrestrial'}
+                  JSON.stringify({data: [
+                    {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}},
+                    {type: 'planets', id: '12346', attributes: {name: 'Earth', classification: 'terrestrial'}}
                   ]}));
   });
   stop();
@@ -113,9 +113,9 @@ test("records will be matched with existing records if find is called mutiple ti
       ok(true, 'GET request');
       xhr.respond(200,
                   {'Content-Type': 'application/json'},
-                  JSON.stringify({planets: [
-                    {id: '12345', name: 'Jupiter', classification: 'gas giant'},
-                    {id: '12346', name: 'Earth', classification: 'terrestrial'}
+                  JSON.stringify({data: [
+                    {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}},
+                    {type: 'planets', id: '12346', attributes: {name: 'Earth', classification: 'terrestrial'}}
                   ]}));
   });
   stop();
@@ -137,10 +137,10 @@ test("records inserted into memory should be posted with rest", function() {
   expect(8);
 
   server.respondWith('POST', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
     xhr.respond(201,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
 
   stop();
@@ -161,10 +161,10 @@ test("records posted with rest should be inserted into memory", function() {
   expect(8);
 
   server.respondWith('POST', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
     xhr.respond(201,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
 
   stop();
@@ -185,13 +185,13 @@ test("records updated in memory should be updated with rest", function() {
   expect(9);
 
   server.respondWith('POST', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
     xhr.respond(201,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
-  server.respondWith('PUT', '/planets/12345', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Earth'}}, 'PUT request');
+  server.respondWith('PATCH', '/planets/12345', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', id: '12345', attributes: {name: 'Earth'}}}, 'PATCH request');
     xhr.respond(200,
                 {'Content-Type': 'application/json'},
                 JSON.stringify({}));
@@ -221,16 +221,16 @@ test("records updated with rest should be updated in memory", function() {
   expect(9);
 
   server.respondWith('POST', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
     xhr.respond(201,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
-  server.respondWith('PUT', '/planets/12345', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {id: '12345', name: 'Earth', classification: 'terrestrial'}}, 'PUT request');
+  server.respondWith('PATCH', '/planets/12345', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', id: '12345', attributes: {name: 'Earth', classification: 'terrestrial'}}}, 'PUT request');
     xhr.respond(200,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Earth', classification: 'terrestrial'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Earth', classification: 'terrestrial'}}}));
   });
 
   stop();
@@ -258,13 +258,13 @@ test("records patched in memory should be patched with rest", function() {
   expect(7);
 
   server.respondWith('POST', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
     xhr.respond(201,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
-  server.respondWith('PUT', '/planets/12345', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {classification: 'terrestrial'}}, 'PUT request');
+  server.respondWith('PATCH', '/planets/12345', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', id: '12345', attributes: {classification: 'terrestrial'}}}, 'PATCH request');
     xhr.respond(200,
                 {'Content-Type': 'application/json'},
                 JSON.stringify({}));
@@ -289,13 +289,13 @@ test("records patched with rest should be patched in memory", function() {
   expect(9);
 
   server.respondWith('POST', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
     xhr.respond(201,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
-  server.respondWith('PUT', '/planets/12345', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {classification: 'terrestrial'}}, 'PUT request');
+  server.respondWith('PATCH', '/planets/12345', function(xhr) {
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', id: '12345', attributes: {classification: 'terrestrial'}}}, 'PUT request');
     xhr.respond(200,
                 {'Content-Type': 'application/json'},
                 JSON.stringify({}));
@@ -324,10 +324,10 @@ test("records deleted in memory should be deleted with rest", function() {
   expect(5);
 
   server.respondWith('POST', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
     xhr.respond(201,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
   server.respondWith('DELETE', '/planets/12345', function(xhr) {
     deepEqual(JSON.parse(xhr.requestBody), null, 'DELETE request');
@@ -352,10 +352,10 @@ test("records deleted with rest should be deleted in memory", function() {
   expect(5);
 
   server.respondWith('POST', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+    deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
     xhr.respond(201,
                 {'Content-Type': 'application/json'},
-                JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
   });
   server.respondWith('DELETE', '/planets/12345', function(xhr) {
     deepEqual(JSON.parse(xhr.requestBody), null, 'DELETE request');

--- a/test/tests/integration/rest-memory-local-non-blocking-transforms-test.js
+++ b/test/tests/integration/rest-memory-local-non-blocking-transforms-test.js
@@ -117,7 +117,7 @@ test("records inserted into memory should be posted with rest", function() {
 
   stop();
   memorySource.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(record) {
-    equal(memorySource.length('planet'), 1,    'memory source should contain one record');
+    equal(memorySource.length('planet'), 1,   'memory source should contain one record');
     ok(record.__id,                           'orbit id should be defined');
     equal(record.id, undefined,               'server id should NOT be defined yet');
     equal(record.name, 'Jupiter',             'name should match');
@@ -125,10 +125,10 @@ test("records inserted into memory should be posted with rest", function() {
 
   }).then(function() {
     server.respond('POST', '/planets', function(xhr) {
-      deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+      deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
       xhr.respond(201,
                   {'Content-Type': 'application/json'},
-                  JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                  JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
     });
   });
 });
@@ -184,8 +184,8 @@ test("records updated in memory should be updated with rest", function() {
       equal(operation.value.classification, 'gas giant', 'rest source - inserted - classification - gas giant');
 
       setTimeout(function() {
-        server.respond('PUT', '/planets/12345', function(xhr) {
-          deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Earth'}}, 'PUT request');
+        server.respond('PATCH', '/planets/12345', function(xhr) {
+          deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', id: '12345', attributes: {name: 'Earth'}}}, 'PUT request');
           xhr.respond(200,
             {'Content-Type': 'application/json'},
             JSON.stringify({}));
@@ -237,10 +237,10 @@ test("records updated in memory should be updated with rest", function() {
     equal(record.classification, 'gas giant', 'memory source - inserted - classification - gas giant');
 
     server.respond('POST', '/planets', function(xhr) {
-      deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+      deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
       xhr.respond(201,
                   {'Content-Type': 'application/json'},
-                  JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                  JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
     });
 
     record = clone(record);
@@ -300,8 +300,8 @@ test("records patched in memory should be patched with rest", function() {
       equal(operation.value.classification, 'gas giant', 'rest source - inserted - classification - gas giant');
 
       setTimeout(function() {
-        server.respond('PUT', '/planets/12345', function(xhr) {
-          deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Earth'}}, 'PUT request');
+        server.respond('PATCH', '/planets/12345', function(xhr) {
+          deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', id: '12345', attributes: {name: 'Earth'}}}, 'PUT request');
           xhr.respond(200,
             {'Content-Type': 'application/json'},
             JSON.stringify({}));
@@ -353,10 +353,10 @@ test("records patched in memory should be patched with rest", function() {
     equal(record.classification, 'gas giant', 'memory source - inserted - classification - gas giant');
 
     server.respond('POST', '/planets', function(xhr) {
-      deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+      deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
       xhr.respond(201,
                   {'Content-Type': 'application/json'},
-                  JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                  JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
     });
 
     return memorySource.patch('planet', record.__id, 'name', 'Earth');
@@ -443,10 +443,10 @@ test("records deleted in memory should be deleted with rest", function() {
     equal(memorySource.length('planet'), 1, 'memory source - inserted - should contain one record');
 
     server.respond('POST', '/planets', function(xhr) {
-      deepEqual(JSON.parse(xhr.requestBody), {planets: {name: 'Jupiter', classification: 'gas giant'}}, 'POST request');
+      deepEqual(JSON.parse(xhr.requestBody), {data: {type: 'planets', attributes: {name: 'Jupiter', classification: 'gas giant'}}}, 'POST request');
       xhr.respond(201,
                   {'Content-Type': 'application/json'},
-                  JSON.stringify({planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}));
+                  JSON.stringify({data: {type: 'planets', id: '12345', attributes: {name: 'Jupiter', classification: 'gas giant'}}}));
     });
 
     return memorySource.remove('planet', planet.__id);

--- a/test/tests/integration/rest-memory-source-assist-test.js
+++ b/test/tests/integration/rest-memory-source-assist-test.js
@@ -87,12 +87,17 @@ test("multiple subsequent find requests", function() {
   expect(6);
 
   var planets = {
-    "planets": [
+    "data": [
       {
+        "type": "planets",
         "id": "1",
-        "name": "Jupiter",
-        "links": {
-          "moons": ["2"]
+        "attributes": {
+          "name": "Jupiter"
+        },
+        "relationships": {
+          "moons": {
+            "data": [{"type": "moons", "id": "2"}]
+          }
         }
       }
     ]
@@ -105,13 +110,20 @@ test("multiple subsequent find requests", function() {
   });
 
   var moons = {
-    "moons": [
+    "data": [
       {
+        "type": "moons",
         "id": "2",
-        "name": "Io",
-        "links": {
-          "mountains": ["3"],
-          "planet": "1"
+        "attributes": {
+          "name": "Io"
+        },
+        "relationships": {
+          "mountains": {
+            "data": [{"type": "mountains", "id": "3"}]
+          },
+          "planet": {
+            "data": {"type": "planets", "id": "1"}
+          }
         }
       }
     ]
@@ -124,12 +136,17 @@ test("multiple subsequent find requests", function() {
   });
 
   var mountains = {
-    "mountains": [
+    "data": [
       {
+        "type": "mountains",
         "id": "3",
-        "name": "Danube Planum",
-        "links": {
-          "moon": "2"
+        "attributes": {
+          "name": "Danube Planum"
+        },
+        "relationships": {
+          "moon": {
+            "data": {"type": "moons", "id": "2"}
+          }
         }
       }
     ]
@@ -170,33 +187,43 @@ test("multiple subsequent find requests", function() {
 test("a single find request that returns a compound document", function() {
   expect(2);
 
-  var planets = {
-    "linked": {
-      "mountains": [
-        {
-          "id": "3",
-          "name": "Danube Planum",
-          "links": {
-            "moon": "2"
-          }
-        }
-      ],
-      "moons": [
-        {
-          "id": "2",
-          "name": "Io",
-          "links": {
-            "mountains": ["3"]
-          }
-        }
-      ]
-    },
-    "planets": [
+  var data = {
+    "included": [
       {
+        "type": "mountains",
+        "id": "3",
+        "attributes": {
+          "name": "Danube Planum"
+        },
+        "relationships": {
+          "moon": {
+            "data": {"type": "moons", "id": "2"}
+          }
+        }
+      }, {
+        "type": "moons",
+        "id": "2",
+        "attributes": {
+          "name": "Io"
+        },
+        "relationships": {
+          "mountains": {
+            "data": [{"type": "mountains", "id": "3"}]
+          }
+        }
+      }
+    ],
+    "data": [
+      {
+        "type": "planets",
         "id": "1",
-        "name": "Jupiter",
-        "links": {
-          "moons": ["2"]
+        "attributes": {
+          "name": "Jupiter"
+        },
+        "relationships": {
+          "moons": {
+            "data": [{"type": "moons", "id": "2"}]
+          }
         }
       }
     ]
@@ -205,7 +232,7 @@ test("a single find request that returns a compound document", function() {
       ok(true, 'GET /planets request');
       xhr.respond(200,
                   {'Content-Type': 'application/json'},
-                  JSON.stringify(planets));
+                  JSON.stringify(data));
   });
 
   memorySource.on('assistFind', function(type, id) {
@@ -222,24 +249,32 @@ test("a single find request that returns a compound document", function() {
 
 test("update record with an inverse relation", function() {
   expect(4);
-  var planets = {
-    "linked": {
-      "moons": [
-        {
-          "id": "2",
-          "name": "Io",
-          "links": {
-            "planet": "1"
+  var data = {
+    "included": [
+      {
+        "type": "moons",
+        "id": "2",
+        "attributes": {
+          "name": "Io"
+        },
+        "relationships": {
+          "planet": {
+            "data": {"type": "planets", "id": "1"}
           }
         }
-      ]
-    },
-    "planets": [
+      }
+    ],
+    "data": [
       {
+        "type": "planets",
         "id": "1",
-        "name": "Jupiter",
-        "links": {
-          "moons": ["2"]
+        "attributes": {
+          "name": "Jupiter"
+        },
+        "relationships": {
+          "moons": {
+            "data": [{"type": "moons", "id": "2"}]
+          }
         }
       }
     ]
@@ -250,9 +285,9 @@ test("update record with an inverse relation", function() {
       ok(true, 'GET /planets request');
       request.respond(200,
                       {'Content-Type': 'application/json'},
-                      JSON.stringify(planets));
-    } else if (request.method === 'PUT' && request.url === '/planets/1') {
-      ok(true, 'PUT /planets/1 request');
+                      JSON.stringify(data));
+    } else if (request.method === 'PATCH' && request.url === '/planets/1') {
+      ok(true, 'PATCH /planets/1 request');
       request.respond(204, {}, "");
     } else {
       ok(false, request.method + ' ' + request.url + ' unexpected request');

--- a/test/tests/orbit-common/unit/jsonapi-patch-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-patch-source-test.js
@@ -1,224 +1,224 @@
-import Orbit from 'orbit/main';
-import { uuid } from 'orbit/lib/uuid';
-import Schema from 'orbit-common/schema';
-import Source from 'orbit-common/source';
-import JSONAPISource from 'orbit-common/jsonapi-source';
-import JSONAPIPatchSource from 'orbit-common/jsonapi-patch-source';
-import { Promise } from 'rsvp';
-import jQuery from 'jquery';
-
-var server,
-    schema,
-    source;
-
-///////////////////////////////////////////////////////////////////////////////
-
-module("OC - JSONAPIPatchSource", {
-  setup: function() {
-    Orbit.Promise = Promise;
-    Orbit.ajax = jQuery.ajax;
-
-    // fake xhr
-    server = sinon.fakeServer.create();
-    server.autoRespond = true;
-
-    schema = new Schema({
-      modelDefaults: {
-        keys: {
-          '__id': {primaryKey: true, defaultValue: uuid},
-          'id': {}
-        }
-      },
-      models: {
-        planet: {
-          attributes: {
-            name: {type: 'string'},
-            classification: {type: 'string'}
-          },
-          links: {
-            moons: {type: 'hasMany', model: 'moon', inverse: 'planet'}
-          }
-        },
-        moon: {
-          attributes: {
-            name: {type: 'string'}
-          },
-          links: {
-            planet: {type: 'hasOne', model: 'planet', inverse: 'moons'}
-          }
-        }
-      }
-    });
-
-    source = new JSONAPIPatchSource(schema);
-  },
-
-  teardown: function() {
-    schema = null;
-    source = null;
-
-    server.restore();
-  }
-});
-
-test("it exists", function() {
-  ok(source);
-});
-
-test("its prototype chain is correct", function() {
-  ok(source instanceof Source, 'instanceof Source');
-  ok(source instanceof JSONAPISource, 'instanceof JSONAPISource');
-});
-
-test("#add - can insert records", function() {
-  expect(5);
-
-  server.respondWith('PATCH', '/planets', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), [{op: 'add', path: '/-', value: {name: 'Jupiter', classification: 'gas giant', links: {moons: []}}}], 'PATCH request');
-    xhr.respond(201,
-                {'Content-Type': 'application/json'},
-                JSON.stringify([{planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}]));
-  });
-
-  stop();
-  source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
-    start();
-    ok(planet.__id, 'orbit id should be defined');
-    equal(planet.id, 12345, 'server id should be defined');
-    equal(planet.name, 'Jupiter', 'name should match');
-    equal(planet.classification, 'gas giant', 'classification should match');
-  });
-});
-
-test("#update - can update records", function() {
-  expect(5);
-
-  server.respondWith('PATCH', '/planets/12345', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: {id: '12345', name: 'Jupiter', classification: 'gas giant', links: {moons: []}}}], 'PATCH request');
-    xhr.respond(200,
-                {'Content-Type': 'application/json'},
-                JSON.stringify({}));
-  });
-
-  stop();
-  var data = {id: '12345', name: 'Jupiter', classification: 'gas giant'};
-  source.update('planet', data).then(function() {
-    start();
-    var planetId = source.getId('planet', data);
-    var planet = source.retrieve(['planet', planetId]);
-    equal(planet.__id, planetId, 'orbit id should be defined');
-    equal(planet.id, '12345', 'server id should be defined');
-    equal(planet.name, 'Jupiter', 'name should match');
-    equal(planet.classification, 'gas giant', 'classification should match');
-  });
-});
-
-test("#patch - can patch records", function() {
-  expect(2);
-
-  server.respondWith('PATCH', '/planets/12345', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/classification', value: 'gas giant'}], 'PATCH request');
-    xhr.respond(200,
-                {'Content-Type': 'application/json'},
-                JSON.stringify({}));
-  });
-
-  stop();
-  source.patch('planet', {id: 12345}, 'classification', 'gas giant').then(function() {
-    start();
-    ok(true, 'record patched');
-  });
-});
-
-test("#remove - can delete records", function() {
-  expect(2);
-
-  server.respondWith('PATCH', '/planets/12345', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), [{op: 'remove', path: '/'}],
-              'PATCH request to remove record');
-    xhr.respond(200,
-                {'Content-Type': 'application/json'},
-                JSON.stringify({}));
-  });
-
-  stop();
-  source.remove('planet', {id: '12345'}).then(function() {
-    start();
-    ok(true, 'record deleted');
-  });
-});
-
-test("#addLink - can add a hasMany relationship", function() {
-  expect(2);
-
-  server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), [{op: 'add', path: '/-', value: '987'}],
-              'PATCH request to add link to primary record');
-    xhr.respond(200,
-                {'Content-Type': 'application/json'},
-                JSON.stringify({}));
-  });
-
-  stop();
-  source.addLink('planet', {id: '12345'}, 'moons', {id: '987'}).then(function() {
-    start();
-    ok(true, 'records linked');
-  });
-});
-
-test("#removeLink - can remove a relationship", function() {
-  expect(2);
-
-  server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), [{op: 'remove', path: '/987'}],
-              'PATCH request to remove link from primary record');
-    xhr.respond(200,
-                {'Content-Type': 'application/json'},
-                JSON.stringify({}));
-  });
-
-  stop();
-  source.removeLink('planet', {id: 12345}, 'moons', {id: 987}).then(function() {
-    start();
-    ok(true, 'records unlinked');
-  });
-});
-
-test("#updateLink - can replace a hasOne relationship", function() {
-  expect(2);
-
-  server.respondWith('PATCH', '/moons/987/links/planet', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: '12345'}],
-              'PATCH request to replace link');
-    xhr.respond(200,
-                {'Content-Type': 'application/json'},
-                JSON.stringify({}));
-  });
-
-  stop();
-  source.updateLink('moon', {id: '987'}, 'planet', {id: '12345'}).then(function() {
-    start();
-    ok(true, 'records linked');
-  });
-});
-
-test("#updateLink - can replace a hasMany relationship (flagged as `actsAsSet`)", function() {
-  expect(2);
-
-  // Moons link must be flagged with `actsAsSet`
-  source.schema.models.planet.links.moons.actsAsSet = true;
-
-  server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: ['987']}],
-      'PATCH request to replace link');
-    xhr.respond(200,
-      {'Content-Type': 'application/json'},
-      JSON.stringify({}));
-  });
-
-  stop();
-  source.updateLink('planet', {id: '12345'}, 'moons', [{id: '987'}]).then(function() {
-    start();
-    ok(true, 'records linked');
-  });
-});
+// import Orbit from 'orbit/main';
+// import { uuid } from 'orbit/lib/uuid';
+// import Schema from 'orbit-common/schema';
+// import Source from 'orbit-common/source';
+// import JSONAPISource from 'orbit-common/jsonapi-source';
+// import JSONAPIPatchSource from 'orbit-common/jsonapi-patch-source';
+// import { Promise } from 'rsvp';
+// import jQuery from 'jquery';
+//
+// var server,
+//     schema,
+//     source;
+//
+// ///////////////////////////////////////////////////////////////////////////////
+//
+// module("OC - JSONAPIPatchSource", {
+//   setup: function() {
+//     Orbit.Promise = Promise;
+//     Orbit.ajax = jQuery.ajax;
+//
+//     // fake xhr
+//     server = sinon.fakeServer.create();
+//     server.autoRespond = true;
+//
+//     schema = new Schema({
+//       modelDefaults: {
+//         keys: {
+//           '__id': {primaryKey: true, defaultValue: uuid},
+//           'id': {}
+//         }
+//       },
+//       models: {
+//         planet: {
+//           attributes: {
+//             name: {type: 'string'},
+//             classification: {type: 'string'}
+//           },
+//           links: {
+//             moons: {type: 'hasMany', model: 'moon', inverse: 'planet'}
+//           }
+//         },
+//         moon: {
+//           attributes: {
+//             name: {type: 'string'}
+//           },
+//           links: {
+//             planet: {type: 'hasOne', model: 'planet', inverse: 'moons'}
+//           }
+//         }
+//       }
+//     });
+//
+//     source = new JSONAPIPatchSource(schema);
+//   },
+//
+//   teardown: function() {
+//     schema = null;
+//     source = null;
+//
+//     server.restore();
+//   }
+// });
+//
+// test("it exists", function() {
+//   ok(source);
+// });
+//
+// test("its prototype chain is correct", function() {
+//   ok(source instanceof Source, 'instanceof Source');
+//   ok(source instanceof JSONAPISource, 'instanceof JSONAPISource');
+// });
+//
+// test("#add - can insert records", function() {
+//   expect(5);
+//
+//   server.respondWith('PATCH', '/planets', function(xhr) {
+//     deepEqual(JSON.parse(xhr.requestBody), [{op: 'add', path: '/-', value: {name: 'Jupiter', classification: 'gas giant', links: {moons: []}}}], 'PATCH request');
+//     xhr.respond(201,
+//                 {'Content-Type': 'application/json'},
+//                 JSON.stringify([{planets: {id: '12345', name: 'Jupiter', classification: 'gas giant'}}]));
+//   });
+//
+//   stop();
+//   source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
+//     start();
+//     ok(planet.__id, 'orbit id should be defined');
+//     equal(planet.id, 12345, 'server id should be defined');
+//     equal(planet.name, 'Jupiter', 'name should match');
+//     equal(planet.classification, 'gas giant', 'classification should match');
+//   });
+// });
+//
+// test("#update - can update records", function() {
+//   expect(5);
+//
+//   server.respondWith('PATCH', '/planets/12345', function(xhr) {
+//     deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: {id: '12345', name: 'Jupiter', classification: 'gas giant', links: {moons: []}}}], 'PATCH request');
+//     xhr.respond(200,
+//                 {'Content-Type': 'application/json'},
+//                 JSON.stringify({}));
+//   });
+//
+//   stop();
+//   var data = {id: '12345', name: 'Jupiter', classification: 'gas giant'};
+//   source.update('planet', data).then(function() {
+//     start();
+//     var planetId = source.getId('planet', data);
+//     var planet = source.retrieve(['planet', planetId]);
+//     equal(planet.__id, planetId, 'orbit id should be defined');
+//     equal(planet.id, '12345', 'server id should be defined');
+//     equal(planet.name, 'Jupiter', 'name should match');
+//     equal(planet.classification, 'gas giant', 'classification should match');
+//   });
+// });
+//
+// test("#patch - can patch records", function() {
+//   expect(2);
+//
+//   server.respondWith('PATCH', '/planets/12345', function(xhr) {
+//     deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/classification', value: 'gas giant'}], 'PATCH request');
+//     xhr.respond(200,
+//                 {'Content-Type': 'application/json'},
+//                 JSON.stringify({}));
+//   });
+//
+//   stop();
+//   source.patch('planet', {id: 12345}, 'classification', 'gas giant').then(function() {
+//     start();
+//     ok(true, 'record patched');
+//   });
+// });
+//
+// test("#remove - can delete records", function() {
+//   expect(2);
+//
+//   server.respondWith('PATCH', '/planets/12345', function(xhr) {
+//     deepEqual(JSON.parse(xhr.requestBody), [{op: 'remove', path: '/'}],
+//               'PATCH request to remove record');
+//     xhr.respond(200,
+//                 {'Content-Type': 'application/json'},
+//                 JSON.stringify({}));
+//   });
+//
+//   stop();
+//   source.remove('planet', {id: '12345'}).then(function() {
+//     start();
+//     ok(true, 'record deleted');
+//   });
+// });
+//
+// test("#addLink - can add a hasMany relationship", function() {
+//   expect(2);
+//
+//   server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
+//     deepEqual(JSON.parse(xhr.requestBody), [{op: 'add', path: '/-', value: '987'}],
+//               'PATCH request to add link to primary record');
+//     xhr.respond(200,
+//                 {'Content-Type': 'application/json'},
+//                 JSON.stringify({}));
+//   });
+//
+//   stop();
+//   source.addLink('planet', {id: '12345'}, 'moons', {id: '987'}).then(function() {
+//     start();
+//     ok(true, 'records linked');
+//   });
+// });
+//
+// test("#removeLink - can remove a relationship", function() {
+//   expect(2);
+//
+//   server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
+//     deepEqual(JSON.parse(xhr.requestBody), [{op: 'remove', path: '/987'}],
+//               'PATCH request to remove link from primary record');
+//     xhr.respond(200,
+//                 {'Content-Type': 'application/json'},
+//                 JSON.stringify({}));
+//   });
+//
+//   stop();
+//   source.removeLink('planet', {id: 12345}, 'moons', {id: 987}).then(function() {
+//     start();
+//     ok(true, 'records unlinked');
+//   });
+// });
+//
+// test("#updateLink - can replace a hasOne relationship", function() {
+//   expect(2);
+//
+//   server.respondWith('PATCH', '/moons/987/links/planet', function(xhr) {
+//     deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: '12345'}],
+//               'PATCH request to replace link');
+//     xhr.respond(200,
+//                 {'Content-Type': 'application/json'},
+//                 JSON.stringify({}));
+//   });
+//
+//   stop();
+//   source.updateLink('moon', {id: '987'}, 'planet', {id: '12345'}).then(function() {
+//     start();
+//     ok(true, 'records linked');
+//   });
+// });
+//
+// test("#updateLink - can replace a hasMany relationship (flagged as `actsAsSet`)", function() {
+//   expect(2);
+//
+//   // Moons link must be flagged with `actsAsSet`
+//   source.schema.models.planet.links.moons.actsAsSet = true;
+//
+//   server.respondWith('PATCH', '/planets/12345/links/moons', function(xhr) {
+//     deepEqual(JSON.parse(xhr.requestBody), [{op: 'replace', path: '/', value: ['987']}],
+//       'PATCH request to replace link');
+//     xhr.respond(200,
+//       {'Content-Type': 'application/json'},
+//       JSON.stringify({}));
+//   });
+//
+//   stop();
+//   source.updateLink('planet', {id: '12345'}, 'moons', [{id: '987'}]).then(function() {
+//     start();
+//     ok(true, 'records linked');
+//   });
+// });


### PR DESCRIPTION
This PR brings Orbit into compliance with v1.0 of the JSON API spec.

Most of this work is related to the `JSONAPISource` and `JSONAPISerializer`.

Also, the `JSONAPIPatchSource` has been temporarily removed now that the `jsonpatch` extension has been made an experimental part of the JSON API spec. Work can be expected to continue on both the extension and the source (although time will tell whether it remains part of the OrbitCommon lib).

Note that further work is planned related to JSON API, which will be discussed in separate issues.