### PR TITLE
Check for undefined before assigning Promise

### DIFF
--- a/lib/orbit.js
+++ b/lib/orbit.js
@@ -24,7 +24,10 @@ import { capitalize } from 'orbit/lib/strings';
 import { noop, required } from 'orbit/lib/stubs';
 import { uuid } from 'orbit/lib/uuid';
 
-Orbit.Promise = Promise;
+if (typeof Promise !== 'undefined') {
+  Orbit.Promise = Promise;
+}
+
 Orbit.Action = Action;
 Orbit.ActionQueue = ActionQueue;
 Orbit.Document = Document;


### PR DESCRIPTION
Add a guard to using `Promise` - if `Promise` is not defined trying to assign it to something will cause a ReferenceError:

Fixes bug in #164