### PR TITLE
Consolidate JSON:API requests as possible.

### DIFF
--- a/lib/orbit-common/jsonapi/update-requests.js
+++ b/lib/orbit-common/jsonapi/update-requests.js
@@ -1,15 +1,14 @@
 import Orbit from 'orbit/main';
 import Transform from 'orbit/transform';
 import { clone } from 'orbit/lib/objects';
-import { identity } from '../lib/identifiers';
+import { toIdentifier, identity, eqIdentity } from '../lib/identifiers';
 import { recordDiffs } from '../lib/operations';
 
 export const UpdateRequestProcessors = {
   addRecord(source, request) {
     const { serializer, schema } = source;
-
-    let record = schema.normalize(request.record);
-    let json = serializer.serialize(record);
+    const record = schema.normalize(request.record);
+    const json = serializer.serialize(record);
 
     return source.ajax(source.resourceURL(record.type), 'POST', { data: json })
       .then((raw) => {
@@ -30,6 +29,7 @@ export const UpdateRequestProcessors = {
 
   removeRecord(source, request) {
     const { type, id } = request.record;
+
     return source.ajax(source.resourceURL(type, id), 'DELETE')
       .then(() => []);
   },
@@ -45,7 +45,6 @@ export const UpdateRequestProcessors = {
   addToHasMany(source, request) {
     const { type, id } = request.record;
     const { relationship } = request;
-
     const json = {
       data: request.relatedRecords.map(r => source.serializer.serializeIdentifier(r))
     };
@@ -57,7 +56,6 @@ export const UpdateRequestProcessors = {
   removeFromHasMany(source, request) {
     const { type, id } = request.record;
     const { relationship } = request;
-
     const json = {
       data: request.relatedRecords.map(r => source.serializer.serializeIdentifier(r))
     };
@@ -69,7 +67,6 @@ export const UpdateRequestProcessors = {
   replaceHasOne(source, request) {
     const { type, id } = request.record;
     const { relationship, relatedRecord } = request;
-
     const json = {
       data: relatedRecord ? source.serializer.serializeIdentifier(relatedRecord) : null
     };
@@ -81,7 +78,6 @@ export const UpdateRequestProcessors = {
   replaceHasMany(source, request) {
     const { type, id } = request.record;
     const { relationship, relatedRecords } = request;
-
     const json = {
       data: relatedRecords.map(r => source.serializer.serializeIdentifier(r))
     };
@@ -91,7 +87,55 @@ export const UpdateRequestProcessors = {
   }
 };
 
-const OperationToUpdateRequestMap = {
+export function getUpdateRequests(transform) {
+  const requests = [];
+  let prevRequest;
+
+  transform.operations.forEach(operation => {
+    let request;
+    let newRequestNeeded = true;
+
+    if (prevRequest && eqIdentity(prevRequest.record, operation.record)) {
+      if (operation.op === 'removeRecord') {
+        newRequestNeeded = false;
+
+        if (prevRequest.op !== 'removeRecord') {
+          prevRequest = null;
+          requests.pop();
+        }
+      } else if (prevRequest.op === 'addRecord' || prevRequest.op === 'replaceRecord') {
+        if (operation.op === 'replaceAttribute') {
+          newRequestNeeded = false;
+          replaceRecordAttribute(prevRequest.record, operation.attribute, operation.value);
+        } else if (operation.op === 'replaceHasOne') {
+          newRequestNeeded = false;
+          replaceRecordHasOne(prevRequest.record, operation.relationship, operation.relatedRecord);
+        } else if (operation.op === 'replaceHasMany') {
+          newRequestNeeded = false;
+          replaceRecordHasMany(prevRequest.record, operation.relationship, operation.relatedRecords);
+        }
+      } else if (prevRequest.op === 'addToHasMany' &&
+                 operation.op === 'addToHasMany' &&
+                 prevRequest.relationship === operation.relationship) {
+        newRequestNeeded = false;
+        prevRequest.relatedRecords.push(identity(operation.relatedRecord));
+      }
+    }
+
+    if (newRequestNeeded) {
+      request = OperationToRequestMap[operation.op](operation);
+    }
+
+    if (request) {
+      requests.push(request);
+      prevRequest = request;
+    }
+  });
+
+  return requests;
+}
+
+const OperationToRequestMap = {
   addRecord(operation) {
     return {
       op: 'addRecord',
@@ -107,13 +151,9 @@ const OperationToUpdateRequestMap = {
   },
 
   replaceAttribute(operation) {
-    const record = {
-      type: operation.record.type,
-      id: operation.record.id,
-      attributes: {}
-    };
+    const record = identity(operation.record);
 
-    record.attributes[operation.attribute] = operation.value;
+    replaceRecordAttribute(record, operation.attribute, operation.value);
 
     return {
       op: 'replaceRecord',
@@ -147,58 +187,46 @@ const OperationToUpdateRequestMap = {
   },
 
   replaceHasOne(operation) {
+    const record = identity(operation.record);
+    record.relationships = {};
+    record.relationships[operation.relationship] = {};
+    record.relationships[operation.relationship].data = toIdentifier(operation.relatedRecord);
+
     return {
-      op: 'replaceHasOne',
-      record: identity(operation.record),
-      relationship: operation.relationship,
-      relatedRecord: operation.relatedRecord ? identity(operation.relatedRecord) : null
+      op: 'replaceRecord',
+      record
     };
   },
 
   replaceHasMany(operation) {
+    const record = identity(operation.record);
+    const relationshipData = {};
+    operation.relatedRecords.forEach(r => {
+      relationshipData[toIdentifier(r)] = true;
+    });
+    record.relationships = {};
+    record.relationships[operation.relationship] = { data: relationshipData };
+
     return {
-      op: 'replaceHasMany',
-      record: identity(operation.record),
-      relationship: operation.relationship,
-      relatedRecords: operation.relatedRecords.map(r => identity(r))
+      op: 'replaceRecord',
+      record
     };
   }
 };
 
-function eqIdentity(record1, record2) {
-  return record1.type === record2.type && record1.id === record2.id;
+function replaceRecordAttribute(record, attribute, value) {
+  record.attributes = record.attributes || {};
+  record.attributes[attribute] = value;
 }
 
-export function getUpdateRequests(transform) {
-  const requests = [];
-  let request;
+function replaceRecordHasOne(record, relationship, relatedRecord) {
+  record.relationships = record.relationships || {};
+  record.relationships[relationship] = record.relationships[relationship] || {};
+  record.relationships[relationship].data = relatedRecord ? identity(relatedRecord) : null;
+}
 
-  transform.operations.forEach(operation => {
-    // if (request) {
-    // switch(request.op) {
-    //   case 'addRecord':
-    //     if (operation.op === 'addRecord') {
-    //
-    //     }
-    //     if (eqIdentity(operation.record))
-    //
-    //     request = {
-    //       op: operation.op,
-    //       record: operation.record
-    //     }
-    //   case 'removeRecord':
-    //
-    //     request = {
-    //       op: operation.op,
-    //       record: operation.record
-    //     }
-    //
-    // }
-    // } else {
-    // }
-    request = OperationToUpdateRequestMap[operation.op](operation);
-    requests.push(request);
-  });
-
-  return requests;
+function replaceRecordHasMany(record, relationship, relatedRecords) {
+  record.relationships = record.relationships || {};
+  record.relationships[relationship] = record.relationships[relationship] || {};
+  record.relationships[relationship].data = relatedRecords.map(r => identity(r));
 }

--- a/lib/orbit-common/lib/identifiers.js
+++ b/lib/orbit-common/lib/identifiers.js
@@ -1,4 +1,4 @@
-import { isObject } from 'orbit/lib/objects';
+import { isObject, isNone } from 'orbit/lib/objects';
 
 function toIdentifier(type, id) {
   if (type) {
@@ -22,4 +22,11 @@ function identity(record) {
   return { type, id };
 }
 
-export { toIdentifier, parseIdentifier, identity };
+function eqIdentity(record1, record2) {
+  return (isNone(record1) && isNone(record2)) ||
+         (isObject(record1) && isObject(record2) &&
+          record1.type === record2.type &&
+          record1.id === record2.id);
+}
+
+export { toIdentifier, parseIdentifier, identity, eqIdentity };

--- a/lib/orbit-common/lib/identifiers.js
+++ b/lib/orbit-common/lib/identifiers.js
@@ -1,5 +1,15 @@
+import { isObject } from 'orbit/lib/objects';
+
 function toIdentifier(type, id) {
-  return type + ':' + id;
+  if (type) {
+    if (isObject(type)) {
+      return type.type + ':' + type.id;
+    } else {
+      return type + ':' + id;
+    }
+  } else {
+    return null;
+  }
 }
 
 function parseIdentifier(identifier) {

--- a/test/tests/orbit-common/unit/jsonapi/update-requests-test.js
+++ b/test/tests/orbit-common/unit/jsonapi/update-requests-test.js
@@ -1,2 +1,276 @@
 import Transform from 'orbit/transform';
 import { UpdateRequestProcessors, getUpdateRequests } from 'orbit-common/jsonapi/update-requests';
+
+module('OC - JSONAPI - UpdateRequests', function() {
+  module('getUpdateRequests', function() {
+    test('addRecord', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
+
+      const t = Transform.from({
+        op: 'addRecord',
+        record: jupiter
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'addRecord',
+        record: jupiter
+      }]);
+    });
+
+    test('removeRecord', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
+
+      const t = Transform.from({
+        op: 'removeRecord',
+        record: jupiter
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'removeRecord',
+        record: { type: 'planet', id: 'jupiter' }
+      }]);
+    });
+
+    test('replaceAttribute => replaceRecord', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
+
+      const t = Transform.from({
+        op: 'replaceAttribute',
+        record: { type: 'planet', id: 'jupiter' },
+        attribute: 'name',
+        value: 'Earth'
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'replaceRecord',
+        record: { type: 'planet', id: 'jupiter', attributes: { name: 'Earth' } }
+      }]);
+    });
+
+    test('replaceRecord', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
+
+      const t = Transform.from({
+        op: 'replaceRecord',
+        record: jupiter
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'replaceRecord',
+        record: jupiter
+      }]);
+    });
+
+    test('addToHasMany', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter' };
+      const io = { type: 'moon', id: 'io' };
+
+      const t = Transform.from({
+        op: 'addToHasMany',
+        record: jupiter,
+        relationship: 'moons',
+        relatedRecord: io
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'addToHasMany',
+        record: jupiter,
+        relationship: 'moons',
+        relatedRecords: [io]
+      }]);
+    });
+
+    test('removeFromHasMany', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter' };
+      const io = { type: 'moon', id: 'io' };
+
+      const t = Transform.from({
+        op: 'removeFromHasMany',
+        record: jupiter,
+        relationship: 'moons',
+        relatedRecord: io
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'removeFromHasMany',
+        record: jupiter,
+        relationship: 'moons',
+        relatedRecords: [io]
+      }]);
+    });
+
+    test('replaceHasOne => replaceRecord', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter' };
+      const io = { type: 'moon', id: 'io' };
+
+      const t = Transform.from({
+        op: 'replaceHasOne',
+        record: io,
+        relationship: 'planet',
+        relatedRecord: jupiter
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'replaceRecord',
+        record: {
+          type: 'moon',
+          id: 'io',
+          relationships: {
+            planet: {
+              data: 'planet:jupiter'
+            }
+          }
+        }
+      }]);
+    });
+
+    test('replaceHasOne (with null) => replaceRecord', function(assert) {
+      const io = { type: 'moon', id: 'io' };
+
+      const t = Transform.from({
+        op: 'replaceHasOne',
+        record: io,
+        relationship: 'planet',
+        relatedRecord: null
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'replaceRecord',
+        record: {
+          type: 'moon',
+          id: 'io',
+          relationships: {
+            planet: {
+              data: null
+            }
+          }
+        }
+      }]);
+    });
+
+    test('replaceHasMany => replaceRecord', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter' };
+      const io = { type: 'moon', id: 'io' };
+      const europa = { type: 'moon', id: 'europa' };
+
+      const t = Transform.from({
+        op: 'replaceHasMany',
+        record: jupiter,
+        relationship: 'moons',
+        relatedRecords: [io, europa]
+      });
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'replaceRecord',
+        record: {
+          type: 'planet',
+          id: 'jupiter',
+          relationships: {
+            moons: {
+              data: {
+                'moon:io': true,
+                'moon:europa': true
+              }
+            }
+          }
+        }
+      }]);
+    });
+
+    test('addRecord + removeRecord => []', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
+
+      const t = Transform.from([{
+        op: 'addRecord',
+        record: { type: 'planet', id: 'jupiter', attributes: { name: 'Earth' } }
+      }, {
+        op: 'removeRecord',
+        record: { type: 'planet', id: 'jupiter' }
+      }]);
+
+      assert.deepEqual(getUpdateRequests(t), []);
+    });
+
+    test('removeRecord + removeRecord => [removeRecord]', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
+
+      const t = Transform.from([{
+        op: 'removeRecord',
+        record: { type: 'planet', id: 'jupiter' }
+      }, {
+        op: 'removeRecord',
+        record: { type: 'planet', id: 'jupiter' }
+      }]);
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'removeRecord',
+        record: { type: 'planet', id: 'jupiter' }
+      }]);
+    });
+
+    test('addRecord + replaceAttribute => [addRecord]', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
+
+      const t = Transform.from([{
+        op: 'addRecord',
+        record: { type: 'planet', id: 'jupiter', attributes: { name: 'Earth' } }
+      }, {
+        op: 'replaceAttribute',
+        record: { type: 'planet', id: 'jupiter' },
+        attribute: 'atmosphere',
+        value: 'gaseous'
+      }]);
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'addRecord',
+        record: { type: 'planet', id: 'jupiter', attributes: { name: 'Earth', atmosphere: 'gaseous' } }
+      }]);
+    });
+
+    test('replaceAttribute + replaceAttribute => [replaceRecord]', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
+
+      const t = Transform.from([{
+        op: 'replaceAttribute',
+        record: { type: 'planet', id: 'jupiter' },
+        attribute: 'name',
+        value: 'Earth'
+      }, {
+        op: 'replaceAttribute',
+        record: { type: 'planet', id: 'jupiter' },
+        attribute: 'atmosphere',
+        value: 'gaseous'
+      }]);
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'replaceRecord',
+        record: { type: 'planet', id: 'jupiter', attributes: { name: 'Earth', atmosphere: 'gaseous' } }
+      }]);
+    });
+
+    test('addToHasMany + addToHasMany => [addToHasMany]', function(assert) {
+      const jupiter = { type: 'planet', id: 'jupiter' };
+      const io = { type: 'moon', id: 'io' };
+      const europa = { type: 'moon', id: 'europa' };
+
+      const t = Transform.from([{
+        op: 'addToHasMany',
+        record: jupiter,
+        relationship: 'moons',
+        relatedRecord: io
+      }, {
+        op: 'addToHasMany',
+        record: jupiter,
+        relationship: 'moons',
+        relatedRecord: europa
+      }]);
+
+      assert.deepEqual(getUpdateRequests(t), [{
+        op: 'addToHasMany',
+        record: jupiter,
+        relationship: 'moons',
+        relatedRecords: [io, europa]
+      }]);
+    });
+  });
+});

--- a/test/tests/orbit-common/unit/lib/identifiers-test.js
+++ b/test/tests/orbit-common/unit/lib/identifiers-test.js
@@ -1,4 +1,4 @@
-import { toIdentifier, parseIdentifier, identity } from 'orbit-common/lib/identifiers';
+import { toIdentifier, parseIdentifier, identity, eqIdentity } from 'orbit-common/lib/identifiers';
 
 module('OC - Lib - Identifiers', {
 });
@@ -15,4 +15,12 @@ test('`parseIdentifier` converts an identifier string to an object with a `type`
 
 test('`identity` returns a simple { type, id } identity object from any object with a `type` and `id`', function(assert) {
   assert.deepEqual(identity({ type: 'planet', id: '1', attributes: { }, relationships: { } }), { type: 'planet', id: '1' });
+});
+
+test('`eqIdentity` compares the type/id identity of two objects', function(assert) {
+  assert.ok(eqIdentity({ type: 'planet', id: '1' }, { type: 'planet', id: '1' }), 'identities match');
+  assert.ok(eqIdentity(null, null), 'identities match');
+  assert.ok(!eqIdentity({ type: 'planet', id: '1' }, { type: 'moon', id: '1' }), 'identities do not match');
+  assert.ok(!eqIdentity({ type: 'planet', id: '1' }, null), 'identities do not match');
+  assert.ok(!eqIdentity(null, { type: 'planet', id: '1' }), 'identities do not match');
 });

--- a/test/tests/orbit-common/unit/lib/identifiers-test.js
+++ b/test/tests/orbit-common/unit/lib/identifiers-test.js
@@ -3,8 +3,10 @@ import { toIdentifier, parseIdentifier, identity } from 'orbit-common/lib/identi
 module('OC - Lib - Identifiers', {
 });
 
-test('`toIdentifier` converts a `type` and `id` to an identifier string', function(assert) {
-  assert.equal(toIdentifier('planet', '1'), 'planet:1');
+test('`toIdentifier` converts inputs to an identifier', function(assert) {
+  assert.equal(toIdentifier('planet', '1'), 'planet:1', 'works with `type` and `id` args');
+  assert.equal(toIdentifier(null), null, 'works with null');
+  assert.equal(toIdentifier({ type: 'planet', id: '1' }), 'planet:1', 'works with an identity object');
 });
 
 test('`parseIdentifier` converts an identifier string to an object with a `type` and `id`', function(assert) {


### PR DESCRIPTION
`getUpdateRequests` now consolidates requests as possible.

In order to make this more straightforward, `replaceRecord` is favored
in place of `replaceHasOne` and `replaceHasMany`.