### PR TITLE
Find / Query split

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -241,7 +241,7 @@ export default Class.extend({
     if (op === 'add' || op === 'replace') {
       if (path.length > 1) {
         if (!this.exists(path[0])) {
-          this._doc.add(path.slice(0, 1), {});
+          this.registerModel(path[0]);
         }
 
         if (!this.exists(path.slice(0, path.length - 1))) {

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -22,27 +22,36 @@ import { diffs } from 'orbit/lib/diffs';
  @class Cache
  @namespace OC
  @param {OC.Schema} schema
- @param {Object} [options]
- @param {Array}  [options.processors=[SchemaConsistencyProcessor, CacheIntegrityProcessor]] Operation processors to notify for every call to `transform`
+ @param {Object}  [options]
+ @param {Array}   [options.processors=[SchemaConsistencyProcessor, CacheIntegrityProcessor]] Operation processors to notify for every call to `transform`.
+ @param {Boolean} [options.sparse=true] A sparse cache is an incomplete representation of data for a schema. Non-sparse (i.e. "full") caches will pre-fill data for all models in a schema.
  @constructor
  */
 export default Class.extend({
   init: function(schema, options) {
-    this._doc = new Document(null, {arrayBasedPaths: true});
-
     this.schema = schema;
-    for (var model in schema.models) {
-      if (schema.models.hasOwnProperty(model)) {
-        this._registerModel(model);
-      }
-    }
+
+    this._doc = new Document(null, {arrayBasedPaths: true});
 
     options = options || {};
     var processors = options.processors ? options.processors : [ SchemaConsistencyProcessor, CacheIntegrityProcessor ];
     this._initProcessors(processors);
 
-    // TODO - clean up listener
-    this.schema.on('modelRegistered', this._registerModel, this);
+    this.sparse = options.sparse === undefined ? true : options.sparse;
+
+    // Non-sparse caches should pre-fill data for all models in a schema.
+    if (!this.sparse) {
+      // Pre-register all models.
+      for (var model in schema.models) {
+        if (schema.models.hasOwnProperty(model)) {
+          this.registerModel(model);
+        }
+      }
+
+      // Automatically fill data for models as they're registered.
+      // TODO - clean up listener
+      this.schema.on('modelRegistered', this.registerModel, this);
+    }
   },
 
   _initProcessors: function(processors) {
@@ -53,7 +62,7 @@ export default Class.extend({
     return new Processor(this);
   },
 
-  _registerModel: function(model) {
+  registerModel: function(model) {
     var modelRootPath = [model];
     if (!this.retrieve(modelRootPath)) {
       this._doc.add(modelRootPath, {});
@@ -79,7 +88,7 @@ export default Class.extend({
   length: function(path) {
     var data = this.retrieve(path);
     if (data === null || data === undefined) {
-      return data;
+      return 0;
     } else if (isArray(data)) {
       return data.length;
     } else {
@@ -230,8 +239,14 @@ export default Class.extend({
     }
 
     if (op === 'add' || op === 'replace') {
-      if (!this.exists(path.slice(0, path.length - 1))) {
-        return;
+      if (path.length > 1) {
+        if (!this.exists(path[0])) {
+          this._doc.add(path.slice(0, 1), {});
+        }
+
+        if (!this.exists(path.slice(0, path.length - 1))) {
+          return;
+        }
       }
     }
 

--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -1,6 +1,7 @@
 import Orbit from 'orbit/main';
 import { assert } from 'orbit/lib/assert';
-import { isArray, toArray, isObject, merge } from 'orbit/lib/objects';
+import { Exception } from 'orbit/lib/exceptions';
+import { isArray, toArray, isObject, isNone, merge } from 'orbit/lib/objects';
 import Operation from 'orbit/operation';
 import ActionQueue from 'orbit/action-queue';
 import Source from './source';
@@ -97,27 +98,27 @@ export default Source.extend({
   // Requestable interface implementation
   /////////////////////////////////////////////////////////////////////////////
 
-  _find: function(type, id) {
-    if (id && (typeof id === 'number' || typeof id === 'string')) {
-      return this._findOne(type, id);
+  _find: function(type, id, options) {
+    if (options) throw new Exception('`JSONAPISource#findLink` does not support `options` argument');
 
-    } else if (id && isArray(id)) {
+    if (isNone(id)) {
+      return this._findAll(type);
+
+    } else if (isArray(id)) {
       return this._findMany(type, id);
 
     } else {
-      var resourceKey = this.serializer.resourceKey(type);
-
-      if (id && typeof id === 'object' && id[resourceKey]) {
-        return this._findOne(type, id);
-
-      } else {
-        return this._findQuery(type, id);
-      }
+      return this._findOne(type, id);
     }
   },
 
-  _findLink: function(type, id, link) {
+  _findLink: function(type, id, link, options) {
     var _this = this;
+
+    if (options) throw new Exception('`JSONAPISource#findLink` does not support `options` argument');
+
+    id = this.getId(type, id);
+
     return this.ajax(this.resourceLinkURL(type, id, link), 'GET').then(
       function(raw) {
         var relId = _this.serializer.deserializeLink(raw.data);
@@ -126,24 +127,39 @@ export default Source.extend({
     );
   },
 
- _findLinked: function(type, id, link, relId) {
+ _findLinked: function(type, id, link, options) {
    var _this = this;
 
-   if (relId === undefined) {
-     return this.ajax(this.resourceLinkedURL(type, id, link), 'GET').then(
-       function(raw) {
-         var linkDef = _this.schema.linkDefinition(type, link);
+   if (options) throw new Exception('`JSONAPISource#findLinked` does not support `options` argument');
 
-         var result = _this.deserialize(linkDef.model, null, raw);
+   id = this.getId(type, id);
 
-         return _this.transformed(result.result).then(function() {
-           return result.data;
-         });
-       }
-     );
-   } else {
-     return this._super.apply(this, arguments);
-   }
+   return this.ajax(this.resourceLinkedURL(type, id, link), 'GET').then(
+     function(raw) {
+       var linkDef = _this.schema.linkDefinition(type, link);
+
+       var result = _this.deserialize(linkDef.model, null, raw);
+
+       return _this.transformed(result.result).then(function() {
+         return result.data;
+       });
+     }
+   );
+ },
+
+ _query: function(type, query, options) {
+   var _this = this;
+
+   if (options) throw new Exception('`JSONAPISource#query` does not support `options` argument');
+
+   return this.ajax(this.resourceURL(type), 'GET', {data: {filter: query}}).then(
+     function(raw) {
+       var deserialized = _this.deserialize(type, null, raw);
+       return _this.transformed(deserialized.result).then(function() {
+         return deserialized.data;
+       });
+     }
+   );
  },
 
   /////////////////////////////////////////////////////////////////////////////
@@ -386,6 +402,18 @@ export default Source.extend({
     };
   },
 
+  _findAll: function(type) {
+    var _this = this;
+    return this.ajax(this.resourceURL(type), 'GET').then(
+      function(raw) {
+        var deserialized = _this.deserialize(type, null, raw);
+        return _this.transformed(deserialized.result).then(function() {
+          return deserialized.data;
+        });
+      }
+    );
+  },
+
   _findOne: function(type, id) {
     var _this = this;
     return this.ajax(this.resourceURL(type, id), 'GET').then(
@@ -401,19 +429,6 @@ export default Source.extend({
   _findMany: function(type, ids) {
     var _this = this;
     return this.ajax(this.resourceURL(type, ids), 'GET').then(
-      function(raw) {
-        var deserialized = _this.deserialize(type, null, raw);
-        return _this.transformed(deserialized.result).then(function() {
-          return deserialized.data;
-        });
-      }
-    );
-  },
-
-  _findQuery: function(type, query) {
-    var _this = this;
-
-    return this.ajax(this.resourceURL(type), 'GET', {data: {filter: query}}).then(
       function(raw) {
         var deserialized = _this.deserialize(type, null, raw);
         return _this.transformed(deserialized.result).then(function() {

--- a/lib/orbit-common/memory-source.js
+++ b/lib/orbit-common/memory-source.js
@@ -2,6 +2,7 @@ import Orbit from 'orbit/main';
 import { assert } from 'orbit/lib/assert';
 import { Exception } from 'orbit/lib/exceptions';
 import { isArray, isObject, isNone, clone, merge } from 'orbit/lib/objects';
+import { eq } from 'orbit/lib/eq';
 import Source from './source';
 import CacheIntegrityProcessor from 'orbit-common/operation-processors/cache-integrity-processor';
 import SchemaConsistencyProcessor from 'orbit-common/operation-processors/schema-consistency-processor';
@@ -203,7 +204,7 @@ var MemorySource = Source.extend({
         record = dataForType[i];
         match = false;
         for (prop in query) {
-          if (record[prop] === query[prop]) {
+          if (eq(record[prop], query[prop])) {
             match = true;
           } else {
             match = false;

--- a/lib/orbit-common/memory-source.js
+++ b/lib/orbit-common/memory-source.js
@@ -1,5 +1,6 @@
 import Orbit from 'orbit/main';
 import { assert } from 'orbit/lib/assert';
+import { Exception } from 'orbit/lib/exceptions';
 import { isArray, isObject, isNone, clone, merge } from 'orbit/lib/objects';
 import Source from './source';
 import CacheIntegrityProcessor from 'orbit-common/operation-processors/cache-integrity-processor';
@@ -40,127 +41,37 @@ var MemorySource = Source.extend({
   /////////////////////////////////////////////////////////////////////////////
 
   _find: function(type, id, options) {
-    var _this = this,
-        modelDefinition = this.schema.modelDefinition(type),
-        pk = modelDefinition.primaryKey.name,
-        result;
+    var _this = this;
 
-    options = options || {};
+    if (options) throw new Exception('`MemorySource#find` does not support `options` argument');
 
-    return new Orbit.Promise(function(resolve, reject) {
+    return new Orbit.Promise(function(resolve) {
+      var result;
+
       if (isNone(id)) {
-        result = _this._filter.call(_this, type);
+        result = _this._fetchAll(type);
 
       } else if (isArray(id)) {
-        var res,
-            resId,
-            notFound;
-
-        result = [];
-        notFound = [];
-
-        for (var i = 0, l = id.length; i < l; i++) {
-          resId = id[i];
-
-          res = _this.retrieve([type, resId]);
-
-          if (res) {
-            result.push(res);
-          } else {
-            notFound.push(resId);
-          }
-        }
-
-        if (notFound.length > 0) {
-          result = null;
-          id = notFound;
-        }
-        else if (options.include) {
-          _this._fetchRecords(type, id, options);
-        }
-
-      } else if (id !== null && typeof id === 'object') {
-        if (id[pk]) {
-          result = _this._fetchRecord(type, id[pk], options);
-
-        } else {
-          result = _this._filter.call(_this, type, id);
-
-          // If all keys in our query were keys, always return a single record.
-          if (Object.keys(id).every(function(key) {
-            return modelDefinition.keys[key];
-          })) {
-            result = result[0];
-          }
-        }
+        result = _this._fetchMany(type, id);
 
       } else {
-        result = _this._fetchRecord(type, id, options);
+        result = _this._fetchOne(type, id);
       }
 
-      if (result) {
-        resolve(result);
-      } else {
-        reject(new RecordNotFoundException(type, id));
-      }
+      resolve(result);
     });
   },
 
-  _fetchRecords: function(type, ids, options) {
-    var records = [];
-
-    for (var i = 0, l = ids.length; i < l; i++) {
-      var record = this._fetchRecord(type, ids[i], options);
-      records.push(record);
-    }
-
-    return records;
-  },
-
-  _fetchRecord: function(type, id, options) {
+  _query: function(type, query, options) {
     var _this = this;
-    var record = this.retrieve([type, id]);
-    if (!record) throw new RecordNotFoundException(type, id);
 
-    var include = this._parseInclude(options.include);
+    if (options) throw new Exception('`MemorySource#query` does not support `options` argument');
 
-    if (include) {
-      Object.keys(include).forEach(function(link) {
-        _this._fetchLinked(type, id, link, merge(options, {include: include[link]}));
-      });
-    }
+    return new Orbit.Promise(function(resolve) {
+      var result = _this._filter(type, query);
 
-    return record;
-  },
-
-  _fetchLinked: function(type, id, link, options) {
-    var linkType = this.schema.modelDefinition(type).links[link].model;
-    var linkValue = this.retrieveLink(type, id, link);
-
-    if (linkValue === undefined) throw new LinkNotFoundException(type, id, link);
-    if (linkValue === null) return null;
-
-    return isArray(linkValue)
-           ? this._fetchRecords(linkType, linkValue, options)
-           : this._fetchRecord(linkType, linkValue, options);
-  },
-
-  _parseInclude: function(include) {
-    if (!include) return undefined;
-    if (isObject(include) && !isArray(include)) return include;
-    if (!isArray(include)) include = [include];
-
-    var parsed = {};
-
-    include.forEach(function(inclusion) {
-      var current = parsed;
-      inclusion.split(".").forEach(function(link) {
-        current[link] = current[link] || {};
-        current = current[link];
-      });
+      resolve(result);
     });
-
-    return parsed;
   },
 
   _findLink: function(type, id, link) {
@@ -198,9 +109,83 @@ var MemorySource = Source.extend({
     });
   },
 
+  _findLinked: function(type, id, link, options) {
+    var _this = this;
+
+    if (options) throw new Exception('`MemorySource#findLinked` does not support `options` argument');
+
+    return new Orbit.Promise(function(resolve) {
+      var result = _this._fetchLinked(type, id, link);
+
+      resolve(result);
+    });
+  },
+
   /////////////////////////////////////////////////////////////////////////////
   // Internals
   /////////////////////////////////////////////////////////////////////////////
+
+  _fetchAll: function(type) {
+    var records = [];
+    var dataForType = this.retrieve([type]);
+
+    if (!dataForType) throw new RecordNotFoundException(type);
+
+    for (var i in dataForType) {
+      if (dataForType.hasOwnProperty(i)) {
+        records.push( dataForType[i] );
+      }
+    }
+
+    return records;
+  },
+
+  _fetchMany: function(type, ids) {
+    var _this = this;
+    var records = [];
+    var notFound = [];
+    var id;
+    var record;
+
+    for (var i = 0, l = ids.length; i < l; i++) {
+      id = _this.getId(type, ids[i]);
+      record = this.retrieve([type, id]);
+
+      if (record) {
+        records.push(record);
+      } else {
+        notFound.push(id);
+      }
+    }
+
+    if (notFound.length > 0) throw new RecordNotFoundException(type, notFound);
+
+    return records;
+  },
+
+  _fetchOne: function(type, id) {
+    id = this.getId(type, id);
+
+    var record = this.retrieve([type, id]);
+
+    if (!record) throw new RecordNotFoundException(type, id);
+
+    return record;
+  },
+
+  _fetchLinked: function(type, id, link) {
+    id = this.getId(type, id);
+
+    var linkType = this.schema.modelDefinition(type).links[link].model;
+    var linkValue = this.retrieveLink(type, id, link);
+
+    if (linkValue === undefined) throw new LinkNotFoundException(type, id, link);
+    if (linkValue === null) return null;
+
+    return isArray(linkValue)
+           ? this._fetchMany(linkType, linkValue)
+           : this._fetchOne(linkType, linkValue);
+  },
 
   _filter: function(type, query) {
     var all = [],
@@ -211,44 +196,25 @@ var MemorySource = Source.extend({
         record;
 
     dataForType = this.retrieve([type]);
+    if (!dataForType) throw new RecordNotFoundException(type, query);
 
     for (i in dataForType) {
       if (dataForType.hasOwnProperty(i)) {
         record = dataForType[i];
-        if (query === undefined) {
-          match = true;
-        } else {
-          match = false;
-          for (prop in query) {
-            if (record[prop] === query[prop]) {
-              match = true;
-            } else {
-              match = false;
-              break;
-            }
+        match = false;
+        for (prop in query) {
+          if (record[prop] === query[prop]) {
+            match = true;
+          } else {
+            match = false;
+            break;
           }
         }
         if (match) all.push(record);
       }
     }
+
     return all;
-  },
-
-  _filterOne: function(type, prop, value) {
-    var dataForType,
-        i,
-        record;
-
-    dataForType = this.retrieve([type]);
-
-    for (i in dataForType) {
-      if (dataForType.hasOwnProperty(i)) {
-        record = dataForType[i];
-        if (record[prop] === value) {
-          return record;
-        }
-      }
-    }
   }
 });
 

--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -38,7 +38,7 @@ var Source = Class.extend({
     }
 
     Transformable.extend(this);
-    Requestable.extend(this, ['find', 'add', 'update', 'patch', 'remove',
+    Requestable.extend(this, ['find', 'query', 'add', 'update', 'patch', 'remove',
                               'findLink', 'addLink', 'removeLink', 'updateLink',
                               'findLinked']);
 
@@ -125,18 +125,11 @@ var Source = Class.extend({
 
   _find: required,
 
+  _query: required,
+
   _findLink: required,
 
-  _findLinked: function(type, id, link, options) {
-    var modelId = this.getId(type, id);
-    var linkType = this.schema.linkDefinition(type, link).model;
-    var linkValue = this.retrieveLink(type, modelId, link);
-
-    if (linkValue === undefined) throw new LinkNotFoundException(type, id, link);
-    if (linkValue === null) return null;
-
-    return this._find(linkType, linkValue, options);
-  },
+  _findLinked: required,
 
   _add: function(type, data) {
     data = data || {};
@@ -240,7 +233,19 @@ var Source = Class.extend({
 
   getId: function(type, data) {
     if (isObject(data)) {
-      return data[this.schema.modelDefinition(type).primaryKey.name];
+      var modelDefinition = this.schema.modelDefinition(type);
+
+      if (data[modelDefinition.primaryKey.name]) {
+        return data[modelDefinition.primaryKey.name];
+
+      } else {
+        var secondaryKeys = modelDefinition.secondaryKeys;
+
+        for (var key in secondaryKeys) {
+          var value = data[key];
+          if (value) return secondaryKeys[key].secondaryToPrimaryKeyMap[value];
+        }
+      }
     } else {
       return data;
     }

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -40,6 +40,20 @@ test("it exists", function() {
   ok(cache);
 });
 
+test("is sparse by default", function(assert) {
+  cache = new Cache(schema);
+
+  assert.equal(cache.sparse, true, 'sparse is true');
+  assert.equal(cache.retrieve('planet'), undefined, 'no data is initialized');
+});
+
+test("non-sparse caches will initialize data for all models in a schema", function(assert) {
+  cache = new Cache(schema, {sparse: false});
+
+  assert.equal(cache.sparse, false, 'sparse is false');
+  assert.deepEqual(cache.retrieve('planet'), {}, 'data is initialized');
+});
+
 test("#transform sets data and #retrieve retrieves it", function() {
   cache = new Cache(schema);
 
@@ -74,8 +88,7 @@ test("#hasDeleted by default just returns the inverse of #exists", function() {
 test("#length returns the size of data at a path", function() {
   cache = new Cache(schema);
 
-  equal(cache.length('planet'), 0, 'returns 0 when an object exists at a path but has no properties');
-  equal(cache.length('notthere'), null, 'returns null when an object does not exist at a path');
+  equal(cache.length('notthere'), 0, 'returns 0 when an object does not exist at a path');
 
   cache.transform([{op: 'add', path: 'planet/1', value: {name: 'Earth'}},
                    {op: 'add', path: 'planet/2', value: {name: 'Mars'}}]);

--- a/test/tests/orbit-common/unit/jsonapi-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-source-test.js
@@ -542,7 +542,7 @@ test("#find - can find all records", function() {
   });
 });
 
-test("#find - can filter records", function() {
+test("#query - can filter records", function() {
   expect(14);
 
   var records = [
@@ -560,7 +560,7 @@ test("#find - can filter records", function() {
   });
 
   stop();
-  source.find('planet', {classification: 'terrestrial'}).then(function(planets) {
+  source.query('planet', {classification: 'terrestrial'}).then(function(planets) {
     start();
 
     var planet, record;

--- a/test/tests/orbit-common/unit/memory-source-test.js
+++ b/test/tests/orbit-common/unit/memory-source-test.js
@@ -319,7 +319,7 @@ test("#find - returns RecordNotFoundException when any record in an array can't 
   });
 });
 
-test("#find - can find records by one or more filters", function() {
+test("#query - can find records by one or more filters", function() {
   expect(5);
 
   equal(source.length('planet'), 0, 'source should be empty');
@@ -333,9 +333,9 @@ test("#find - can find records by one or more filters", function() {
   ]).then(function() {
     equal(source.length('planet'), 4, 'source should contain 4 records');
 
-    source.find('planet', {classification: 'terrestrial', atmosphere: true}).then(function(allPlanets) {
+    source.query('planet', {classification: 'terrestrial', atmosphere: true}).then(function(allPlanets) {
       start();
-      equal(allPlanets.length, 2, 'findRecord() should return all records');
+      equal(allPlanets.length, 2, 'query() should return all matching records');
       equal(allPlanets[0].name, 'Earth', 'first matching planet');
       equal(allPlanets[1].name, 'Venus', 'second matching planet');
       return allPlanets;
@@ -375,7 +375,6 @@ test("#find - secondary key searches always return single records", function() {
       equal(planet, jupiter, 'found jupiter');
     })
     .then(start, start);
-
 });
 
 test("#add - creates a record", function() {

--- a/test/tests/orbit-common/unit/memory-source-test.js
+++ b/test/tests/orbit-common/unit/memory-source-test.js
@@ -8,7 +8,7 @@ import { spread } from 'orbit/lib/functions';
 import { uuid } from 'orbit/lib/uuid';
 import 'tests/test-helper';
 
-var source;
+var schema, source;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -16,7 +16,7 @@ module("OC - MemorySource", {
   setup: function() {
     Orbit.Promise = Promise;
 
-    var schema = new Schema({
+    schema = new Schema({
       models: {
         planet: {
           attributes: {
@@ -46,6 +46,7 @@ module("OC - MemorySource", {
   },
 
   teardown: function() {
+    schema = null;
     source = null;
     Orbit.Promise = null;
   }
@@ -256,6 +257,36 @@ test("#find - can find all records", function() {
       equal(allPlanets.length, 3, 'find() should return all records');
       return allPlanets;
     });
+  });
+});
+
+test("#find - returns RecordNotFoundException when no records of a type have been added (using a default sparse cache)", function() {
+  expect(2);
+
+  equal(source.length('planet'), 0, 'source should be empty');
+
+  stop();
+  source.find('planet').then(function() {
+    ok(false, 'no planet should be found');
+  }, function(e) {
+    start();
+    ok(e instanceof RecordNotFoundException, 'RecordNotFoundException thrown');
+  });
+});
+
+test("#find - returns an empty array of records when none have been added (using a non-sparse cache)", function() {
+  expect(2);
+
+  source = new MemorySource(schema, {cacheOptions: {sparse: false}});
+
+  equal(source.length('planet'), 0, 'source should be empty');
+
+  stop();
+  source.find('planet').then(function(planets) {
+    start();
+    equal(planets.length, 0, 'an empty array of planets should be found');
+  }, function(e) {
+    ok(false, 'RecordNotFoundException should not be thrown');
   });
 });
 


### PR DESCRIPTION
This PR addresses a couple areas related to the `find` requestable method:

## Extract `query` from `find`

OC sources should now support `query` as a separate method from `find`. This simplifies the logic required to determine whether a request is a query or a request for a specific individual record or records. It also allows for separate requestable hooks for `find` vs. `query` (e.g. `rescueFind` vs `rescueQuery`).

## Remove support for `options` in find requests from memory and json-api sources

Options, such as `include`, were not tested in these sources and the implementations need re-evaluation.

For now, these sources will throw exceptions if you pass `options` into `find`, `query`, `findLink`, or `findLinked`.

Of course, options can still be passed into custom sources.

## Introduce `sparse` option for Cache

The concept of a "sparse" cache is introduced to indicate that a cache is an incomplete representation of data. Most caches will be sparse, except perhaps a local storage source which is treated as the definitive source of data for a browser-only app (i.e. not connected to other definitive sources).

Sparse caches will not automatically initialize top-level collections. As `find` request for a collection that isn't initialized will throw a RecordNotFoundException.