### PR TITLE
Query by keys should reject missing, and always return an object

### DIFF
--- a/lib/orbit-common/memory-source.js
+++ b/lib/orbit-common/memory-source.js
@@ -83,6 +83,13 @@ var MemorySource = Source.extend({
 
         } else {
           result = _this._filter.call(_this, type, id);
+
+          // If all keys in our query were keys, always return a single record.
+          if (Object.keys(id).every(function(key) {
+            return modelSchema.keys[key];
+          })) {
+            result = result[0];
+          }
         }
 
       } else {


### PR DESCRIPTION
Currently, doing a `.find('planet', { secondaryKey: key })` will return `[]` and `[object]` even when it does find one.  This messes with the standard connections using when secondary keys for rescue/assist finds.