### PR TITLE
Use firefox v43 to run travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: node_js
 
+addons:
+  firefox: "43.0"
+
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
@dgeb this is enough to get travis running the tests again. The only remaining issue is that testem currently includes it's [own copy of qunit](https://github.com/testem/testem/blob/v0.9.11/public/testem/qunit.js). It's locked at 1.17 for now which means that none of the nested modules are run. There's a release candidate for 1.0 though which has qunit 1.20 configured so it might be worth waiting for that. Otherwise we can create a custom testem runner page.