### PR TITLE
Upgrade testem - includes qunit 1.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "broccoli-sourcemap-concat": "^0.4.3",
     "broccoli-string-replace": "0.0.2",
     "git-repo-version": "^0.1.1",
-    "testem": "^0.7.6",
+    "testem": "^1.0.0-rc.1",
     "yuidocjs": "^0.8.1"
   }
 }


### PR DESCRIPTION
Temporary fix for https://github.com/orbitjs/orbit.js/issues/234

This includes the qunit upgrade that's in testem master. @dgeb seems fine for now, we can leave the issue open as a reminder to upgrade to the full release when it's available.