### PR TITLE
Assign record.id from record.keys.id if missing

### DIFF
--- a/lib/orbit-common/schema.js
+++ b/lib/orbit-common/schema.js
@@ -439,6 +439,8 @@ var Schema = Class.extend({
       }
     }
 
+    if (record.id === undefined) { record.id = record.keys.id; }
+
     // init default attribute values
     if (modelSchema.attributes) {
       if (record.attributes === undefined) { record.attributes = {}; }


### PR DESCRIPTION
I think this was caused because secondary keys are no longer kept in the record's root (they're under `keys` now). @dgeb this fix works but you may have thoughts on a better way to do it.