### PR TITLE
Introduce `quiet` option for Document `retrieve` and `test`.

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -92,19 +92,14 @@ var Cache = Class.extend({
   /**
    Return data at a particular path.
 
-   Returns `null` if the path does not exist in the document.
+   Returns `undefined` if the path does not exist in the document.
 
    @method retrieve
    @param path
    @returns {Object}
    */
   retrieve: function(path) {
-    try {
-      // console.log('Cache#retrieve', path, this._doc.retrieve(path));
-      return this._doc.retrieve(path);
-    } catch(e) {
-      return undefined;
-    }
+    return this._doc.retrieve(path, true);
   },
 
   /**

--- a/lib/orbit/document.js
+++ b/lib/orbit/document.js
@@ -43,14 +43,17 @@ var Document = Class.extend({
   /**
    Retrieve the value at a path.
 
-   Throws `PathNotFoundException` if the path does not exist in the document.
+   If the path does not exist in the document, `PathNotFoundException` will be
+   thrown by default. If `quiet` is truthy, `undefined` will be returned
+   instead.
 
    @method retrieve
-   @param {Array or String} path
-   @returns {Object} Object at the specified `path`
+   @param {Array or String} [path]
+   @param {Boolean} [quiet=false] Return `undefined` instead of throwing an exception if `path` can't be found?
+   @returns {Object} Value at the specified `path` or `undefined`
    */
-  retrieve: function(path) {
-    return this._retrieve(this.deserializePath(path));
+  retrieve: function(path, quiet) {
+    return this._retrieve(this.deserializePath(path), quiet);
   },
 
   /**
@@ -155,12 +158,13 @@ var Document = Class.extend({
    Throws `PathNotFoundException` if the path does not exist in the document.
 
    @method test
-   @param {Array or String} path
-   @param {Object} value Expected value to test
+   @param {Array or String} [path]
+   @param {Object} [value] Expected value to test
+   @param {Boolean} [quiet=false] Use `undefined` instead of throwing an exception if `path` can't be found?
    @returns {Boolean} Does the value at `path` equal `value`?
    */
-  test: function(path, value) {
-    return eq(this._retrieve(this.deserializePath(path)), value);
+  test: function(path, value, quiet) {
+    return eq(this._retrieve(this.deserializePath(path), quiet), value);
   },
 
   /**
@@ -232,11 +236,15 @@ var Document = Class.extend({
   // Internals
   /////////////////////////////////////////////////////////////////////////////
 
-  _pathNotFound: function(path) {
-    throw new PathNotFoundException(this.serializePath(path));
+  _pathNotFound: function(path, quiet) {
+    if (quiet) {
+      return undefined;
+    } else {
+      throw new PathNotFoundException(this.serializePath(path));
+    }
   },
 
-  _retrieve: function(path) {
+  _retrieve: function(path, quiet) {
     var ptr = this._data,
         segment;
     if (path) {
@@ -252,7 +260,7 @@ var Document = Class.extend({
           ptr = ptr[segment];
         }
         if (ptr === undefined) {
-          this._pathNotFound(path);
+          return this._pathNotFound(path, quiet);
         }
       }
     }

--- a/test/tests/orbit/unit/document-test.js
+++ b/test/tests/orbit/unit/document-test.js
@@ -75,6 +75,21 @@ test("#retrieve - can retrieve a value with an array in the path", function() {
   deepEqual(doc.retrieve('/c/1/e'), 'f');
 });
 
+test("#retrieve - throws an exception for a path that doesn't exist", function() {
+  doc.reset({a: 'b'});
+  throws(
+    function() {
+      doc.retrieve('/b');
+    },
+    Document.PathNotFoundException
+  );
+});
+
+test("#retrieve - returns `undefined` for a path that doesn't exist when `quiet=true`", function() {
+  doc.reset({a: 'b'});
+  strictEqual(doc.retrieve('/b', true), undefined);
+});
+
 /*
   `test`
  */
@@ -122,6 +137,11 @@ test("#test - throws an exception for a path that doesn't exist", function() {
     },
     Document.PathNotFoundException
   );
+});
+
+test("#test - uses `undefined` for the value of a path that doesn't exist when `quiet=true`", function() {
+  doc.reset({a: 'b'});
+  strictEqual(doc.test('/b', undefined, true), true);
 });
 
 /*


### PR DESCRIPTION
This option allows the Document to skip throwing expensive exceptions when
a path can't be found.