### PR TITLE
Introduce record set operations

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -11,7 +11,12 @@ import TransformLog from 'orbit/transform-log';
 import { diffs } from 'orbit/lib/diffs';
 import QueryProcessor from 'orbit/query-processor';
 import { normalizeOperations } from 'orbit/lib/operations';
-import { coalesceOperations } from 'orbit-common/lib/operations';
+import {
+  coalesceOperations,
+  operationType,
+  addRecordToSetOperation,
+  removeRecordFromSetOperation
+} from 'orbit-common/lib/operations';
 import {
   QueryEvaluator
 } from './oql/evaluator';
@@ -24,6 +29,7 @@ import {
   relatedRecordsOperator,
   relatedRecordOperator
 } from './oql/operators';
+import { toIdentifier } from 'orbit-common/lib/identifiers';
 
 import LiveQueryOperators from './oql/live-query-operators';
 import { fromOrbitEvent } from './observable/adapters';
@@ -137,7 +143,18 @@ export default Class.extend(QueryProcessor, {
   },
 
   liveQuery(exp) {
-    return this.processQuery(exp, 'liveQuery');
+    return this
+      .processQuery(exp, 'liveQuery')
+      .map(operation => {
+        switch (operationType(operation)) {
+          case 'addRecord': {
+            return addRecordToSetOperation(operation.value);
+          }
+          case 'removeRecord': {
+            return removeRecordFromSetOperation(toIdentifier(...operation.path));
+          }
+        }
+      });
   },
 
   reset(data) {

--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -151,7 +151,8 @@ export default Class.extend(QueryProcessor, {
             return addRecordToSetOperation(operation.value);
           }
           case 'removeRecord': {
-            return removeRecordFromSetOperation(toIdentifier(...operation.path));
+            const identifier = { type: operation.path[0], id: operation.path[1] };
+            return removeRecordFromSetOperation(identifier);
           }
         }
       });

--- a/lib/orbit-common/lib/operations.js
+++ b/lib/orbit-common/lib/operations.js
@@ -293,8 +293,7 @@ function addRecordToSetOperation(record) {
 }
 
 function removeRecordFromSetOperation(record) {
-  const identifier = record.type && record.id ? toIdentifier(record.type, record.id) : record;
-  return toOperation('remove', toIdentifier(identifier));
+  return toOperation('remove', toIdentifier(record));
 }
 
 export { operationType,

--- a/lib/orbit-common/lib/operations.js
+++ b/lib/orbit-common/lib/operations.js
@@ -213,8 +213,11 @@ function operationType(operation) {
   var path = operation.path;
   var value = operation.value;
 
-  if (path.length < 2) {
-    throw new OperationNotAllowed('Path must have at least 2 segments');
+  if (path.length < 1) {
+    throw new OperationNotAllowed('Path must have at least 1 segments');
+  } else if (path.length === 1) {
+    if (op === 'add') { return 'addRecordToSet'; }
+    if (op === 'remove') { return 'removeRecordFromSet'; }
   } else if (path.length === 2) {
     if (op === 'add' || op === 'remove' || op === 'replace') {
       return op + 'Record';
@@ -285,6 +288,15 @@ function replaceHasOneOperation(record, hasOneRelationship, value) {
     data);
 }
 
+function addRecordToSetOperation(record) {
+  return toOperation('add', toIdentifier(record.type, record.id), true);
+}
+
+function removeRecordFromSetOperation(record) {
+  const identifier = record.type && record.id ? toIdentifier(record.type, record.id) : record;
+  return toOperation('remove', toIdentifier(identifier));
+}
+
 export { operationType,
          coalesceOperations,
          addRecordOperation,
@@ -295,4 +307,6 @@ export { operationType,
          addToHasManyOperation,
          removeFromHasManyOperation,
          replaceHasManyOperation,
-         replaceHasOneOperation };
+         replaceHasOneOperation,
+         addRecordToSetOperation,
+         removeRecordFromSetOperation };

--- a/test/tests/orbit-common/unit/cache/live-queries-test.js
+++ b/test/tests/orbit-common/unit/cache/live-queries-test.js
@@ -178,6 +178,27 @@ module('OC - Cache - liveQuery', function(hooks) {
     cache.patches.onCompleted();
   });
 
+  test('filter - nested', function(assert) {
+    const done = assert.async();
+
+    cache.transform(new Transform(addRecordOperation(pluto)));
+    cache.transform(new Transform(addRecordOperation(jupiter)));
+    cache.patches.onCompleted();
+
+    const liveQuery = cache.liveQuery({
+      oql:
+        oqe('filter',
+          oqe('filter',
+            oqe('recordsOfType', 'planet'),
+            oqe('equal', oqe('get', 'attributes/name'), 'Pluto')),
+          oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
+
+    liveQuery.toArray().subscribe((operations) => {
+      equalOps(operations, [addRecordOperation(pluto)]);
+      done();
+    });
+  });
+
   test('record - responds to record added/removed', function(assert) {
     const done = assert.async();
 

--- a/test/tests/orbit-common/unit/cache/live-queries-test.js
+++ b/test/tests/orbit-common/unit/cache/live-queries-test.js
@@ -6,7 +6,9 @@ import {
   replaceAttributeOperation,
   replaceHasOneOperation,
   addToHasManyOperation,
-  removeFromHasManyOperation
+  removeFromHasManyOperation,
+  addRecordToSetOperation,
+  removeRecordFromSetOperation
 } from 'orbit-common/lib/operations';
 import Cache from 'orbit-common/cache';
 import {
@@ -53,8 +55,8 @@ module('OC - Cache - liveQuery', function(hooks) {
 
     liveQuery.toArray().subscribe((operations) => {
       equalOps(operations, [
-        addRecordOperation(pluto),
-        addRecordOperation(jupiter)
+        addRecordToSetOperation(pluto),
+        addRecordToSetOperation(jupiter)
       ]);
 
       done();
@@ -75,7 +77,7 @@ module('OC - Cache - liveQuery', function(hooks) {
           oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
 
     liveQuery.toArray().subscribe((operations) => {
-      equalOps(operations, [addRecordOperation(pluto)]);
+      equalOps(operations, [addRecordToSetOperation(pluto)]);
       done();
     });
   });
@@ -91,8 +93,8 @@ module('OC - Cache - liveQuery', function(hooks) {
 
     liveQuery.toArray().subscribe(operations => {
       equalOps(operations, [
-        addRecordOperation(pluto),
-        removeRecordOperation(pluto)
+        addRecordToSetOperation(pluto),
+        removeRecordFromSetOperation(pluto)
       ]);
       done();
     });
@@ -116,7 +118,7 @@ module('OC - Cache - liveQuery', function(hooks) {
     cache.patches.onCompleted();
 
     liveQuery.take(2).toArray().subscribe((operations) => {
-      equalOps(operations, [addRecordOperation(pluto)]);
+      equalOps(operations, [addRecordToSetOperation(pluto)]);
       done();
     });
   });
@@ -131,7 +133,7 @@ module('OC - Cache - liveQuery', function(hooks) {
           oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
 
     liveQuery.take(2).toArray().subscribe(operations => {
-      equalOps(operations[1], removeRecordOperation({ type: 'planet', id: 'pluto' }));
+      equalOps(operations[1], removeRecordFromSetOperation({ type: 'planet', id: 'pluto' }));
       done();
     });
 
@@ -150,7 +152,7 @@ module('OC - Cache - liveQuery', function(hooks) {
           oqe('equal', oqe('get', 'attributes/name'), 'Uranus2')) });
 
     liveQuery.subscribe(operation => {
-      equalOps(operation, addRecordOperation({ type: 'planet', id: 'uranus', attributes: { name: 'Uranus2' } }));
+      equalOps(operation, addRecordToSetOperation({ type: 'planet', id: 'uranus', attributes: { name: 'Uranus2' } }));
       done();
     });
 
@@ -194,7 +196,7 @@ module('OC - Cache - liveQuery', function(hooks) {
           oqe('equal', oqe('get', 'attributes/name'), 'Pluto')) });
 
     liveQuery.toArray().subscribe((operations) => {
-      equalOps(operations, [addRecordOperation(pluto)]);
+      equalOps(operations, [addRecordToSetOperation(pluto)]);
       done();
     });
   });
@@ -206,8 +208,8 @@ module('OC - Cache - liveQuery', function(hooks) {
 
     liveQuery.toArray().subscribe(operations => {
       equalOps(operations, [
-        addRecordOperation(pluto),
-        removeRecordOperation(pluto)
+        addRecordToSetOperation(pluto),
+        removeRecordFromSetOperation(pluto)
       ]);
 
       done();
@@ -230,8 +232,8 @@ module('OC - Cache - liveQuery', function(hooks) {
 
       liveQuery.toArray().subscribe(operations => {
         equalOps(operations, [
-          addRecordOperation(jupiter),
-          removeRecordOperation(jupiter)
+          addRecordToSetOperation(jupiter),
+          removeRecordFromSetOperation(jupiter)
         ]);
 
         done();
@@ -239,72 +241,6 @@ module('OC - Cache - liveQuery', function(hooks) {
 
       cache.transform(new Transform(replaceHasOneOperation(callisto, 'planet', jupiter)));
       cache.transform(new Transform(replaceHasOneOperation(callisto, 'planet', null)));
-      cache.patches.onCompleted();
-    });
-
-    test('emits updates for record after it\'s added to liveQuery', function(assert) {
-      const done = assert.async();
-
-      cache.reset({ planet: { jupiter }, moon: { callisto } });
-
-      const liveQuery = cache.liveQuery({
-        oql:
-          oqe('relatedRecord', 'moon', 'callisto', 'planet') });
-
-      liveQuery.toArray().subscribe(operations => {
-        equalOps(operations, [
-          addRecordOperation(jupiter),
-          replaceAttributeOperation(jupiter, 'name', 'Jupiter2')
-        ]);
-
-        done();
-      });
-
-      cache.transform(new Transform(replaceHasOneOperation(callisto, 'planet', jupiter)));
-      cache.transform(new Transform(replaceAttributeOperation(jupiter, 'name', 'Jupiter2')));
-      cache.patches.onCompleted();
-    });
-
-    test('emits updates for initial record', function(assert) {
-      const done = assert.async();
-
-      cache.reset({ planet: { saturn }, moon: { titan } });
-
-      const liveQuery = cache.liveQuery({
-        oql:
-          oqe('relatedRecord', 'moon', 'titan', 'planet') });
-
-      liveQuery.toArray().subscribe(operations => {
-        equalOps(operations, [
-          replaceAttributeOperation(saturn, 'name', 'Saturn2')
-        ]);
-
-        done();
-      });
-
-      cache.transform(new Transform(replaceAttributeOperation(saturn, 'name', 'Saturn2')));
-      cache.patches.onCompleted();
-    });
-
-    test('stops emitting updates for related record once it\'s been removed', function(assert) {
-      const done = assert.async();
-
-      cache.reset({ planet: { saturn }, moon: { titan } });
-
-      const liveQuery = cache.liveQuery({
-        oql:
-          oqe('relatedRecord', 'moon', 'titan', 'planet') });
-
-      liveQuery.toArray().subscribe(operations => {
-        equalOps(operations, [
-          removeRecordOperation(saturn)
-        ]);
-
-        done();
-      });
-
-      cache.transform(new Transform(replaceHasOneOperation(titan, 'planet', null)));
-      cache.transform(new Transform(replaceAttributeOperation(saturn, 'name', 'Saturn2')));
       cache.patches.onCompleted();
     });
   });
@@ -321,8 +257,8 @@ module('OC - Cache - liveQuery', function(hooks) {
 
       liveQuery.toArray().subscribe(operations => {
         equalOps(operations, [
-          addRecordOperation(callisto),
-          removeRecordOperation(callisto)
+          addRecordToSetOperation(callisto),
+          removeRecordFromSetOperation(callisto)
         ]);
 
         done();
@@ -330,72 +266,6 @@ module('OC - Cache - liveQuery', function(hooks) {
 
       cache.transform(new Transform(addToHasManyOperation(jupiter, 'moons', callisto)));
       cache.transform(new Transform(removeFromHasManyOperation(jupiter, 'moons', callisto)));
-      cache.patches.onCompleted();
-    });
-
-    test('emits updates to records included in liveQuery', function(assert) {
-      const done = assert.async();
-
-      cache.reset({ planet: { jupiter }, moon: { callisto } });
-
-      const liveQuery = cache.liveQuery({
-        oql:
-          oqe('relatedRecords', 'planet', 'jupiter', 'moons') });
-
-      liveQuery.toArray().subscribe(operations => {
-        equalOps(operations, [
-          addRecordOperation(callisto),
-          replaceAttributeOperation(callisto, 'name', 'Callisto2')
-        ]);
-
-        done();
-      });
-
-      cache.transform(new Transform(addToHasManyOperation(jupiter, 'moons', callisto)));
-      cache.transform(new Transform(replaceAttributeOperation(callisto, 'name', 'Callisto2')));
-      cache.patches.onCompleted();
-    });
-
-    test('emits updates to records included in liveQuery with initial values', function(assert) {
-      const done = assert.async();
-
-      cache.reset({ planet: { saturn }, moon: { titan } });
-
-      const liveQuery = cache.liveQuery({
-        oql:
-          oqe('relatedRecords', 'planet', 'saturn', 'moons') });
-
-      liveQuery.toArray().subscribe(operations => {
-        equalOps(operations, [
-          replaceAttributeOperation(titan, 'name', 'Titan2')
-        ]);
-
-        done();
-      });
-
-      cache.transform(new Transform(replaceAttributeOperation(titan, 'name', 'Titan2')));
-      cache.patches.onCompleted();
-    });
-
-    test('stops emitting updates to records that have been removed from liveQuery', function(assert) {
-      const done = assert.async();
-
-      cache.reset({ planet: { saturn }, moon: { titan } });
-
-      const liveQuery = cache.liveQuery({
-        oql:
-          oqe('relatedRecords', 'planet', 'saturn', 'moons') });
-
-      liveQuery.toArray().subscribe(operations => {
-        equalOps(operations, [
-          removeRecordOperation(titan)
-        ]);
-
-        done();
-      });
-
-      cache.transform(new Transform(removeFromHasManyOperation(saturn, 'moons', titan)));
-      cache.transform(new Transform(replaceAttributeOperation(titan, 'name', 'Titan2')));
       cache.patches.onCompleted();
     });
   });


### PR DESCRIPTION
@dgeb this ended up being a fairly superficial treatment. I've updated the external API, so `cache.liveQuery(operation => {})` now emits `addRecordToSet` or `removeRecordFromSet`. Internally though I'm still reusing the operations from the normalized schema and the operators are still emitting updates. The reason I'm still emitting updates is that operators further upstream in the RxJS chain need to know to recheck set membership for the updated record. Switching over to `addRecordToSet` and `removeRecordFromSet` should be fine but we'll need to choose a new operation to indicate updates (maybe `replaceRecordInSet`).

Anyway, this PR can be merged as is, the external API, `cache.liveQuery(operation => {})`, now emits the operations that we discussed.