### PR TITLE
Fine tune `coalesceOperations`.

### DIFF
--- a/lib/orbit/lib/operations.js
+++ b/lib/orbit/lib/operations.js
@@ -1,13 +1,19 @@
 import { isObject, merge } from 'orbit/lib/objects';
-import Document from 'orbit/document';
 import { eq } from 'orbit/lib/eq';
+import Document from 'orbit/document';
 import Operation from 'orbit/operation';
 
-function _requiresMerge(superceded, superceding) {
-  return (
-    superceded.path.join("/").indexOf(superceding.path.join("/")) === 0 ||
-    superceding.path.join("/").indexOf(superceded.path.join("/")) === 0
+function _shouldMerge(supercededOp, supercedingOp, consecutiveOps) {
+  var pathsOverlap = (
+    supercededOp.path.join("/").indexOf(supercedingOp.path.join("/")) === 0 ||
+    supercedingOp.path.join("/").indexOf(supercededOp.path.join("/")) === 0
   );
+
+  // In order to allow merging of operations, their paths must overlap
+  // and the operations must either be consecutive or the superceding
+  // operation must only change a field (not a relationship).
+  return pathsOverlap &&
+         (consecutiveOps || _valueTypeForPath(supercedingOp.path) === 'field');
 }
 
 function _valueTypeForPath(path) {
@@ -157,7 +163,10 @@ function _merge(superceded, superceding) {
 }
 
 /**
- Coalesces operations into a minimal set of equivalent operations
+ Coalesces operations into a minimal set of equivalent operations.
+
+ This method respects the order of the operations array and does not allow
+ reordering of operations that affect relationships.
 
  @method coalesceOperations
  @for Orbit
@@ -165,23 +174,34 @@ function _merge(superceded, superceding) {
  @returns {Array}
  */
 function coalesceOperations(operations) {
-  var coalesced = [];
-  var superceding;
+  var coalescedOps = [];
+  var currentOp;
+  var nextOp;
+  var consecutiveOps;
 
-  operations.forEach(function(superceding) {
-    coalesced.slice(0).forEach(function(superceded) {
+  for (var i = 0, l = operations.length; i < l; i++) {
+    currentOp = operations[i];
 
-      if (_requiresMerge(superceded, superceding)) {
-        var index = coalesced.indexOf(superceded);
-        coalesced.splice(index, 1);
-        superceding = _merge(superceded, superceding);
+    if (currentOp) {
+      consecutiveOps = true;
+
+      for (var j = i + 1; j < l; j++) {
+        nextOp = operations[j];
+        if (nextOp) {
+          if (_shouldMerge(currentOp, nextOp, consecutiveOps)) {
+            currentOp = _merge(currentOp, nextOp);
+            operations[j] = undefined;
+          } else {
+            consecutiveOps = false;
+          }
+        }
       }
 
-    });
-    coalesced.push(superceding);
-  });
+      coalescedOps.push(currentOp);
+    }
+  }
 
-  return coalesced;
+  return coalescedOps;
 }
 
 function normalizeOperation(operation) {

--- a/test/tests/orbit/unit/lib/operations-test.js
+++ b/test/tests/orbit/unit/lib/operations-test.js
@@ -220,3 +220,22 @@ test("coalesceOperations - record link takes precedence over remove operation", 
     ]
   );
 });
+
+test("coalesceOperations - coalesces operations, but doesn't allow reordering of ops that affect relationships", function() {
+  shouldCoalesceOperations(
+    [
+      op('add', ['address', 'def789'], { id: 'def789' }),
+      op('replace', ['address', 'def789', 'street'], 'a'),
+      op('add', ['contact', '1234', '__rel', 'address', 'def789'], true),
+      op('add', ['address', 'def789', '__rel', 'contact'], '1234'),
+      op('replace', ['address', 'def789', 'street'], 'ab'),
+      op('replace', ['address', 'def789', 'street'], 'abc'),
+      op('replace', ['address', 'def789', 'street'], 'abcd')
+    ],
+    [
+      op('add', ['address', 'def789'], { id: 'def789', street: 'abcd' }),
+      op('add', ['contact', '1234', '__rel', 'address', 'def789'], true),
+      op('add', ['address', 'def789', '__rel', 'contact'], '1234')
+    ]
+  );
+});


### PR DESCRIPTION
This method now respects the order of the operations array and does not allow
reordering of operations that affect relationships.