### PR TITLE
[WIP] Introduce store.on(mutation) events

### DIFF
--- a/lib/orbit-common/store.js
+++ b/lib/orbit-common/store.js
@@ -14,7 +14,8 @@ import {
 } from 'orbit-common/oql/expressions';
 import MemorySource from 'orbit-common/memory-source';
 import {
-  toIdentifier
+  toIdentifier,
+  parseIdentifier
 } from 'orbit-common/lib/identifiers';
 
 export default MemorySource.extend({
@@ -59,28 +60,28 @@ export default MemorySource.extend({
     return this.transform(replaceRecordOperation(this.schema.normalize(record)));
   },
 
-  removeRecord(record) {
-    return this.transform(removeRecordOperation(record));
+  removeRecord(recordIdentifier) {
+    return this.transform(removeRecordOperation(parseIdentifier(recordIdentifier)));
   },
 
-  replaceAttribute(record, attribute, value) {
-    return this.transform(replaceAttributeOperation(record, attribute, value));
+  replaceAttribute(recordIdentifier, attribute, value) {
+    return this.transform(replaceAttributeOperation(parseIdentifier(recordIdentifier), attribute, value));
   },
 
-  addToHasMany(record, relationship, value) {
-    return this.transform(addToHasManyOperation(record, relationship, value));
+  addToHasMany(recordIdentifier, relationship, value) {
+    return this.transform(addToHasManyOperation(parseIdentifier(recordIdentifier), relationship, parseIdentifier(value)));
   },
 
-  removeFromHasMany(record, relationship, value) {
-    return this.transform(removeFromHasManyOperation(record, relationship, value));
+  removeFromHasMany(recordIdentifier, relationship, value) {
+    return this.transform(removeFromHasManyOperation(parseIdentifier(recordIdentifier), relationship, parseIdentifier(value)));
   },
 
-  replaceHasMany(record, relationship, value) {
-    return this.transform(replaceHasManyOperation(record, relationship, value));
+  replaceHasMany(recordIdentifier, relationship, value) {
+    return this.transform(replaceHasManyOperation(parseIdentifier(recordIdentifier), relationship, value.map(identifier => parseIdentifier(identifier))));
   },
 
-  replaceHasOne(record, relationship, value) {
-    return this.transform(replaceHasOneOperation(record, relationship, value));
+  replaceHasOne(recordIdentifier, relationship, value) {
+    return this.transform(replaceHasOneOperation(parseIdentifier(recordIdentifier), relationship, parseIdentifier(value)));
   },
 
   _emitOperation(operation) {
@@ -89,7 +90,7 @@ export default MemorySource.extend({
         return this._emit('addRecord', operation.value);
 
       case 'replaceRecord': // never called
-        return this._emit('replaceRecord', toIdentifier(operation.path[0], operation.path[1]), operation.value);
+        return this._emit('replaceRecord', operation.value);
 
       case 'removeRecord':
         return this._emit('removeRecord', toIdentifier(operation.path[0], operation.path[1]));

--- a/lib/orbit-common/store.js
+++ b/lib/orbit-common/store.js
@@ -6,14 +6,25 @@ import {
   addToHasManyOperation,
   removeFromHasManyOperation,
   replaceHasOneOperation,
-  replaceHasManyOperation
+  replaceHasManyOperation,
+  operationType
 } from 'orbit-common/lib/operations';
 import {
   queryExpression as oqe
 } from 'orbit-common/oql/expressions';
 import MemorySource from 'orbit-common/memory-source';
+import {
+  toIdentifier
+} from 'orbit-common/lib/identifiers';
 
 export default MemorySource.extend({
+
+  init(options) {
+    this._super.call(this, options);
+
+    this.cache.on('patch', operation => this._emitOperation(operation));
+  },
+
   /////////////////////////////////////////////////////////////////////////////
   // Query helpers
   /////////////////////////////////////////////////////////////////////////////
@@ -70,5 +81,40 @@ export default MemorySource.extend({
 
   replaceHasOne(record, relationship, value) {
     return this.transform(replaceHasOneOperation(record, relationship, value));
+  },
+
+  _emitOperation(operation) {
+    switch (operationType(operation)) {
+      case 'addRecord':
+        return this._emit('addRecord', operation.value);
+
+      case 'replaceRecord': // never called
+        return this._emit('replaceRecord', toIdentifier(operation.path[0], operation.path[1]), operation.value);
+
+      case 'removeRecord':
+        return this._emit('removeRecord', toIdentifier(operation.path[0], operation.path[1]));
+
+      case 'replaceAttribute':
+        return this._emit('replaceAttribute', operation.path[3], operation.value);
+
+      case 'addToHasMany':
+        return this._emit('addToHasMany', toIdentifier(operation.path[0], operation.path[1]), operation.path[3], operation.path[5]);
+
+      case 'removeFromHasMany': // never called
+        return this._emit('removeFromHasMany', toIdentifier(operation.path[0], operation.path[1]), operation.path[3], operation.path[5]);
+
+      case 'replaceHasMany':
+        return this._emit('replaceHasMany', toIdentifier(operation.path[0], operation.path[1]), operation.path[3], Object.keys(operation.value));
+
+      case 'replaceHasOne':
+        return this._emit('replaceHasOne', toIdentifier(operation.path[0], operation.path[1]), operation.path[3], operation.value);
+
+      default: console.log('ignored', operation);
+    }
+  },
+
+  _emit(...args) {
+    console.log('emitting', ...args);
+    this.emit(...args);
   }
 });

--- a/test/tests/orbit-common/unit/store-test.js
+++ b/test/tests/orbit-common/unit/store-test.js
@@ -194,7 +194,7 @@ test('#removeRecord - deleted record', function({ async }) {
     planet: { pluto }
   });
 
-  store.removeRecord(pluto)
+  store.removeRecord('planet:pluto')
     .then(function() {
       ok(didTransform.calledWith(transformMatching(removeRecordTransform)), 'operation has been emitted as a transform');
       ok(didRemoveRecord.calledWith('planet:pluto'));
@@ -217,7 +217,7 @@ test('#replaceAttribute', function({ async }) {
     planet: { pluto }
   });
 
-  store.replaceAttribute(pluto, 'name', 'pluto returns')
+  store.replaceAttribute('planet:pluto', 'name', 'pluto returns')
     .then(function() {
       ok(didTransform.calledWith(transformMatching(replaceAttributeTransform)), 'operation has been emitted as a transform');
       ok(didReplaceAttribute.calledWith('name', 'pluto returns'));
@@ -240,7 +240,7 @@ test('#addToHasMany', function({ async }) {
     moon: { io }
   });
 
-  store.addToHasMany(earth, 'moons', io)
+  store.addToHasMany('planet:earth', 'moons', 'moon:io')
     .then(function() {
       ok(didTransform.calledWith(transformMatching(addToHasManyTransform)), 'operation has been emitted as a transform');
       ok(didAddToHasMany.calledWith('planet:earth', 'moons', 'moon:io'));
@@ -267,7 +267,7 @@ test('#removeFromHasMany', function({ async }) {
     moon: { io }
   });
 
-  store.removeFromHasMany(earth, 'moons', io)
+  store.removeFromHasMany('planet:earth', 'moons', 'moon:io')
     .then(function() {
       ok(didTransform.calledWith(transformMatching(removeFromHasManyTransform)), 'operation has been emitted as a transform');
       ok(didRemoveFromHasMany.calledWith('planet:earth', 'moons', 'moon:io'), 'removed from hasMany');
@@ -299,7 +299,7 @@ test('#replaceHasMany', function({ async }) {
     moon: { io, titan }
   });
 
-  store.replaceHasMany(earth, 'moons', [titan])
+  store.replaceHasMany('planet:earth', 'moons', ['moon:titan'])
     .then(function() {
       ok(didTransform.calledWith(transformMatching(replaceHasManyTransform)), 'operation has been emitted as a transform');
 
@@ -335,7 +335,7 @@ test('#replaceHasOne', function({ async }) {
     moon: { io }
   });
 
-  store.replaceHasOne(io, 'planet', jupiter)
+  store.replaceHasOne('moon:io', 'planet', 'planet:jupiter')
     .then(function() {
       ok(didTransform.calledWith(transformMatching(replaceHasOneTransform)), 'operation has been emitted as a transform');
 


### PR DESCRIPTION
@dgeb thought I'd try out the idea we discussed on Friday regarding having the store emit events like store.on('addRecord'). 

A couple of observations:

#### store.mutate* don't necessarily result in store.on('mutation*')
When mutating the store the cache doesn't necessarily emit the corresponding patch, it will only emit the diff. This is expected, I'm not sure if that mismatch causes confusion in the store api though (but I think it's ok).

#### Operations contain less information than the arguments to store.mutate*
It wasn't possible to match `store.removeRecord(record)` with `on('removeRecord', record)` because the operation doesn't include the record value. This could be resolved by looking up the record but I went with `on('removeRecord', recordIndentifier)`. The same issue popped up again with the relationship operations, e.g. `store.addToHasMany(record, relationship, value)` and `on('addToHasMany', recordIdentifier, relationship, valueIdentifier)`. 

Following this I thought I'd try out refactoring the store api to use this consistently so this PR includes refactored store.mutate* methods that take identifiers in place of records. Just an experiment at this stage but worth considering I think. Something else to consider is that if we replaced identifiers with uuids (as discussed) then this would simplify things even further. 

It's also worth considering the ember-orbit store that would layered on top of the orbit store, an ember-orbit record != orbit record so there's a translation cost there, translating to/from identifiers where possible is probably going to be cheaper.