### PR TITLE
Introduce Query class.

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -6,8 +6,10 @@ import CacheIntegrityProcessor from './cache/operation-processors/cache-integrit
 import SchemaConsistencyProcessor from './cache/operation-processors/schema-consistency-processor';
 import Transform from 'orbit/transform';
 import TransformLog from 'orbit/transform-log';
+import Query from 'orbit/query';
 import QueryEvaluator from 'orbit/query/evaluator';
 import QueryOperators from './cache/query-operators';
+import QueryBuilder from './query/builder';
 import TransformBuilder from './transform/builder';
 import PatchTransforms from './cache/patch-transforms';
 import InverseTransforms from './cache/inverse-transforms';
@@ -37,19 +39,21 @@ export default class Cache {
 
     this.schema = schema;
     this._doc = new Document();
+
     this.transformLog = new TransformLog();
     this._transformInverses = {};
+    this.transformBuilder = new TransformBuilder();
+
+    this.queryEvaluator = new QueryEvaluator(this, QueryOperators);
+    this.queryBuilder = new QueryBuilder();
 
     const processors = options.processors ? options.processors : [SchemaConsistencyProcessor, CacheIntegrityProcessor];
     this._processors = processors.map(Processor => new Processor(this));
-
-    this.queryEvaluator = new QueryEvaluator(this, QueryOperators);
-
-    this.transformBuilder = new TransformBuilder();
   }
 
-  query(exp, context) {
-    return this.queryEvaluator.evaluate(exp, context);
+  query(_query) {
+    let query = Query.from(_query, this.queryBuilder);
+    return this.queryEvaluator.evaluate(query.expression);
   }
 
   reset(data) {

--- a/lib/orbit-common/memory-source.js
+++ b/lib/orbit-common/memory-source.js
@@ -5,6 +5,7 @@ import Cache from './cache';
 import Queryable from 'orbit/queryable';
 import Updatable from 'orbit/updatable';
 import TransformBuilder from './transform/builder';
+import QueryBuilder from './query/builder';
 
 /**
  Source for storing in-memory data
@@ -26,6 +27,8 @@ export default class MemorySource extends Source {
 
     Queryable.extend(this);
     Updatable.extend(this);
+
+    this.queryBuilder = new QueryBuilder();
     this.transformBuilder = new TransformBuilder();
 
     this.cache = new Cache(options.schema, options.cacheOptions);

--- a/lib/orbit-common/query/builder.js
+++ b/lib/orbit-common/query/builder.js
@@ -1,29 +1,39 @@
+import { merge } from 'orbit/lib/objects';
 import { queryExpression as oqe } from 'orbit/query/expression';
 import OrbitQueryBuilder from 'orbit/query/builder';
 import { Records } from 'orbit-common/query/terms';
 
-export default class QueryBuilder extends OrbitQueryBuilder {
-  constructor(options = {}) {
-    super(options);
-    this._typeTerms = this._createTypeTerms(options.terms.recordsOfType);
-  }
+function _createTypeTerms(typeOptions) {
+  if (!typeOptions) { return {}; }
 
+  const typeTerms = {};
+
+  Object.keys(typeOptions).forEach(type => {
+    const scopes = typeOptions[type];
+    typeTerms[type] = Records.withScopes(scopes);
+  });
+
+  return typeTerms;
+}
+
+const defaultTerms = {
   recordsOfType(type) {
     const TypeTerm = this._typeTerms[type] || Records;
 
     return new TypeTerm(oqe('recordsOfType', type));
   }
+};
 
-  _createTypeTerms(typeOptions) {
-    if (!typeOptions) { return {}; }
+export default class QueryBuilder extends OrbitQueryBuilder {
+  constructor(options = {}) {
+    super(options);
 
-    const typeTerms = {};
+    this.terms = merge(this.terms, defaultTerms);
 
-    Object.keys(typeOptions).forEach(type => {
-      const scopes = typeOptions[type];
-      typeTerms[type] = Records.withScopes(scopes);
-    });
-
-    return typeTerms;
+    if (options.terms) {
+      this.terms._typeTerms = _createTypeTerms(options.terms.recordsOfType);
+    } else {
+      this.terms._typeTerms = {};
+    }
   }
 }

--- a/lib/orbit-common/query/terms.js
+++ b/lib/orbit-common/query/terms.js
@@ -13,7 +13,7 @@ export class RecordCursor extends Cursor {
 export class Records extends TermBase {
   filter(predicateExpression) {
     const filterBuilder = new RecordCursor();
-    return new this.constructor(oqe('filter', this._oqe, predicateExpression(filterBuilder)));
+    return new this.constructor(oqe('filter', this.expression, predicateExpression(filterBuilder)));
   }
 
   filterAttributes(attributeValues) {
@@ -26,11 +26,7 @@ export class Records extends TermBase {
     const andExpression = attributeExpressions.length === 1 ? attributeExpressions[0]
                                                             : oqe('and', ...attributeExpressions);
 
-    return new this.constructor(oqe('filter', this._oqe, andExpression));
-  }
-
-  build() {
-    return this._oqe;
+    return new this.constructor(oqe('filter', this.expression, andExpression));
   }
 
   static withScopes(scopes) {

--- a/lib/orbit/lib/exceptions.js
+++ b/lib/orbit/lib/exceptions.js
@@ -49,3 +49,11 @@ export class TransformBuilderNotRegisteredException extends Exception {
     this.name = 'Orbit.TransformBuilderNotRegisteredException';
   }
 }
+
+export class QueryBuilderNotRegisteredException extends Exception {
+  constructor(queryBuilder) {
+    super(`QueryBuilder not registered: ${queryBuilder}`);
+    this.queryBuilder = queryBuilder;
+    this.name = 'Orbit.QueryBuilderNotRegisteredException';
+  }
+}

--- a/lib/orbit/query.js
+++ b/lib/orbit/query.js
@@ -1,0 +1,38 @@
+import { uuid } from './lib/uuid';
+import { QueryBuilderNotRegisteredException } from './lib/exceptions';
+
+/**
+ Queries are used to extract data from a source.
+
+ Queries are automatically assigned a UUID `id`.
+
+ @class Query
+ @namespace Orbit
+ @param {Object}    [expression] Query expression
+ @param {Object}    [options]
+ @param {String}    [options.id] Unique id for this query (will be assigned a uuid by default)
+ @constructor
+ */
+export default class Query {
+  constructor(expression, _options) {
+    this.expression = expression;
+
+    let options = _options || {};
+
+    this.id = options.id || uuid();
+  }
+}
+
+Query.from = function(queryOrExpression, queryBuilder) {
+  if (queryOrExpression instanceof Query) {
+    return queryOrExpression;
+  } else if (typeof queryOrExpression === 'function') {
+    if (queryBuilder) {
+      return queryBuilder.build(queryOrExpression);
+    } else {
+      throw new QueryBuilderNotRegisteredException();
+    }
+  } else {
+    return new Query(queryOrExpression);
+  }
+};

--- a/lib/orbit/query/builder.js
+++ b/lib/orbit/query/builder.js
@@ -1,11 +1,16 @@
 import { queryExpression as oqe } from './expression';
 import { Value } from './terms';
+import Query from '../query';
 
 export default class QueryBuilder {
   constructor(options = {}) {
     this._options = options;
 
     options.terms = options.terms || {};
+  }
+
+  build(fn) {
+    return Query.from(fn(this).expression);
   }
 
   get(path) {

--- a/lib/orbit/query/builder.js
+++ b/lib/orbit/query/builder.js
@@ -1,27 +1,28 @@
+import { merge } from 'orbit/lib/objects';
 import { queryExpression as oqe } from './expression';
 import { Value } from './terms';
 import Query from '../query';
 
-export default class QueryBuilder {
-  constructor(options = {}) {
-    this._options = options;
-
-    options.terms = options.terms || {};
-  }
-
-  build(fn) {
-    return Query.from(fn(this).expression);
-  }
-
+const defaultTerms = {
   get(path) {
     return new Value(oqe('get', path));
-  }
+  },
 
   or(a, b) {
     return oqe('or', a, b);
-  }
+  },
 
   and(a, b) {
     return oqe('and', a, b);
+  }
+};
+
+export default class QueryBuilder {
+  constructor(options = {}) {
+    this.terms = defaultTerms;
+  }
+
+  build(fn) {
+    return Query.from(fn(this.terms).expression);
   }
 }

--- a/lib/orbit/query/expression.js
+++ b/lib/orbit/query/expression.js
@@ -13,8 +13,8 @@ class QueryExpression {
   }
 }
 
-export function queryExpression(op) {
-  return new QueryExpression(op, Array.prototype.slice.call(arguments, 1));
+export function queryExpression(op, ...args) {
+  return new QueryExpression(op, args);
 }
 
 export function isQueryExpression(obj) {

--- a/lib/orbit/query/terms.js
+++ b/lib/orbit/query/terms.js
@@ -1,8 +1,9 @@
 import { queryExpression as oqe } from './expression';
+import Query from 'orbit/query';
 
 export class TermBase {
-  constructor(oqe) {
-    this._oqe = oqe;
+  constructor(expression) {
+    this.expression = expression;
   }
 }
 
@@ -14,6 +15,6 @@ export class Cursor extends TermBase {
 
 export class Value extends TermBase {
   equal(value) {
-    return oqe('equal', this._oqe, value);
+    return oqe('equal', this.expression, value);
   }
 }

--- a/lib/orbit/queryable.js
+++ b/lib/orbit/queryable.js
@@ -1,6 +1,7 @@
 import Orbit from './main';
 import Evented from './evented';
 import { extend } from './lib/objects';
+import Query from './query';
 
 export default {
   /**
@@ -21,7 +22,9 @@ export default {
   interface: {
     _queryable: true,
 
-    query(query) {
+    query(queryOrExpression) {
+      const query = Query.from(queryOrExpression, this.queryBuilder);
+
       return this.series('beforeQuery', query)
         .then(() => {
           const result = this._query(query);

--- a/lib/orbit/transform.js
+++ b/lib/orbit/transform.js
@@ -3,9 +3,8 @@ import { uuid } from './lib/uuid';
 import { TransformBuilderNotRegisteredException } from './lib/exceptions';
 
 /**
- Transforms represent a set of operations that are applied against a
- source. After a transform has been applied, it should be assigned the
- `result`, a `TransformResult` that represents the result of the transform.
+ Transforms represent a set of operations that are applied to mutate a
+ source.
 
  Transforms are automatically assigned a UUID `id`.
 

--- a/test/tests/orbit-common/unit/jsonapi-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-source-test.js
@@ -6,7 +6,6 @@ import JSONAPISource from 'orbit-common/jsonapi-source';
 import { Promise } from 'rsvp';
 import jQuery from 'jquery';
 import { toIdentifier, parseIdentifier } from 'orbit-common/lib/identifiers';
-import { queryExpression as oqe } from 'orbit/query/expression';
 
 let server,
     schema,
@@ -435,7 +434,7 @@ test('#update - can replace a hasMany relationship with PATCH', function(assert)
 //   });
 //
 //   stop();
-//   source.query(oqe('get', `planet/${planet.id}`))
+//   source.query(q => q.get(`planet/${planet.id}`))
 //     .then(function(foundPlanet) {
 //       start();
 //       equal(foundPlanet.id, planet.id, 'orbit id should match');

--- a/test/tests/orbit-common/unit/memory-source-test.js
+++ b/test/tests/orbit-common/unit/memory-source-test.js
@@ -10,9 +10,6 @@ import { uuid } from 'orbit/lib/uuid';
 import { toIdentifier } from 'orbit-common/lib/identifiers';
 import CacheIntegrityProcessor from 'orbit-common/cache/operation-processors/cache-integrity-processor';
 import SchemaConsistencyProcessor from 'orbit-common/cache/operation-processors/schema-consistency-processor';
-import {
-  queryExpression as oqe
-} from 'orbit/query/expression';
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -110,7 +107,7 @@ module('OC - MemorySource', function(hooks) {
 
     assert.equal(source.cache.length('planet'), 1, 'cache should contain one planet');
 
-    source.query(oqe('get', 'planet/1'))
+    source.query(q => q.get('planet/1'))
       .then(function(foundPlanet) {
         strictEqual(foundPlanet, jupiter, 'found planet matches original');
         done();

--- a/test/tests/orbit-common/unit/query/builder-test.js
+++ b/test/tests/orbit-common/unit/query/builder-test.js
@@ -2,14 +2,6 @@ import 'tests/test-helper';
 import { queryExpression as oqe } from 'orbit/query/expression';
 import QueryBuilder from 'orbit-common/query/builder';
 
-function assertEqualQuery(actual, expected) {
-  function jsonify(query) {
-    return JSON.parse(JSON.stringify(query));
-  }
-
-  deepEqual(actual.toString(), expected.toString());
-}
-
 module('OC - QueryBuilder', function(hooks) {
   let qb;
 
@@ -18,19 +10,19 @@ module('OC - QueryBuilder', function(hooks) {
   });
 
   test('recordsOfType', function(assert) {
-    assertEqualQuery(
-      qb.recordsOfType('planet').build(),
+    assert.deepEqual(
+      qb.build(q => q.recordsOfType('planet')).expression,
 
       oqe('recordsOfType', 'planet')
     );
   });
 
   test('recordsOfType/filter/equal/get', function(assert) {
-    assertEqualQuery(
-      qb
-        .recordsOfType('planet')
-        .filter(record => record.get('attributes/name').equal('Pluto'))
-        .build(),
+    assert.deepEqual(
+      qb.build(q => {
+        return q.recordsOfType('planet')
+                .filter(record => record.get('attributes/name').equal('Pluto'));
+      }).expression,
 
       oqe('filter',
         oqe('recordsOfType', 'planet'),
@@ -39,16 +31,15 @@ module('OC - QueryBuilder', function(hooks) {
   });
 
   test('recordsOfType/filter/equal/get/or', function(assert) {
-    assertEqualQuery(
-      qb
-        .recordsOfType('planet')
-        .filter(record =>
-          qb.or(
-            record.get('attributes/name').equal('Jupiter'),
-            record.get('attributes/name').equal('Pluto')
-          )
-        )
-        .build(),
+    assert.deepEqual(
+      qb.build(q => q.recordsOfType('planet')
+                     .filter(record =>
+                       q.or(
+                         record.get('attributes/name').equal('Jupiter'),
+                         record.get('attributes/name').equal('Pluto')
+                       )
+                     )
+      ).expression,
 
       oqe('filter',
         oqe('recordsOfType', 'planet'),
@@ -59,16 +50,15 @@ module('OC - QueryBuilder', function(hooks) {
   });
 
   test('recordsOfType/filter/equal/get/and', function(assert) {
-    assertEqualQuery(
-      qb
-        .recordsOfType('planet')
-        .filter(record =>
-          qb.and(
-            record.get('attributes/name').equal('Jupiter'),
-            record.get('attributes/name').equal('Pluto')
-          )
-        )
-        .build(),
+    assert.deepEqual(
+      qb.build(q => q.recordsOfType('planet')
+                     .filter(record =>
+                       q.and(
+                         record.get('attributes/name').equal('Jupiter'),
+                         record.get('attributes/name').equal('Pluto')
+                       )
+                     )
+      ).expression,
 
       oqe('filter',
         oqe('recordsOfType', 'planet'),
@@ -79,16 +69,15 @@ module('OC - QueryBuilder', function(hooks) {
   });
 
   test('recordsOfType/filter/equal/attribute/and', function(assert) {
-    assertEqualQuery(
-      qb
-        .recordsOfType('planet')
-        .filter(record =>
-          qb.and(
-            record.attribute('name').equal('Jupiter'),
-            record.attribute('name').equal('Pluto')
-          )
-        )
-        .build(),
+    assert.deepEqual(
+      qb.build(q => q.recordsOfType('planet')
+                     .filter(record =>
+                       q.and(
+                         record.attribute('name').equal('Jupiter'),
+                         record.attribute('name').equal('Pluto')
+                       )
+                     )
+      ).expression,
 
       oqe('filter',
         oqe('recordsOfType', 'planet'),
@@ -99,11 +88,10 @@ module('OC - QueryBuilder', function(hooks) {
   });
 
   test('recordsOfType/filterAttributes', function(assert) {
-    assertEqualQuery(
-      qb
-        .recordsOfType('planet')
-        .filterAttributes({ 'name': 'Jupiter', 'age': '23000000' })
-        .build(),
+    assert.deepEqual(
+      qb.build(q => q.recordsOfType('planet')
+                     .filterAttributes({ 'name': 'Jupiter', 'age': '23000000' })
+      ).expression,
 
       oqe('filter',
         oqe('recordsOfType', 'planet'),
@@ -126,11 +114,10 @@ module('OC - QueryBuilder', function(hooks) {
       }
     });
 
-    assertEqualQuery(
-      qb
-        .recordsOfType('planet')
-        .namedPluto()
-        .build(),
+    assert.deepEqual(
+      qb.build(q => q.recordsOfType('planet')
+                     .namedPluto()
+      ).expression,
 
       oqe('filter',
         oqe('recordsOfType', 'planet'),

--- a/test/tests/orbit/unit/query-test.js
+++ b/test/tests/orbit/unit/query-test.js
@@ -1,0 +1,64 @@
+import Orbit from 'orbit/main';
+import Query from 'orbit/query';
+import Builder from 'orbit/query/builder';
+import { queryExpression as oqe } from 'orbit/query/expression';
+import { QueryBuilderNotRegisteredException } from 'orbit/lib/exceptions';
+
+///////////////////////////////////////////////////////////////////////////////
+
+module('Orbit', function() {
+  module('Query', function() {
+    test('it exists', function(assert) {
+      let query = new Query();
+      assert.ok(query);
+    });
+
+    test('it is assigned an `id`', function(assert) {
+      let query = new Query();
+      assert.ok(query.id, 'query has an id');
+    });
+
+    test('can be created from with all attributes specified as options', function(assert) {
+      let expression = { op: 'foo' };
+      let options = { id: 'abc123' };
+
+      let query = new Query(expression, options);
+
+      assert.strictEqual(query.id, options.id, 'id was populated');
+      assert.deepEqual(query.expression, expression, 'expression was populated');
+    });
+
+    test('.from will return a query passed into it', function(assert) {
+      let query = new Query();
+      assert.strictEqual(Query.from(query), query);
+    });
+
+    test('.from will create a query from an expression passed into it', function(assert) {
+      let query = Query.from({ op: 'foo' });
+      assert.ok(query instanceof Query);
+    });
+
+    test('.from should pass any query functions to queryBuilder, if one is passed', function(assert) {
+      assert.expect(2);
+
+      const queryBuilder = new Builder();
+
+      let query = Query.from(
+        (q) => q.get('foo'),
+        queryBuilder
+      );
+
+      assert.ok(query instanceof Query, 'built a Query');
+      assert.deepEqual(query.expression, oqe('get', 'foo'), 'query contains expression returned from builder');
+    });
+
+    test('.from should throw an exception if a function is passed but a queryBuilder is not', function(assert) {
+      assert.throws(
+        () => {
+          Query.from((b) => {});
+        },
+        QueryBuilderNotRegisteredException
+      );
+    });
+  });
+});

--- a/test/tests/orbit/unit/query/builder-test.js
+++ b/test/tests/orbit/unit/query/builder-test.js
@@ -1,0 +1,35 @@
+import 'tests/test-helper';
+import Builder from 'orbit/query/builder';
+import Query from 'orbit/query';
+import { queryExpression as oqe } from 'orbit/query/expression';
+
+///////////////////////////////////////////////////////////////////////////////
+
+let builder;
+
+module('Orbit', function() {
+  module('Query', function() {
+    module('Builder', {
+      setup() {
+        builder = new Builder();
+      },
+
+      teardown() {
+        builder = null;
+      }
+    }, function() {
+      test('exists', function(assert) {
+        assert.ok(builder, 'it exists');
+      });
+
+      test('#build - takes a function and returns a Query instance ', function(assert) {
+        assert.expect(2);
+
+        let query = builder.build(b => b.get('foo'));
+
+        assert.ok(query instanceof Query, 'returns Query');
+        assert.deepEqual(query.expression, oqe('get', 'foo'), 'query contains expression returned from builder');
+      });
+    });
+  });
+});

--- a/test/tests/orbit/unit/queryable-test.js
+++ b/test/tests/orbit/unit/queryable-test.js
@@ -46,13 +46,13 @@ test('it should trigger `query` event after a successful action in which `_query
 
   source._query = function(query) {
     assert.equal(++order, 1, 'action performed after willQuery');
-    assert.deepEqual(query, { fetch: ['abc', 'def'] }, 'query object matches');
+    assert.deepEqual(query.expression, { fetch: ['abc', 'def'] }, 'query object matches');
     return successfulOperation();
   };
 
   source.on('query', (query, result) => {
     assert.equal(++order, 2, 'query triggered after action performed successfully');
-    assert.deepEqual(query, { fetch: ['abc', 'def'] }, 'query matches');
+    assert.deepEqual(query.expression, { fetch: ['abc', 'def'] }, 'query matches');
     assert.equal(result, ':)', 'result matches');
   });
 
@@ -70,13 +70,13 @@ test('it should trigger `query` event after a successful action in which `_query
 
   source._query = function(query) {
     assert.equal(++order, 1, 'action performed after willQuery');
-    assert.deepEqual(query, { fetch: ['abc', 'def'] }, 'query object matches');
+    assert.deepEqual(query.expression, { fetch: ['abc', 'def'] }, 'query object matches');
     return;
   };
 
   source.on('query', (query, result) => {
     equal(++order, 2, 'query triggered after action performed successfully');
-    assert.deepEqual(query, { fetch: ['abc', 'def'] }, 'query matches');
+    assert.deepEqual(query.expression, { fetch: ['abc', 'def'] }, 'query matches');
     assert.equal(result, undefined, 'result matches');
   });
 
@@ -94,7 +94,7 @@ test('`query` event should receive results as the last argument, even if they ar
 
   source._query = function(query) {
     assert.equal(++order, 1, 'action performed after willQuery');
-    assert.deepEqual(query, { fetch: ['abc', 'def'] }, 'query object matches');
+    assert.deepEqual(query.expression, { fetch: ['abc', 'def'] }, 'query object matches');
     return new Promise(function(resolve, reject) {
       resolve(['a', 'b', 'c']);
     });
@@ -102,7 +102,7 @@ test('`query` event should receive results as the last argument, even if they ar
 
   source.on('query', (query, result) => {
     equal(++order, 2, 'query triggered after action performed successfully');
-    assert.deepEqual(query, { fetch: ['abc', 'def'] }, 'query matches');
+    assert.deepEqual(query.expression, { fetch: ['abc', 'def'] }, 'query matches');
     assert.deepEqual(result, ['a', 'b', 'c'], 'result matches');
   });
 
@@ -120,7 +120,7 @@ test('it should trigger `queryFail` event after an unsuccessful query', function
 
   source._query = function(query) {
     assert.equal(++order, 1, 'action performed after willQuery');
-    assert.deepEqual(query, { fetch: ['abc', 'def'] }, 'query object matches');
+    assert.deepEqual(query.expression, { fetch: ['abc', 'def'] }, 'query object matches');
     return failedOperation();
   };
 
@@ -130,7 +130,7 @@ test('it should trigger `queryFail` event after an unsuccessful query', function
 
   source.on('queryFail', (query, error) => {
     assert.equal(++order, 2, 'queryFail triggered after an unsuccessful query');
-    assert.deepEqual(query, { fetch: ['abc', 'def'] }, 'query matches');
+    assert.deepEqual(query.expression, { fetch: ['abc', 'def'] }, 'query matches');
     assert.equal(error, ':(', 'error matches');
   });
 

--- a/test/tests/orbit/unit/transform-test.js
+++ b/test/tests/orbit/unit/transform-test.js
@@ -4,93 +4,94 @@ import { TransformBuilderNotRegisteredException } from 'orbit/lib/exceptions';
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('Orbit - Transform', {
-});
+module('Orbit', function() {
+  module('Transform', function() {
+    test('it exists', function(assert) {
+      let transform = new Transform();
+      assert.ok(transform);
+    });
 
-test('it exists', function(assert) {
-  let transform = new Transform();
-  assert.ok(transform);
-});
+    test('#isEmpty returns true if no operations have been added', function(assert) {
+      assert.expect(2);
 
-test('#isEmpty returns true if no operations have been added', function(assert) {
-  assert.expect(2);
+      let emptyTransform = new Transform();
+      assert.equal(emptyTransform.isEmpty(), true);
 
-  let emptyTransform = new Transform();
-  assert.equal(emptyTransform.isEmpty(), true);
+      let fullTransform = new Transform([
+        { op: 'addRecord', record: { type: 'planet', id: '2' } }
+      ]);
+      assert.equal(fullTransform.isEmpty(), false);
+    });
 
-  let fullTransform = new Transform([
-    { op: 'addRecord', record: { type: 'planet', id: '2' } }
-  ]);
-  assert.equal(fullTransform.isEmpty(), false);
-});
+    test('it is assigned an `id`', function(assert) {
+      let transform = new Transform();
+      assert.ok(transform.id, 'transform has an id');
+    });
 
-test('it is assigned an `id`', function(assert) {
-  let transform = new Transform();
-  assert.ok(transform.id, 'transform has an id');
-});
-
-test('can be created from with all attributes specified as options', function(assert) {
-  let operations = [];
-  let options = { id: 'abc123' };
-
-  let transform = new Transform(operations, options);
-
-  assert.strictEqual(transform.id, options.id, 'id was populated');
-  assert.deepEqual(transform.operations, operations, 'operations was populated');
-});
-
-test('.from will return a transform passed into it', function(assert) {
-  let transform = new Transform();
-  assert.strictEqual(Transform.from(transform), transform);
-});
-
-test('.from will create a transform from operations passed into it', function(assert) {
-  let transform = Transform.from([{ op: 'addRecord' }, { op: 'removeRecord' }]);
-  assert.ok(transform instanceof Transform);
-});
-
-test('.from should pass any transform functions to transformBuilder, if one is passed', function(assert) {
-  assert.expect(5);
-
-  const planet = { type: 'planet', id: '1' };
-  const moon = { type: 'moon', id: '1' };
-
-  const transformBuilder = {
-    build(b) {
+    test('can be created from with all attributes specified as options', function(assert) {
       let operations = [];
+      let options = { id: 'abc123' };
 
-      let context = {
-        addRecord(record) {
-          assert.ok(record, 'transformBuilder.addRecord called');
-          operations.push({ op: 'addRecord', record: record });
+      let transform = new Transform(operations, options);
+
+      assert.strictEqual(transform.id, options.id, 'id was populated');
+      assert.deepEqual(transform.operations, operations, 'operations was populated');
+    });
+
+    test('.from will return a transform passed into it', function(assert) {
+      let transform = new Transform();
+      assert.strictEqual(Transform.from(transform), transform);
+    });
+
+    test('.from will create a transform from operations passed into it', function(assert) {
+      let transform = Transform.from([{ op: 'addRecord' }, { op: 'removeRecord' }]);
+      assert.ok(transform instanceof Transform);
+    });
+
+    test('.from should pass any transform functions to transformBuilder, if one is passed', function(assert) {
+      assert.expect(5);
+
+      const planet = { type: 'planet', id: '1' };
+      const moon = { type: 'moon', id: '1' };
+
+      const transformBuilder = {
+        build(b) {
+          let operations = [];
+
+          let context = {
+            addRecord(record) {
+              assert.ok(record, 'transformBuilder.addRecord called');
+              operations.push({ op: 'addRecord', record: record });
+            }
+          };
+
+          assert.ok(b, 'transformBuilder called');
+
+          b(context);
+
+          return new Transform(operations);
         }
       };
 
-      assert.ok(b, 'transformBuilder called');
+      let transform = Transform.from(
+        (b) => {
+          b.addRecord(planet);
+          b.addRecord(moon);
+        },
+        transformBuilder
+      );
 
-      b(context);
+      assert.ok(transform instanceof Transform, 'built a Transform');
+      assert.equal(transform.operations.length, 2, 'transform includes two operations');
+    });
 
-      return new Transform(operations);
-    }
-  };
-
-  let transform = Transform.from(
-    (b) => {
-      b.addRecord(planet);
-      b.addRecord(moon);
-    },
-    transformBuilder
-  );
-
-  assert.ok(transform instanceof Transform, 'built a Transform');
-  assert.equal(transform.operations.length, 2, 'transform includes two operations');
-});
-
-test('.from should throw an exception if a function is passed but a transformBuilder is not', function(assert) {
-  assert.throws(
-    () => {
-      Transform.from((b) => {});
-    },
-    TransformBuilderNotRegisteredException
-  );
+    test('.from should throw an exception if a function is passed but a transformBuilder is not', function(assert) {
+      assert.throws(
+        () => {
+          Transform.from((b) => {});
+        },
+        TransformBuilderNotRegisteredException
+      );
+    });
+  });
 });

--- a/test/tests/orbit/unit/transform/builder-test.js
+++ b/test/tests/orbit/unit/transform/builder-test.js
@@ -6,27 +6,31 @@ import Transform from 'orbit/transform';
 
 let builder;
 
-module('Orbit - Transform - Builder', {
-  setup() {
-    builder = new Builder();
-  },
+module('Orbit', function() {
+  module('Transform', function() {
+    module('Builder', {
+      setup() {
+        builder = new Builder();
+      },
 
-  teardown() {
-    builder = null;
-  }
-});
+      teardown() {
+        builder = null;
+      }
+    }, function() {
+      test('exists', function(assert) {
+        assert.ok(builder, 'it exists');
+      });
 
-test('exists', function(assert) {
-  assert.ok(builder, 'it exists');
-});
+      test('#build - takes a function and returns a Transform instance (empty by default)', function(assert) {
+        assert.expect(3);
 
-test('#build - takes a function and returns a Transform instance (empty by default)', function(assert) {
-  assert.expect(3);
+        let t = builder.build((b) => {
+          assert.ok(b.transform instanceof Transform);
+        });
 
-  let t = builder.build((b) => {
-    assert.ok(b.transform instanceof Transform);
+        assert.ok(t instanceof Transform);
+        assert.deepEqual(t.operations, [], 'has no operations by default');
+      });
+    });
   });
-
-  assert.ok(t instanceof Transform);
-  assert.deepEqual(t.operations, [], 'has no operations by default');
 });


### PR DESCRIPTION
Queries are used to extract data from a source.

The Query class mirrors the Transform class - it also assigns an `id` to each `query` and supports `Query.from` as well as the use of builders.