### PR TITLE
Introduce Schema#modelNotDefined hook.

### DIFF
--- a/lib/orbit-common/schema.js
+++ b/lib/orbit-common/schema.js
@@ -360,12 +360,40 @@ var Schema = Class.extend({
     return record;
   },
 
+  /**
+   A hook that can be used to define a model that's not yet defined.
+
+   This allows for schemas to lazily define models, rather than requiring
+   full definitions upfront.
+
+   @method modelNotDefined
+   @param {String} [model] name of model
+   */
+  modelNotDefined: null,
+
+  /**
+   Look up a model definition.
+
+   If none can be found, `modelNotDefined` will be triggered, which provides
+   an opportunity for lazily defining models.
+
+   If still no model has been defined, a `ModelNotRegisteredException` is
+   raised.
+
+   @method modelDefinition
+   @param {String} [model] name of model
+   @return {Object} model definition
+   */
   modelDefinition: function(model) {
-    var modelSchema = this.models[model];
-    if (!modelSchema) {
+    var modelDefinition = this.models[model];
+    if (!modelDefinition && this.modelNotDefined) {
+      this.modelNotDefined(model);
+      modelDefinition = this.models[model];
+    }
+    if (!modelDefinition) {
       throw new ModelNotRegisteredException(model);
     }
-    return modelSchema;
+    return modelDefinition;
   },
 
   initDefaults: function(model, record) {

--- a/test/tests/orbit-common/unit/schema-test.js
+++ b/test/tests/orbit-common/unit/schema-test.js
@@ -181,6 +181,55 @@ test("#registerModel can register models after initialization", function() {
   });
 });
 
+test("#modelDefinition returns a registered model definition", function() {
+  var planetDefinition = {
+    attributes: {
+      name: {type: 'string', defaultValue: 'Earth'}
+    }
+  };
+
+  var schema = new Schema({
+    models: {
+      planet: planetDefinition
+    }
+  });
+
+  deepEqual(schema.modelDefinition('planet').attributes, planetDefinition.attributes);
+});
+
+test("#modelDefinition throws an exception if a model is not registered", function() {
+  var schema = new Schema({
+    models: {
+    }
+  });
+
+  throws(function() {
+    schema.modelDefinition('planet');
+  }, ModelNotRegisteredException, 'threw a OC.ModelNotRegisteredException');
+});
+
+test("#modelNotDefined can provide lazy registrations of models", function(assert) {
+  assert.expect(2);
+
+  var schema = new Schema({
+    models: {
+    }
+  });
+
+  var planetDefinition = {
+    attributes: {
+      name: {type: 'string', defaultValue: 'Earth'}
+    }
+  };
+
+  schema.modelNotDefined = function(type) {
+    assert.equal(type, 'planet', 'modelNotDefined called as expected');
+    schema.registerModel('planet', planetDefinition);
+  };
+
+  assert.deepEqual(schema.modelDefinition('planet').attributes, planetDefinition.attributes);
+});
+
 test("#normalize initializes a record with a unique primary key", function() {
   var schema = new Schema({
     models: {


### PR DESCRIPTION
Allows schemas to lazily define models, rather than requiring full
definitions upfront.