### PR TITLE
Define Schema#operationEncoder.

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -4,7 +4,6 @@ import { Class, clone, expose, isArray, isObject, isNone } from 'orbit/lib/objec
 import { OperationNotAllowed } from './lib/exceptions';
 import { eq } from 'orbit/lib/eq';
 import { deprecate } from 'orbit/lib/deprecate';
-import OperationEncoder from 'orbit-common/operation-encoder';
 import RelatedInverseLinksProcessor from 'orbit-common/operation-processors/related-inverse-links';
 
 /**
@@ -46,7 +45,6 @@ var Cache = Class.extend({
     }
 
     this.schema = schema;
-    this._operationEncoder = new OperationEncoder(schema);
     for (var model in schema.models) {
       if (schema.models.hasOwnProperty(model)) {
         this._registerModel(model);
@@ -247,7 +245,7 @@ var Cache = Class.extend({
   },
 
   _dependentOps: function(operation) {
-    var operationType = this._operationEncoder.identify(operation);
+    var operationType = this.schema.operationEncoder.identify(operation);
     var operations = [];
     if (operationType === 'removeRecord') {
       var _this = this,
@@ -285,7 +283,7 @@ var Cache = Class.extend({
     if (value) {
       var type = path[0],
           id = path[1],
-          operationType = this._operationEncoder.identify(operation);
+          operationType = this.schema.operationEncoder.identify(operation);
 
       switch(operationType) {
         case 'addRecord': return this._addRecordRevLinks(type, value);
@@ -360,7 +358,7 @@ var Cache = Class.extend({
     if (value) {
       var type = path[0],
           id = path[1],
-          operationType = this._operationEncoder.identify(parentOperation);
+          operationType = this.schema.operationEncoder.identify(parentOperation);
 
       switch(operationType) {
         case 'removeRecord': return this._removeRecordRevLinks(type, id, value, parentOperation);

--- a/lib/orbit-common/operation-processors/related-inverse-links.js
+++ b/lib/orbit-common/operation-processors/related-inverse-links.js
@@ -1,11 +1,9 @@
 import { Class, isArray, isObject, isNone } from 'orbit/lib/objects';
-import OperationEncoder from 'orbit-common/operation-encoder';
 
 export default Class.extend({
   init: function(schema, cache) {
     this._schema = schema;
     this._cache = cache;
-    this._operationEncoder = new OperationEncoder(schema);
   },
 
   process: function(operation) {
@@ -14,7 +12,7 @@ export default Class.extend({
     var value = operation.value;
     var type = path[0];
     var schema = this._schema;
-    var operationType = this._operationEncoder.identify(operation);
+    var operationType = this._schema.operationEncoder.identify(operation);
 
     function relatedLinkOps(linkValue, linkDef) {
       linkDef = linkDef || schema.linkDefinition(type, path[3]);
@@ -107,7 +105,7 @@ export default Class.extend({
 
   _relatedLinkOp: function(type, id, link, value, parentOperation, relatedOp) {
     if (this._retrieve([type, id])) {
-      var operation = this._operationEncoder.linkOp(relatedOp, type, id, link, value);
+      var operation = this._schema.operationEncoder.linkOp(relatedOp, type, id, link, value);
       var path = operation.path.join("/");
 
       // Apply operation only if necessary

--- a/lib/orbit-common/schema.js
+++ b/lib/orbit-common/schema.js
@@ -2,6 +2,7 @@ import { Class, clone, extend } from 'orbit/lib/objects';
 import { uuid } from 'orbit/lib/uuid';
 import { OperationNotAllowed, ModelNotRegisteredException, LinkNotRegisteredException } from './lib/exceptions';
 import Evented from 'orbit/evented';
+import OperationEncoder from './operation-encoder';
 
 /**
  `Schema` defines the models allowed in a source, including their keys,
@@ -268,7 +269,15 @@ var Schema = Class.extend({
         }
       }
     }
+
+    this.operationEncoder = new OperationEncoder(this);
   },
+
+  /**
+   @property operationEncoder
+   @type OperationEncoder
+   */
+  operationEncoder: null,
 
   /**
    Registers a model's schema definition.

--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -8,7 +8,6 @@ import { Class, expose, isArray, isObject, isNone } from 'orbit/lib/objects';
 import Cache from './cache';
 import Operation from 'orbit/operation';
 import { LinkNotFoundException } from './lib/exceptions';
-import OperationEncoder from 'orbit-common/operation-encoder';
 
 /**
  `Source` is an abstract base class to be extended by other sources.
@@ -30,8 +29,6 @@ var Source = Class.extend({
     // Create an internal cache and expose some elements of its interface
     this._cache = new Cache(schema);
     expose(this, this._cache, 'length', 'reset', 'retrieve', 'retrieveLink');
-
-    this._operationEncoder = new OperationEncoder(schema);
 
     Transformable.extend(this);
     Requestable.extend(this, ['find', 'add', 'update', 'patch', 'remove',
@@ -88,7 +85,7 @@ var Source = Class.extend({
         path = [type, id],
         _this = this;
 
-    return this.transform(this._operationEncoder.addRecordOp(type, id, record)).then(function() {
+    return this.transform(this.schema.operationEncoder.addRecordOp(type, id, record)).then(function() {
       return _this.retrieve(path);
     });
   },
@@ -97,32 +94,32 @@ var Source = Class.extend({
     var record = this.normalize(type, data);
     var id = this.getId(type, record);
 
-    return this.transform(this._operationEncoder.replaceRecordOp(type, id, record));
+    return this.transform(this.schema.operationEncoder.replaceRecordOp(type, id, record));
   },
 
   _patch: function(type, id, attribute, value) {
     id = this._normalizeId(type, id);
     // todo - confirm this simplification is valid (i.e. don't attempt to deserialize attribute path)
-    return this.transform(this._operationEncoder.replaceAttributeOp(type, id, attribute, value));
+    return this.transform(this.schema.operationEncoder.replaceAttributeOp(type, id, attribute, value));
   },
 
   _remove: function(type, id) {
     id = this._normalizeId(type, id);
-    return this.transform(this._operationEncoder.removeRecordOp(type, id));
+    return this.transform(this.schema.operationEncoder.removeRecordOp(type, id));
   },
 
   _addLink: function(type, id, key, value) {
     id = this._normalizeId(type, id);
     value = this._normalizeLink(type, key, value);
 
-    return this.transform(this._operationEncoder.addLinkOp(type, id, key, value));
+    return this.transform(this.schema.operationEncoder.addLinkOp(type, id, key, value));
   },
 
   _removeLink: function(type, id, key, value) {
     id = this._normalizeId(type, id);
     value = this._normalizeLink(type, key, value);
 
-    return this.transform(this._operationEncoder.removeLinkOp(type, id, key, value));
+    return this.transform(this.schema.operationEncoder.removeLinkOp(type, id, key, value));
   },
 
   _updateLink: function(type, id, key, value) {
@@ -134,7 +131,7 @@ var Source = Class.extend({
     id = this._normalizeId(type, id);
     value = this._normalizeLink(type, key, value);
 
-    var op = this._operationEncoder.replaceLinkOp(type, id, key, value);
+    var op = this.schema.operationEncoder.replaceLinkOp(type, id, key, value);
     return this.transform(op);
   },
 


### PR DESCRIPTION
Eliminate the need to instantiate multiple operation encoders
throughout an application, when a single object on the schema could
serve the same purpose.