### PR TITLE
Subscriptions

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,8 @@
     "start",
     "stop",
     "QUnit",
-    "sinon"
+    "sinon",
+    "Rx"
   ],
   "node" : false,
   "browser" : false,

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -140,7 +140,8 @@ mainWithTests = concat(mainWithTests, {
 var vendor = concat('bower_components', {
   inputFiles: [
     'jquery/dist/jquery.js',
-    'rsvp/rsvp.js'],
+    'rsvp/rsvp.js',
+    'rxjs/dist/rx.all.js'],
   outputFile: '/assets/vendor.js'
 });
 

--- a/bower.json
+++ b/bower.json
@@ -7,5 +7,8 @@
     "qunit": "~1.20.0",
     "rsvp": "~3.0.16",
     "loader": "stefanpenner/loader.js#1.0.1"
+  },
+  "dependencies": {
+    "rxjs": "~4.0.7"
   }
 }

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -23,6 +23,10 @@ import {
   filterOperator
 } from './oql/operators';
 
+import SubscriptionOperators from './oql/subscription-operators';
+import { fromOrbitEvent } from './observable/adapters';
+
+
 /**
  `Cache` provides a thin wrapper over an internally maintained instance of a
  `Document`.
@@ -83,6 +87,14 @@ export default Class.extend(QueryProcessor, {
       this.schema.on('modelRegistered', this._registerModel, this);
     }
 
+    this._initOqlEvaluator();
+    this._initOqlSubscriptionEvaluator();
+
+    this.patches = new Rx.ReplaySubject();
+    fromOrbitEvent(this, 'patch').subscribe(this.patches);
+  },
+
+  _initOqlEvaluator() {
     this.queryEvaluator = new QueryEvaluator(this);
     this.queryEvaluator.register([
       andOperator,
@@ -97,8 +109,30 @@ export default Class.extend(QueryProcessor, {
     });
   },
 
+  _initOqlSubscriptionEvaluator() {
+    this.oqlSubscriptionEvaluator = new QueryEvaluator(this);
+    this.oqlSubscriptionEvaluator.register([
+      SubscriptionOperators.recordsOfType,
+      SubscriptionOperators.filter,
+      SubscriptionOperators.get,
+      andOperator,
+      orOperator,
+      equalOperator
+    ]);
+
+    this.registerQueryProcessor('oql:subscription', (query) => {
+      return this.oqlSubscriptionEvaluator.evaluate(query);
+    });
+  },
+
   query(exp) {
     return this.processQuery(exp);
+  },
+
+  subscribe(exp) {
+    return this.processQuery(exp, 'subscription').filter(operation => {
+      return ['add', 'remove'].indexOf(operation.op) !== -1;
+    });
   },
 
   reset(data) {

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -117,6 +117,7 @@ export default Class.extend(QueryProcessor, {
       SubscriptionOperators.get,
       SubscriptionOperators.record,
       SubscriptionOperators.relatedRecord,
+      SubscriptionOperators.relatedRecords,
       andOperator,
       orOperator,
       equalOperator

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -20,7 +20,9 @@ import {
   orOperator,
   equalOperator,
   getOperator,
-  filterOperator
+  filterOperator,
+  relatedRecordsOperator,
+  relatedRecordOperator
 } from './oql/operators';
 
 import SubscriptionOperators from './oql/subscription-operators';
@@ -95,14 +97,15 @@ export default Class.extend(QueryProcessor, {
   },
 
   _initOqlEvaluator() {
-    this.queryEvaluator = new QueryEvaluator(this);
-    this.queryEvaluator.register([
-      andOperator,
-      orOperator,
-      equalOperator,
-      getOperator,
-      filterOperator
-    ]);
+    this.queryEvaluator = new QueryEvaluator(this, {
+      'and': andOperator,
+      'or': orOperator,
+      'equal': equalOperator,
+      'get': getOperator,
+      'filter': filterOperator,
+      'relatedRecords': relatedRecordsOperator,
+      'relatedRecord': relatedRecordOperator
+    });
 
     this.registerQueryProcessor('oql', (query) => {
       return this.queryEvaluator.evaluate(query);
@@ -110,18 +113,19 @@ export default Class.extend(QueryProcessor, {
   },
 
   _initOqlSubscriptionEvaluator() {
-    this.oqlSubscriptionEvaluator = new QueryEvaluator(this);
-    this.oqlSubscriptionEvaluator.register([
-      SubscriptionOperators.recordsOfType,
-      SubscriptionOperators.filter,
-      SubscriptionOperators.get,
-      SubscriptionOperators.record,
-      SubscriptionOperators.relatedRecord,
-      SubscriptionOperators.relatedRecords,
-      andOperator,
-      orOperator,
-      equalOperator
-    ]);
+    this.oqlSubscriptionEvaluator = new QueryEvaluator(this, {
+      'recordsOfType': SubscriptionOperators.recordsOfType,
+      'filter': SubscriptionOperators.filter,
+      'get': SubscriptionOperators.get,
+      'record': SubscriptionOperators.record,
+      'relatedRecord': SubscriptionOperators.relatedRecord,
+      'relatedRecords': SubscriptionOperators.relatedRecords,
+      'query:relatedRecords': relatedRecordsOperator,
+      'query:relatedRecord': relatedRecordOperator,
+      'and': andOperator,
+      'or': orOperator,
+      'equal': equalOperator
+    });
 
     this.registerQueryProcessor('oql:subscription', (query) => {
       return this.oqlSubscriptionEvaluator.evaluate(query);

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -115,6 +115,7 @@ export default Class.extend(QueryProcessor, {
       SubscriptionOperators.recordsOfType,
       SubscriptionOperators.filter,
       SubscriptionOperators.get,
+      SubscriptionOperators.record,
       andOperator,
       orOperator,
       equalOperator

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -116,6 +116,7 @@ export default Class.extend(QueryProcessor, {
       SubscriptionOperators.filter,
       SubscriptionOperators.get,
       SubscriptionOperators.record,
+      SubscriptionOperators.relatedRecord,
       andOperator,
       orOperator,
       equalOperator

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -133,9 +133,7 @@ export default Class.extend(QueryProcessor, {
   },
 
   subscribe(exp) {
-    return this.processQuery(exp, 'subscription').filter(operation => {
-      return ['add', 'remove'].indexOf(operation.op) !== -1;
-    });
+    return this.processQuery(exp, 'subscription');
   },
 
   reset(data) {

--- a/lib/orbit-common/observable/adapters.js
+++ b/lib/orbit-common/observable/adapters.js
@@ -1,0 +1,9 @@
+function fromOrbitEvent(emitter, event) {
+  return Rx.Observable.create(observer => {
+    emitter.on(event, payload => {
+      observer.onNext(payload);
+    });
+  });
+}
+
+export { fromOrbitEvent };

--- a/lib/orbit-common/oql/evaluator.js
+++ b/lib/orbit-common/oql/evaluator.js
@@ -16,6 +16,9 @@ var QueryContext = Class.extend({
   evaluate(expression) {
     if (isQueryExpression(expression)) {
       let operator = this.evaluator.operators[expression.op];
+
+      if (!operator) { throw new Error('Unable to find operation: ' + expression.op); }
+
       return operator.evaluate(this, expression.args);
     } else {
       return expression;

--- a/lib/orbit-common/oql/evaluator.js
+++ b/lib/orbit-common/oql/evaluator.js
@@ -31,19 +31,9 @@ var QueryEvaluator = Class.extend({
 
   operators: null,
 
-  init(target) {
+  init(target, operators) {
     this.target = target;
-    this.operators = {};
-  },
-
-  register(operator) {
-    if (isArray(operator)) {
-      for (let op of operator) {
-        this.register(op);
-      }
-    } else {
-      this.operators[operator.op] = operator;
-    }
+    this.operators = operators;
   },
 
   evaluate(expression) {

--- a/lib/orbit-common/oql/operators.js
+++ b/lib/orbit-common/oql/operators.js
@@ -6,7 +6,6 @@ import {
 } from 'orbit/lib/paths';
 
 var andOperator = {
-  op: 'and',
   evaluate(context, args) {
     for (let arg of args) {
       if (!context.evaluate(arg)) {
@@ -18,7 +17,6 @@ var andOperator = {
 };
 
 var orOperator = {
-  op: 'or',
   evaluate(context, args) {
     for (let arg of args) {
       if (!!context.evaluate(arg)) { return true; }
@@ -28,7 +26,6 @@ var orOperator = {
 };
 
 var equalOperator = {
-  op: 'equal',
   evaluate(context, args) {
     let value;
     let valueSet = false;
@@ -47,7 +44,6 @@ var equalOperator = {
 };
 
 var getOperator = {
-  op: 'get',
   evaluate(context, args) {
     let path = splitPath(args[0]);
     if (context.basePath) {
@@ -58,7 +54,6 @@ var getOperator = {
 };
 
 var filterOperator = {
-  op: 'filter',
   evaluate(context, args) {
     const path = splitPath(args[0]);
     const where = args[1];
@@ -77,10 +72,40 @@ var filterOperator = {
   }
 };
 
+var relatedRecordsOperator = {
+  evaluate(context, [type, recordId, relationship]) {
+    const cache = context.evaluator.target;
+    const data = cache.get([type, recordId, 'relationships', relationship, 'data']);
+
+    const results = {};
+
+    Object.keys(data||{}).forEach(identifier => {
+      const [type, id] = identifier.split(':');
+      results[id] = cache.get([type, id]);
+    });
+
+    return results;
+  }
+};
+
+var relatedRecordOperator = {
+  evaluate(context, [type, recordId, relationship]) {
+    const cache = context.evaluator.target;
+    const data = cache.get([type, recordId, 'relationships', relationship, 'data']);
+
+    if (!data) { return null; }
+
+    const [relatedType, relatedRecordId] = data.split(':');
+    return { [relatedRecordId]: cache.get([relatedType, relatedRecordId]) };
+  }
+};
+
 export {
   andOperator,
   orOperator,
   equalOperator,
   getOperator,
-  filterOperator
+  filterOperator,
+  relatedRecordsOperator,
+  relatedRecordOperator
 };

--- a/lib/orbit-common/oql/subscription-operators.js
+++ b/lib/orbit-common/oql/subscription-operators.js
@@ -85,8 +85,18 @@ var get = {
   }
 };
 
+var record = {
+  op: 'record',
+  evaluate(context, [type, recordId]) {
+    return context.evaluator.target.patches.filter(operation => {
+      return operation.path[0] === type && operation.path[1] === recordId;
+    });
+  }
+};
+
 export default {
   recordsOfType,
+  record,
   filter,
   get
 };

--- a/lib/orbit-common/oql/subscription-operators.js
+++ b/lib/orbit-common/oql/subscription-operators.js
@@ -1,0 +1,92 @@
+import {
+  addRecordOperation,
+  removeRecordOperation
+} from 'orbit-common/lib/operations';
+
+function filterByOql(operations, context, cache, oqlExpression) {
+  return Rx.Observable.create(function (observer) {
+    const members = {};
+
+    function addRecord(record) {
+      members[record.id] = true;
+      observer.onNext(addRecordOperation(record));
+    }
+
+    function removeRecord(record) {
+      delete members[record.id];
+      observer.onNext(removeRecordOperation(record));
+    }
+
+    operations.subscribe(
+      operation => {
+        const [ type, recordId ] = operation.path;
+        const record = cache.get([type, recordId]);
+        const existingMember = !!members[recordId];
+
+        if (!record) {
+          if (existingMember) {
+            removeRecord({ type, id: recordId });
+          }
+        } else {
+          context.currentObject = record;
+          const matches = context.evaluate(oqlExpression);
+
+          if (matches && !existingMember) {
+            addRecord(record);
+          } else if (!matches && existingMember) {
+            removeRecord(record);
+          } else if (matches && existingMember) {
+            observer.onNext(operation);
+          } else if (!matches && !existingMember) {
+            return; // emit nothing
+          } else {
+            throw new Error('not handled');
+          }
+        }
+      },
+      error => {
+        observer.onError(error);
+      },
+      () => {
+        observer.onCompleted();
+      }
+    );
+  });
+}
+
+
+var recordsOfType = {
+  op: 'recordsOfType',
+  evaluate(context, [type]) {
+    return context.evaluator.target.patches.filter(operation => {
+      return operation.path[0] === type;
+    });
+  }
+};
+
+var filter = {
+  op: 'filter',
+  evaluate(context, [operationsExpression, filterExpression]) {
+    const cache = context.evaluator.target;
+    const operations = context.evaluate(operationsExpression);
+
+    return filterByOql(operations, context, cache, filterExpression);
+  }
+};
+
+var get = {
+  op: 'get',
+  evaluate(context, args) {
+    const path = args[0].split('/');
+
+    return path.reduce((currentObject, segment) => {
+      return currentObject && currentObject[segment];
+    }, context.currentObject);
+  }
+};
+
+export default {
+  recordsOfType,
+  filter,
+  get
+};

--- a/lib/orbit-common/oql/subscription-operators.js
+++ b/lib/orbit-common/oql/subscription-operators.js
@@ -1,6 +1,7 @@
 import {
   addRecordOperation,
-  removeRecordOperation
+  removeRecordOperation,
+  operationType
 } from 'orbit-common/lib/operations';
 import { eq } from 'orbit/lib/eq';
 import { parseIdentifier } from 'orbit-common/lib/identifiers';
@@ -113,9 +114,27 @@ var relatedRecord = {
   }
 };
 
+var relatedRecords = {
+  op: 'relatedRecords',
+  evaluate(context, [type, recordId, relationship]) {
+    return context.evaluator.target.patches
+      .filter(operation =>
+        eq(operation.path.slice(0, 4), [type, recordId, 'relationships', relationship])
+      )
+      .map(operation => {
+        switch (operationType(operation)) {
+          case 'addToHasMany': return addRecordOperation(parseIdentifier(operation.path[5]));
+          case 'removeFromHasMany': return removeRecordOperation(parseIdentifier(operation.path[5]));
+          default: throw new Error(`relatedRecords operator does not support: ${operationType(operation)}`);
+        }
+      });
+  }
+};
+
 export default {
   recordsOfType,
   relatedRecord,
+  relatedRecords,
   record,
   filter,
   get

--- a/lib/orbit-common/oql/subscription-operators.js
+++ b/lib/orbit-common/oql/subscription-operators.js
@@ -5,6 +5,10 @@ import {
 } from 'orbit-common/lib/operations';
 import { eq } from 'orbit/lib/eq';
 import { parseIdentifier } from 'orbit-common/lib/identifiers';
+import {
+  queryExpression as oqe
+} from 'orbit-common/oql/expressions';
+import { toIdentifier } from 'orbit-common/lib/identifiers';
 
 function filterByOql(operations, context, cache, oqlExpression) {
   return Rx.Observable.create(function (observer) {
@@ -59,7 +63,6 @@ function filterByOql(operations, context, cache, oqlExpression) {
 
 
 var recordsOfType = {
-  op: 'recordsOfType',
   evaluate(context, [type]) {
     return context.evaluator.target.patches.filter(operation => {
       return operation.path[0] === type;
@@ -68,7 +71,6 @@ var recordsOfType = {
 };
 
 var filter = {
-  op: 'filter',
   evaluate(context, [operationsExpression, filterExpression]) {
     const cache = context.evaluator.target;
     const operations = context.evaluate(operationsExpression);
@@ -78,7 +80,6 @@ var filter = {
 };
 
 var get = {
-  op: 'get',
   evaluate(context, args) {
     const path = args[0].split('/');
 
@@ -89,7 +90,6 @@ var get = {
 };
 
 var record = {
-  op: 'record',
   evaluate(context, [type, recordId]) {
     return context.evaluator.target.patches.filter(operation => {
       return operation.path[0] === type && operation.path[1] === recordId;
@@ -97,37 +97,93 @@ var record = {
   }
 };
 
-var relatedRecord = {
-  op: 'relatedRecord',
-  evaluate(context, [type, recordId, relationship]) {
-    return context.evaluator.target.patches
-      .filter(operation =>
-        eq(operation.path, [type, recordId, 'relationships', relationship, 'data'])
-      )
-      .scan((previous, operation) => {
-        if (!operation.value) { return removeRecordOperation(previous.value); }
+function extractRecordFromHasOne(value) {
+  if (!value) { return null; }
 
-        const identifier = parseIdentifier(operation.value);
-        const record = context.evaluator.target.get([identifier.type, identifier.id]);
-        return addRecordOperation(record);
-      }, null);
+  const id = Object.keys(value)[0];
+  return value[id];
+}
+
+var relatedRecord = {
+  evaluate(context, [type, recordId, relationship]) {
+    const patches = context.evaluator.target.patches;
+
+    const currentValue = context.evaluate(oqe('query:relatedRecord', type, recordId, relationship));
+    const initialMember = extractRecordFromHasOne(currentValue);
+    const initialOperation = initialMember ? addRecordOperation(initialMember) : Rx.Observable.empty();
+
+    const membershipChanges = patches
+      .filter(operation => {
+        return eq(operation.path, [type, recordId, 'relationships', relationship, 'data']);
+      })
+      .scan((previous, operation) => {
+        if (operation.value) {
+          const identifier = parseIdentifier(operation.value);
+          const record = context.evaluator.target.get([identifier.type, identifier.id]);
+          return addRecordOperation(record);
+        } else {
+          if (previous.value) { return removeRecordOperation(previous.value); }
+        }
+      }, initialOperation);
+
+    const currentMember = membershipChanges
+      .scan((member, operation) => operation.value, initialMember);
+
+    const memberUpdates = currentMember.flatMap(member => {
+      if (member) {
+        return context.evaluate(oqe('record', member.type, member.id));
+      } else {
+        return Rx.Observable.empty();
+      }
+    });
+
+    const membershipChangesWithoutInitialOperation = membershipChanges.filter(
+      operation => operation !== initialOperation
+    );
+
+    return Rx.Observable.concat(membershipChangesWithoutInitialOperation, memberUpdates);
   }
 };
 
 var relatedRecords = {
-  op: 'relatedRecords',
   evaluate(context, [type, recordId, relationship]) {
-    return context.evaluator.target.patches
+    const patches = context.evaluator.target.patches;
+    const initialMembersMap = context.evaluate(oqe('query:relatedRecords', type, recordId, relationship));
+    const initialMembers = Object.keys(initialMembersMap).map(id => initialMembersMap[id]).map(record => `${record.type}:${record.id}`);
+
+    const membershipChanges = patches
       .filter(operation =>
         eq(operation.path.slice(0, 4), [type, recordId, 'relationships', relationship])
       )
       .map(operation => {
+        const recordIdentifier = operation.path[5];
+        const record = context.evaluator.target.get(recordIdentifier.split(':'));
+
         switch (operationType(operation)) {
-          case 'addToHasMany': return addRecordOperation(parseIdentifier(operation.path[5]));
-          case 'removeFromHasMany': return removeRecordOperation(parseIdentifier(operation.path[5]));
+          case 'addToHasMany': return addRecordOperation(record);
+          case 'removeFromHasMany': return removeRecordOperation(record);
           default: throw new Error(`relatedRecords operator does not support: ${operationType(operation)}`);
         }
       });
+
+    const currentMembers = membershipChanges
+      .scan((members, change) => {
+        const identifier = toIdentifier(...change.path);
+
+        if (change.op === 'add') { members.push(identifier); }
+        if (change.op === 'remove') {
+          const condemenedIndex = members.indexOf(identifier);
+          if (condemenedIndex !== -1) { members.splice(condemenedIndex, 1); }
+        }
+
+        return members;
+      }, initialMembers);
+
+    const memberUpdates = currentMembers.flatMap(members => {
+      return members.map(member => context.evaluate(oqe('record', ...member.split(':'))));
+    }).concatAll();
+
+    return Rx.Observable.concat(membershipChanges, memberUpdates);
   }
 };
 

--- a/lib/orbit-common/oql/subscription-operators.js
+++ b/lib/orbit-common/oql/subscription-operators.js
@@ -2,6 +2,8 @@ import {
   addRecordOperation,
   removeRecordOperation
 } from 'orbit-common/lib/operations';
+import { eq } from 'orbit/lib/eq';
+import { parseIdentifier } from 'orbit-common/lib/identifiers';
 
 function filterByOql(operations, context, cache, oqlExpression) {
   return Rx.Observable.create(function (observer) {
@@ -94,8 +96,26 @@ var record = {
   }
 };
 
+var relatedRecord = {
+  op: 'relatedRecord',
+  evaluate(context, [type, recordId, relationship]) {
+    return context.evaluator.target.patches
+      .filter(operation =>
+        eq(operation.path, [type, recordId, 'relationships', relationship, 'data'])
+      )
+      .scan((previous, operation) => {
+        if (!operation.value) { return removeRecordOperation(previous.value); }
+
+        const identifier = parseIdentifier(operation.value);
+        const record = context.evaluator.target.get([identifier.type, identifier.id]);
+        return addRecordOperation(record);
+      }, null);
+  }
+};
+
 export default {
   recordsOfType,
+  relatedRecord,
   record,
   filter,
   get

--- a/lib/orbit/query-processor.js
+++ b/lib/orbit/query-processor.js
@@ -22,20 +22,15 @@ export default {
     }
   },
 
-  processQuery(query) {
-    let processor = this.processorForQuery(query);
-    if (processor) {
-      return processor.process(query[processor.type]);
-    } else {
-      throw new QueryProcessorNotFoundException(query);
-    }
-  },
-
-  processorForQuery(query) {
+  processQuery(query, variant) {
     for (let processor of this.queryProcessors) {
-      if (query[processor.type] !== undefined) {
-        return processor;
+      const [processorType, processorVariant] = processor.type.split(':');
+
+      if (variant === processorVariant && query[processorType] !== undefined) {
+        return processor.process(query[processorType]);
       }
     }
+
+    throw new QueryProcessorNotFoundException(query);
   }
 };

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -692,6 +692,52 @@ test('#query can perform a complex conditional `or` filter', function(assert) {
   );
 });
 
+test('#query - relatedRecords', function(assert) {
+  cache = new Cache(schema);
+
+  const jupiter = {
+    id: 'jupiter', type: 'planet',
+    attributes: { name: 'Jupiter' },
+    relationships: { moons: { data: { 'moon:callisto': true } } } };
+
+  const callisto = {
+    id: 'callisto', type: 'moon',
+    attributes: { name: 'Callisto' },
+    relationships: { planet: { data: 'planet:jupiter' } } };
+
+  cache.reset({ planet: { jupiter }, moon: { callisto } });
+
+  assert.deepEqual(
+    cache.query({ oql: oqe('relatedRecords', 'planet', 'jupiter', 'moons') }),
+    {
+      callisto
+    }
+  );
+});
+
+test('#query - relatedRecord', function(assert) {
+  cache = new Cache(schema);
+
+  const jupiter = {
+    id: 'jupiter', type: 'planet',
+    attributes: { name: 'Jupiter' },
+    relationships: { moons: { data: { 'moon:callisto': true } } } };
+
+  const callisto = {
+    id: 'callisto', type: 'moon',
+    attributes: { name: 'Callisto' },
+    relationships: { planet: { data: 'planet:jupiter' } } };
+
+  cache.reset({ planet: { jupiter }, moon: { callisto } });
+
+  assert.deepEqual(
+    cache.query({ oql: oqe('relatedRecord', 'moon', 'callisto', 'planet') }),
+    {
+      jupiter
+    }
+  );
+});
+
 test('#rollback', function(assert) {
   const addRecordAOp = addRecordOperation({ id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } });
   const addRecordBOp = addRecordOperation({ id: 'saturn', type: 'planet', attributes: { name: 'Saturn' } });

--- a/test/tests/orbit-common/unit/cache/subscriptions-test.js
+++ b/test/tests/orbit-common/unit/cache/subscriptions-test.js
@@ -161,5 +161,28 @@ module('OC - Cache - subscriptions', function(hooks) {
     cache.transform(new Transform(removePluto));
     cache.patches.onCompleted();
   });
+
+  test('record - responds to record added/removed', function(assert) {
+    const done = assert.async();
+    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+    const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
+
+    const query = { oql: oqe('record', 'planet', 'pluto') };
+
+    const eventRecorder = new EventRecorder('recordAdded', 'recordRemoved');
+    const subscription = cache.subscribe(query, { listeners: eventRecorder });
+
+    eventRecorder.take(2).then(events => {
+      deepEqual(events, [
+        { type: 'recordAdded', value: 'pluto' },
+        { type: 'recordRemoved', value: 'pluto' }
+      ]);
+
+      done();
+    });
+
+    cache.transform(new Transform(addPluto));
+    cache.transform(new Transform(removePluto));
+  });
 });
 

--- a/test/tests/orbit-common/unit/cache/subscriptions-test.js
+++ b/test/tests/orbit-common/unit/cache/subscriptions-test.js
@@ -13,39 +13,59 @@ import {
   queryExpression as oqe
 } from 'orbit-common/oql/expressions';
 
+const { skip } = QUnit;
 
 module('OC - Cache - subscriptions', function(hooks) {
   let cache;
+  let pluto;
+  let jupiter;
+  let callisto;
+  let saturn;
+  let titan;
 
   hooks.beforeEach(function() {
+    pluto = planetsSchema.normalize({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+
+    jupiter = planetsSchema.normalize({ type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } });
+    callisto = planetsSchema.normalize({ type: 'moon', id: 'callisto', attributes: { name: 'Callisto' } });
+
+    saturn = planetsSchema.normalize({
+      type: 'planet', id: 'saturn',
+      attributes: { name: 'Saturn' },
+      relationships: { moons: { data: { 'moon:titan': true } } } });
+
+    titan = planetsSchema.normalize({
+      type: 'moon', id: 'titan',
+      attributes: { name: 'Titan' },
+      relationships: { planet: { data: 'planet:saturn' } } });
+
     cache = new Cache(planetsSchema);
   });
 
   test('recordsOfType', function(assert) {
     const done = assert.async();
-    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
-    const addJupiter = addRecordOperation({ type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } });
-    const addCallisto = addRecordOperation({ type: 'moon', id: 'callisto', attributes: { name: 'Callisto' } });
 
-    cache.transform(new Transform(addPluto));
-    cache.transform(new Transform(addJupiter));
+    cache.transform(new Transform(addRecordOperation(pluto)));
+    cache.transform(new Transform(addRecordOperation(jupiter)));
     cache.patches.onCompleted();
 
     const subscription = cache.subscribe({ oql: oqe('recordsOfType', 'planet') });
 
     subscription.toArray().subscribe((operations) => {
-      equalOps(operations, [addPluto, addJupiter]);
+      equalOps(operations, [
+        addRecordOperation(pluto),
+        addRecordOperation(jupiter)
+      ]);
+
       done();
     });
   });
 
   test('filter - add new match', function(assert) {
     const done = assert.async();
-    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
-    const addJupiter = addRecordOperation({ type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } });
 
-    cache.transform(new Transform(addPluto));
-    cache.transform(new Transform(addJupiter));
+    cache.transform(new Transform(addRecordOperation(pluto)));
+    cache.transform(new Transform(addRecordOperation(jupiter)));
     cache.patches.onCompleted();
 
     const subscription = cache.subscribe({
@@ -55,15 +75,13 @@ module('OC - Cache - subscriptions', function(hooks) {
           oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
 
     subscription.toArray().subscribe((operations) => {
-      equalOps(operations, [addPluto]);
+      equalOps(operations, [addRecordOperation(pluto)]);
       done();
     });
   });
 
   test('filter - remove match', function(assert) {
     const done = assert.async();
-    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
-    const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
 
     const subscription = cache.subscribe({
       oql:
@@ -72,19 +90,20 @@ module('OC - Cache - subscriptions', function(hooks) {
           oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
 
     subscription.toArray().subscribe(operations => {
-      equalOps(operations, [addPluto, removePluto]);
+      equalOps(operations, [
+        addRecordOperation(pluto),
+        removeRecordOperation(pluto)
+      ]);
       done();
     });
 
-    cache.transform(new Transform(addPluto));
-    cache.transform(new Transform(removePluto));
+    cache.transform(new Transform(addRecordOperation(pluto)));
+    cache.transform(new Transform(removeRecordOperation(pluto)));
     cache.patches.onCompleted();
   });
 
   test('filter - remove then add match', function(assert) {
     const done = assert.async();
-    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
-    const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
 
     const subscription = cache.subscribe({
       oql:
@@ -92,20 +111,18 @@ module('OC - Cache - subscriptions', function(hooks) {
           oqe('recordsOfType', 'planet'),
           oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
 
-    cache.transform(new Transform(removePluto));
-    cache.transform(new Transform(addPluto));
+    cache.transform(new Transform(removeRecordOperation(pluto)));
+    cache.transform(new Transform(addRecordOperation(pluto)));
     cache.patches.onCompleted();
 
     subscription.take(2).toArray().subscribe((operations) => {
-      equalOps(operations, [addPluto]);
+      equalOps(operations, [addRecordOperation(pluto)]);
       done();
     });
   });
 
   test('filter - change attribute that causes removal from matches', function(assert) {
     const done = assert.async();
-    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
-    const renamePluto = replaceAttributeOperation({ type: 'planet', id: 'pluto' }, 'name', 'Jupiter');
 
     const subscription = cache.subscribe({
       oql:
@@ -118,36 +135,32 @@ module('OC - Cache - subscriptions', function(hooks) {
       done();
     });
 
-    cache.transform(new Transform(addPluto));
-    cache.transform(new Transform(renamePluto));
+    cache.transform(new Transform(addRecordOperation(pluto)));
+    cache.transform(new Transform(replaceAttributeOperation({ type: 'planet', id: 'pluto' }, 'name', 'Jupiter')));
     cache.patches.onCompleted();
   });
 
   test('filter - change attribute that causes add to matches', function(assert) {
     const done = assert.async();
-    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
-    const renamePluto = replaceAttributeOperation({ type: 'planet', id: 'pluto' }, 'name', 'Jupiter');
 
     const subscription = cache.subscribe({
       oql:
         oqe('filter',
           oqe('recordsOfType', 'planet'),
-          oqe('equal', oqe('get', 'attributes/name'), 'Jupiter')) });
+          oqe('equal', oqe('get', 'attributes/name'), 'Uranus2')) });
 
     subscription.subscribe(operation => {
-      equalOps(operation, addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Jupiter' } }));
+      equalOps(operation, addRecordOperation({ type: 'planet', id: 'uranus', attributes: { name: 'Uranus2' } }));
       done();
     });
 
-    cache.transform(new Transform(addPluto));
-    cache.transform(new Transform(renamePluto));
+    cache.transform(new Transform(addRecordOperation({ type: 'planet', id: 'uranus', attributes: { name: 'Uranus' } })));
+    cache.transform(new Transform(replaceAttributeOperation({ type: 'planet', id: 'uranus' }, 'name', 'Uranus2')));
     cache.patches.onCompleted();
   });
 
   test('filter - ignores remove record that isn\'t included in matches', function(assert) {
     const done = assert.async();
-    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
-    const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
 
     const subscription = cache.subscribe({
       oql:
@@ -160,81 +173,210 @@ module('OC - Cache - subscriptions', function(hooks) {
       done();
     });
 
-    cache.transform(new Transform(addPluto));
-    cache.transform(new Transform(removePluto));
+    cache.transform(new Transform(addRecordOperation(pluto)));
+    cache.transform(new Transform(removeRecordOperation(pluto)));
     cache.patches.onCompleted();
   });
 
   test('record - responds to record added/removed', function(assert) {
     const done = assert.async();
-    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
-    const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
 
     const subscription = cache.subscribe({ oql: oqe('record', 'planet', 'pluto') });
 
     subscription.toArray().subscribe(operations => {
-      equalOps(operations, [addPluto, removePluto]);
+      equalOps(operations, [
+        addRecordOperation(pluto),
+        removeRecordOperation(pluto)
+      ]);
+
       done();
     });
 
-    cache.transform(new Transform(addPluto));
-    cache.transform(new Transform(removePluto));
+    cache.transform(new Transform(addRecordOperation(pluto)));
+    cache.transform(new Transform(removeRecordOperation(pluto)));
     cache.patches.onCompleted();
   });
 
-  test('relatedRecord - responds to replace hasOne', function(assert) {
-    const done = assert.async();
-    const addJupiter = addRecordOperation({ type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } });
-    const addCallisto = addRecordOperation({ type: 'planet', id: 'callisto', attributes: { name: 'Callisto' } });
-    const addJupiterToCallisto = replaceHasOneOperation({ type: 'moon', id: 'callisto' }, 'planet', { type: 'planet', id: 'jupiter' });
-    const removeJupiterFromCallisto = replaceHasOneOperation({ type: 'moon', id: 'callisto' }, 'planet', null);
+  module('relatedRecord', function() {
+    test('adds and removes record from subscription', function(assert) {
+      const done = assert.async();
 
-    const query = {
-      oql: oqe('relatedRecord', 'moon', 'callisto', 'planet') };
+      cache.reset({ planet: { jupiter }, moon: { callisto } });
 
-    const eventRecorder = new EventRecorder('recordAdded', 'recordRemoved');
-    const subscription = cache.subscribe(query, { listeners: eventRecorder });
+      const subscription = cache.subscribe({
+        oql:
+          oqe('relatedRecord', 'moon', 'callisto', 'planet') });
 
-    eventRecorder.take(2).then(events => {
-      deepEqual(events, [
-        { type: 'recordAdded', value: 'jupiter' },
-        { type: 'recordRemoved', value: 'jupiter' }
-      ]);
+      subscription.toArray().subscribe(operations => {
+        equalOps(operations, [
+          addRecordOperation(jupiter),
+          removeRecordOperation(jupiter)
+        ]);
 
-      done();
+        done();
+      });
+
+      cache.transform(new Transform(replaceHasOneOperation(callisto, 'planet', jupiter)));
+      cache.transform(new Transform(replaceHasOneOperation(callisto, 'planet', null)));
+      cache.patches.onCompleted();
     });
 
-    cache.transform(new Transform(addJupiter));
-    cache.transform(new Transform(addCallisto));
-    cache.transform(new Transform(addJupiterToCallisto));
-    cache.transform(new Transform(removeJupiterFromCallisto));
+    test('emits updates for record after it\'s added to subscription', function(assert) {
+      const done = assert.async();
+
+      cache.reset({ planet: { jupiter }, moon: { callisto } });
+
+      const subscription = cache.subscribe({
+        oql:
+          oqe('relatedRecord', 'moon', 'callisto', 'planet') });
+
+      subscription.toArray().subscribe(operations => {
+        equalOps(operations, [
+          addRecordOperation(jupiter),
+          replaceAttributeOperation(jupiter, 'name', 'Jupiter2')
+        ]);
+
+        done();
+      });
+
+      cache.transform(new Transform(replaceHasOneOperation(callisto, 'planet', jupiter)));
+      cache.transform(new Transform(replaceAttributeOperation(jupiter, 'name', 'Jupiter2')));
+      cache.patches.onCompleted();
+    });
+
+    test('emits updates for initial record', function(assert) {
+      const done = assert.async();
+
+      cache.reset({ planet: { saturn }, moon: { titan } });
+
+      const subscription = cache.subscribe({
+        oql:
+          oqe('relatedRecord', 'moon', 'titan', 'planet') });
+
+      subscription.toArray().subscribe(operations => {
+        equalOps(operations, [
+          replaceAttributeOperation(saturn, 'name', 'Saturn2')
+        ]);
+
+        done();
+      });
+
+      cache.transform(new Transform(replaceAttributeOperation(saturn, 'name', 'Saturn2')));
+      cache.patches.onCompleted();
+    });
+
+    test('stops emitting updates for related record once it\'s been removed', function(assert) {
+      const done = assert.async();
+
+      cache.reset({ planet: { saturn }, moon: { titan } });
+
+      const subscription = cache.subscribe({
+        oql:
+          oqe('relatedRecord', 'moon', 'titan', 'planet') });
+
+      subscription.toArray().subscribe(operations => {
+        equalOps(operations, [
+          removeRecordOperation(saturn)
+        ]);
+
+        done();
+      });
+
+      cache.transform(new Transform(replaceHasOneOperation(titan, 'planet', null)));
+      cache.transform(new Transform(replaceAttributeOperation(saturn, 'name', 'Saturn2')));
+      cache.patches.onCompleted();
+    });
   });
 
-  test('relatedRecords - responds to add record', function(assert) {
-    const done = assert.async();
-    const addJupiter = addRecordOperation({ type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } });
-    const addCallisto = addRecordOperation({ type: 'planet', id: 'callisto', attributes: { name: 'Callisto' } });
-    const addCallistoToJupiter = addToHasManyOperation({ type: 'planet', id: 'jupiter' }, 'moons', { type: 'moon', id: 'callisto' });
-    const removeCallistoFromJupiter = removeFromHasManyOperation({ type: 'planet', id: 'jupiter' }, 'moons', { type: 'moon', id: 'callisto' });
+  module('relatedRecords', function() {
+    test('adds and removes records from subscription', function(assert) {
+      const done = assert.async();
 
-    const query = { oql: oqe('relatedRecords', 'planet', 'jupiter', 'moons') };
+      cache.reset({ planet: { jupiter }, moon: { callisto } });
 
-    const eventRecorder = new EventRecorder('recordAdded', 'recordRemoved');
-    const subscription = cache.subscribe(query, { listeners: eventRecorder });
+      const subscription = cache.subscribe({
+        oql:
+          oqe('relatedRecords', 'planet', 'jupiter', 'moons') });
 
-    eventRecorder.take(2).then(events => {
-      deepEqual(events, [
-        { type: 'recordAdded', value: 'callisto' },
-        { type: 'recordRemoved', value: 'callisto' }
-      ]);
+      subscription.toArray().subscribe(operations => {
+        equalOps(operations, [
+          addRecordOperation(callisto),
+          removeRecordOperation(callisto)
+        ]);
 
-      done();
+        done();
+      });
+
+      cache.transform(new Transform(addToHasManyOperation(jupiter, 'moons', callisto)));
+      cache.transform(new Transform(removeFromHasManyOperation(jupiter, 'moons', callisto)));
+      cache.patches.onCompleted();
     });
 
-    cache.transform(new Transform(addJupiter));
-    cache.transform(new Transform(addCallisto));
-    cache.transform(new Transform(addCallistoToJupiter));
-    cache.transform(new Transform(removeCallistoFromJupiter));
+    test('emits updates to records included in subscription', function(assert) {
+      const done = assert.async();
+
+      cache.reset({ planet: { jupiter }, moon: { callisto } });
+
+      const subscription = cache.subscribe({
+        oql:
+          oqe('relatedRecords', 'planet', 'jupiter', 'moons') });
+
+      subscription.toArray().subscribe(operations => {
+        equalOps(operations, [
+          addRecordOperation(callisto),
+          replaceAttributeOperation(callisto, 'name', 'Callisto2')
+        ]);
+
+        done();
+      });
+
+      cache.transform(new Transform(addToHasManyOperation(jupiter, 'moons', callisto)));
+      cache.transform(new Transform(replaceAttributeOperation(callisto, 'name', 'Callisto2')));
+      cache.patches.onCompleted();
+    });
+
+    test('emits updates to records included in subscription with initial values', function(assert) {
+      const done = assert.async();
+
+      cache.reset({ planet: { saturn }, moon: { titan } });
+
+      const subscription = cache.subscribe({
+        oql:
+          oqe('relatedRecords', 'planet', 'saturn', 'moons') });
+
+      subscription.toArray().subscribe(operations => {
+        equalOps(operations, [
+          replaceAttributeOperation(titan, 'name', 'Titan2')
+        ]);
+
+        done();
+      });
+
+      cache.transform(new Transform(replaceAttributeOperation(titan, 'name', 'Titan2')));
+      cache.patches.onCompleted();
+    });
+
+    test('stops emits updates to records that have been removed from subscription', function(assert) {
+      const done = assert.async();
+
+      cache.reset({ planet: { saturn }, moon: { titan } });
+
+      const subscription = cache.subscribe({
+        oql:
+          oqe('relatedRecords', 'planet', 'saturn', 'moons') });
+
+      subscription.toArray().subscribe(operations => {
+        equalOps(operations, [
+          removeRecordOperation(titan)
+        ]);
+
+        done();
+      });
+
+      cache.transform(new Transform(removeFromHasManyOperation(saturn, 'moons', titan)));
+      cache.transform(new Transform(replaceAttributeOperation(titan, 'name', 'Titan2')));
+      cache.patches.onCompleted();
+    });
   });
 });
 

--- a/test/tests/orbit-common/unit/cache/subscriptions-test.js
+++ b/test/tests/orbit-common/unit/cache/subscriptions-test.js
@@ -170,22 +170,16 @@ module('OC - Cache - subscriptions', function(hooks) {
     const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
     const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
 
-    const query = { oql: oqe('record', 'planet', 'pluto') };
+    const subscription = cache.subscribe({ oql: oqe('record', 'planet', 'pluto') });
 
-    const eventRecorder = new EventRecorder('recordAdded', 'recordRemoved');
-    const subscription = cache.subscribe(query, { listeners: eventRecorder });
-
-    eventRecorder.take(2).then(events => {
-      deepEqual(events, [
-        { type: 'recordAdded', value: 'pluto' },
-        { type: 'recordRemoved', value: 'pluto' }
-      ]);
-
+    subscription.toArray().subscribe(operations => {
+      equalOps(operations, [addPluto, removePluto]);
       done();
     });
 
     cache.transform(new Transform(addPluto));
     cache.transform(new Transform(removePluto));
+    cache.patches.onCompleted();
   });
 
   test('relatedRecord - responds to replace hasOne', function(assert) {

--- a/test/tests/orbit-common/unit/cache/subscriptions-test.js
+++ b/test/tests/orbit-common/unit/cache/subscriptions-test.js
@@ -1,0 +1,165 @@
+import { planetsSchema, equalOps } from 'tests/test-helper';
+import Transform from 'orbit/transform';
+import {
+  addRecordOperation,
+  removeRecordOperation,
+  replaceAttributeOperation
+} from 'orbit-common/lib/operations';
+import Cache from 'orbit-common/cache';
+import {
+  queryExpression as oqe
+} from 'orbit-common/oql/expressions';
+
+
+module('OC - Cache - subscriptions', function(hooks) {
+  let cache;
+
+  hooks.beforeEach(function() {
+    cache = new Cache(planetsSchema);
+  });
+
+  test('recordsOfType', function(assert) {
+    const done = assert.async();
+    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+    const addJupiter = addRecordOperation({ type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } });
+    const addCallisto = addRecordOperation({ type: 'moon', id: 'callisto', attributes: { name: 'Callisto' } });
+
+    cache.transform(new Transform(addPluto));
+    cache.transform(new Transform(addJupiter));
+    cache.patches.onCompleted();
+
+    const subscription = cache.subscribe({ oql: oqe('recordsOfType', 'planet') });
+
+    subscription.toArray().subscribe((operations) => {
+      equalOps(operations, [addPluto, addJupiter]);
+      done();
+    });
+  });
+
+  test('filter - add new match', function(assert) {
+    const done = assert.async();
+    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+    const addJupiter = addRecordOperation({ type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } });
+
+    cache.transform(new Transform(addPluto));
+    cache.transform(new Transform(addJupiter));
+    cache.patches.onCompleted();
+
+    const subscription = cache.subscribe({
+      oql:
+        oqe('filter',
+          oqe('recordsOfType', 'planet'),
+          oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
+
+    subscription.toArray().subscribe((operations) => {
+      equalOps(operations, [addPluto]);
+      done();
+    });
+  });
+
+  test('filter - remove match', function(assert) {
+    const done = assert.async();
+    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+    const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
+
+    const subscription = cache.subscribe({
+      oql:
+        oqe('filter',
+          oqe('recordsOfType', 'planet'),
+          oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
+
+    subscription.toArray().subscribe(operations => {
+      equalOps(operations, [addPluto, removePluto]);
+      done();
+    });
+
+    cache.transform(new Transform(addPluto));
+    cache.transform(new Transform(removePluto));
+    cache.patches.onCompleted();
+  });
+
+  test('filter - remove then add match', function(assert) {
+    const done = assert.async();
+    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+    const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
+
+    const subscription = cache.subscribe({
+      oql:
+        oqe('filter',
+          oqe('recordsOfType', 'planet'),
+          oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
+
+    cache.transform(new Transform(removePluto));
+    cache.transform(new Transform(addPluto));
+    cache.patches.onCompleted();
+
+    subscription.take(2).toArray().subscribe((operations) => {
+      equalOps(operations, [addPluto]);
+      done();
+    });
+  });
+
+  test('filter - change attribute that causes removal from matches', function(assert) {
+    const done = assert.async();
+    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+    const renamePluto = replaceAttributeOperation({ type: 'planet', id: 'pluto' }, 'name', 'Jupiter');
+
+    const subscription = cache.subscribe({
+      oql:
+        oqe('filter',
+          oqe('recordsOfType', 'planet'),
+          oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
+
+    subscription.take(2).toArray().subscribe(operations => {
+      equalOps(operations[1], removeRecordOperation({ type: 'planet', id: 'pluto' }));
+      done();
+    });
+
+    cache.transform(new Transform(addPluto));
+    cache.transform(new Transform(renamePluto));
+    cache.patches.onCompleted();
+  });
+
+  test('filter - change attribute that causes add to matches', function(assert) {
+    const done = assert.async();
+    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+    const renamePluto = replaceAttributeOperation({ type: 'planet', id: 'pluto' }, 'name', 'Jupiter');
+
+    const subscription = cache.subscribe({
+      oql:
+        oqe('filter',
+          oqe('recordsOfType', 'planet'),
+          oqe('equal', oqe('get', 'attributes/name'), 'Jupiter')) });
+
+    subscription.subscribe(operation => {
+      equalOps(operation, addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Jupiter' } }));
+      done();
+    });
+
+    cache.transform(new Transform(addPluto));
+    cache.transform(new Transform(renamePluto));
+    cache.patches.onCompleted();
+  });
+
+  test('filter - ignores remove record that isn\'t included in matches', function(assert) {
+    const done = assert.async();
+    const addPluto = addRecordOperation({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto' } });
+    const removePluto = removeRecordOperation({ type: 'planet', id: 'pluto' });
+
+    const subscription = cache.subscribe({
+      oql:
+        oqe('filter',
+          oqe('recordsOfType', 'planet'),
+          oqe('equal', oqe('get', 'attributes/name'), 'Jupiter')) });
+
+    subscription.toArray().subscribe(operations => {
+      equal(operations.length, 0);
+      done();
+    });
+
+    cache.transform(new Transform(addPluto));
+    cache.transform(new Transform(removePluto));
+    cache.patches.onCompleted();
+  });
+});
+

--- a/test/tests/support/orbit-setup.js
+++ b/test/tests/support/orbit-setup.js
@@ -1,0 +1,4 @@
+import Orbit from 'orbit/main';
+import { Promise } from 'rsvp';
+
+Orbit.Promise = Promise;

--- a/test/tests/support/schemas.js
+++ b/test/tests/support/schemas.js
@@ -1,0 +1,18 @@
+import Schema from 'orbit-common/schema';
+
+const planetsSchema = new Schema({
+  models: {
+    planet: {
+      relationships: {
+        moons: { type: 'hasMany', model: 'moon' }
+      }
+    },
+    moon: {
+      relationships: {
+        planet: { type: 'hasOne', model: 'planet' }
+      }
+    }
+  }
+});
+
+export { planetsSchema };

--- a/test/tests/support/schemas.js
+++ b/test/tests/support/schemas.js
@@ -1,6 +1,6 @@
 import Schema from 'orbit-common/schema';
 
-const planetsSchema = new Schema({
+var planetsSchema = new Schema({
   models: {
     planet: {
       relationships: {

--- a/test/tests/test-helper.js
+++ b/test/tests/test-helper.js
@@ -1,3 +1,4 @@
+import './support/orbit-setup';
 import { on } from 'rsvp';
 
 on('error', function(reason) {
@@ -22,7 +23,10 @@ import {
   verifyLocalStorageContainsRecord
 } from './support/local-storage';
 
+import { planetsSchema } from './support/schemas';
+
 import './support/rsvp';
+
 
 export {
   serializeOps,
@@ -33,5 +37,6 @@ export {
   equalOps,
   transformMatching,
   verifyLocalStorageIsEmpty,
-  verifyLocalStorageContainsRecord
+  verifyLocalStorageContainsRecord,
+  planetsSchema
 };


### PR DESCRIPTION
#### Remaining
* [ ] switch to hybrid oql strategy
* [x] resolve replace hasOne issue - introduce `recordReplaced`?
* [x] how to handle replace hasMany? what should a subscription emit? perhaps `recordsReplaced`?

#### Depends on
* [x] Add `relatedRecord` and `relatedRecords` static query operators