### PR TITLE
Compile to CommonJS with support for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "broccoli-jshint": "^0.5.3",
     "broccoli-merge-trees": "^0.1.4",
     "broccoli-sourcemap-concat": "^0.4.3",
-    "broccoli-string-replace": "0.0.2",
+    "broccoli-string-replace": "^0.1.0",
     "git-repo-version": "^0.1.1",
     "testem": "^0.7.6",
     "yuidocjs": "^0.8.1",


### PR DESCRIPTION
Proof-of-concept:

```
# In your local copy of orbit
$ broccoli build build
$ cd build/npm
$ npm link

# In your node project folder
$ npm link orbit.js
```

```javascript
// This should now be possible from within your node project
var Orbit = require('orbit.js');
var OC = require('orbit.js/orbit-common');
```