### PR TITLE
Add default Promise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ Orbit relies heavily on promises, events and low-level transforms.
 
 ## Dependencies
 
-Orbit.js has no specific external run-time dependencies, but must be used with a
-library that implements the
-[Promises/A+](http://promises-aplus.github.io/promises-spec/)
-spec, such as [RSVP](https://github.com/tildeio/rsvp.js).
+Orbit.js has no specific external run-time dependencies, but it must be used in an
+environment that includes an implementation of the [Promises/A+](http://promises-aplus.github.io/promises-spec/). If you wish to support legacy browsers, you will need to include a library
+such as [RSVP](https://github.com/tildeio/rsvp.js).
 
 ## Installation
 
@@ -52,7 +51,9 @@ maintained for builds.
 
 You'll need to configure Orbit to recognize any applicable dependencies.
 
-Configure your promise library's `Promise` constructor as follows:
+Orbit defaults to using the global `Promise` constructor, if it exists. If your environment
+does not implement Promises, or if you wish to use another Promise implementation, configure
+your promise library's `Promise` constructor as follows:
 
 ```javascript
 Orbit.Promise = RSVP.Promise;

--- a/lib/orbit.js
+++ b/lib/orbit.js
@@ -24,6 +24,7 @@ import { capitalize } from 'orbit/lib/strings';
 import { noop, required } from 'orbit/lib/stubs';
 import { uuid } from 'orbit/lib/uuid';
 
+Orbit.Promise = Promise;
 Orbit.Action = Action;
 Orbit.ActionQueue = ActionQueue;
 Orbit.Document = Document;


### PR DESCRIPTION
Resolves #163 

===

@gnarf suggested adding a conditional for this – checking for `typeof Promise` – but when an environment doesn't support Promises this statement should not cause any harm. `Orbit.Promise` should simply *continue* to be `undefined`.