### PR TITLE
Refactor builders to use operators property.

### DIFF
--- a/lib/orbit-common/query/builder.js
+++ b/lib/orbit-common/query/builder.js
@@ -1,7 +1,7 @@
 import { merge } from 'orbit/lib/objects';
-import { queryExpression as oqe } from 'orbit/query/expression';
 import OrbitQueryBuilder from 'orbit/query/builder';
 import { Records } from 'orbit-common/query/terms';
+import Operators from './operators';
 
 function _createTypeTerms(typeOptions) {
   if (!typeOptions) { return {}; }
@@ -16,24 +16,16 @@ function _createTypeTerms(typeOptions) {
   return typeTerms;
 }
 
-const defaultTerms = {
-  recordsOfType(type) {
-    const TypeTerm = this._typeTerms[type] || Records;
-
-    return new TypeTerm(oqe('recordsOfType', type));
-  }
-};
-
 export default class QueryBuilder extends OrbitQueryBuilder {
   constructor(options = {}) {
     super(options);
 
-    this.terms = merge(this.terms, defaultTerms);
+    this.operators = merge(this.operators, Operators);
 
-    if (options.terms) {
-      this.terms._typeTerms = _createTypeTerms(options.terms.recordsOfType);
+    if (options.operators) {
+      this.operators._typeTerms = _createTypeTerms(options.operators.recordsOfType);
     } else {
-      this.terms._typeTerms = {};
+      this.operators._typeTerms = {};
     }
   }
 }

--- a/lib/orbit-common/query/operators.js
+++ b/lib/orbit-common/query/operators.js
@@ -1,0 +1,10 @@
+import { queryExpression as oqe } from 'orbit/query/expression';
+import { Records } from 'orbit-common/query/terms';
+
+export default {
+  recordsOfType(type) {
+    const TypeTerm = this._typeTerms[type] || Records;
+
+    return new TypeTerm(oqe('recordsOfType', type));
+  }
+};

--- a/lib/orbit-common/transform/builder.js
+++ b/lib/orbit-common/transform/builder.js
@@ -1,39 +1,10 @@
+import { merge } from 'orbit/lib/objects';
 import OrbitTransformBuilder from 'orbit/transform/builder';
+import Operators from './operators';
 
 export default class TransformBuilder extends OrbitTransformBuilder {
-  addRecord(record) {
-    this.transform.operations.push({ op: 'addRecord', record });
-  }
-
-  replaceRecord(record) {
-    this.transform.operations.push({ op: 'replaceRecord', record });
-  }
-
-  removeRecord(record) {
-    this.transform.operations.push({ op: 'removeRecord', record });
-  }
-
-  replaceKey(record, key, value) {
-    this.transform.operations.push({ op: 'replaceKey', record, key, value });
-  }
-
-  replaceAttribute(record, attribute, value) {
-    this.transform.operations.push({ op: 'replaceAttribute', record, attribute, value });
-  }
-
-  addToHasMany(record, relationship, relatedRecord) {
-    this.transform.operations.push({ op: 'addToHasMany', record, relationship, relatedRecord });
-  }
-
-  removeFromHasMany(record, relationship, relatedRecord) {
-    this.transform.operations.push({ op: 'removeFromHasMany', record, relationship, relatedRecord });
-  }
-
-  replaceHasMany(record, relationship, relatedRecords) {
-    this.transform.operations.push({ op: 'replaceHasMany', record, relationship, relatedRecords });
-  }
-
-  replaceHasOne(record, relationship, relatedRecord) {
-    this.transform.operations.push({ op: 'replaceHasOne', record, relationship, relatedRecord });
+  constructor() {
+    super();
+    this.operators = merge(this.operators, Operators);
   }
 }

--- a/lib/orbit-common/transform/operators.js
+++ b/lib/orbit-common/transform/operators.js
@@ -1,0 +1,46 @@
+export default {
+  addRecord(record) {
+    this.operations.push({ op: 'addRecord', record });
+    return this;
+  },
+
+  replaceRecord(record) {
+    this.operations.push({ op: 'replaceRecord', record });
+    return this;
+  },
+
+  removeRecord(record) {
+    this.operations.push({ op: 'removeRecord', record });
+    return this;
+  },
+
+  replaceKey(record, key, value) {
+    this.operations.push({ op: 'replaceKey', record, key, value });
+    return this;
+  },
+
+  replaceAttribute(record, attribute, value) {
+    this.operations.push({ op: 'replaceAttribute', record, attribute, value });
+    return this;
+  },
+
+  addToHasMany(record, relationship, relatedRecord) {
+    this.operations.push({ op: 'addToHasMany', record, relationship, relatedRecord });
+    return this;
+  },
+
+  removeFromHasMany(record, relationship, relatedRecord) {
+    this.operations.push({ op: 'removeFromHasMany', record, relationship, relatedRecord });
+    return this;
+  },
+
+  replaceHasMany(record, relationship, relatedRecords) {
+    this.operations.push({ op: 'replaceHasMany', record, relationship, relatedRecords });
+    return this;
+  },
+
+  replaceHasOne(record, relationship, relatedRecord) {
+    this.operations.push({ op: 'replaceHasOne', record, relationship, relatedRecord });
+    return this;
+  }
+};

--- a/lib/orbit/query/builder.js
+++ b/lib/orbit/query/builder.js
@@ -2,27 +2,14 @@ import { merge } from 'orbit/lib/objects';
 import { queryExpression as oqe } from './expression';
 import { Value } from './terms';
 import Query from '../query';
-
-const defaultTerms = {
-  get(path) {
-    return new Value(oqe('get', path));
-  },
-
-  or(a, b) {
-    return oqe('or', a, b);
-  },
-
-  and(a, b) {
-    return oqe('and', a, b);
-  }
-};
+import Operators from './operators';
 
 export default class QueryBuilder {
   constructor(options = {}) {
-    this.terms = defaultTerms;
+    this.operators = Operators;
   }
 
   build(fn) {
-    return Query.from(fn(this.terms).expression);
+    return Query.from(fn(this.operators).expression);
   }
 }

--- a/lib/orbit/query/operators.js
+++ b/lib/orbit/query/operators.js
@@ -1,0 +1,16 @@
+import { queryExpression as oqe } from './expression';
+import { Value } from './terms';
+
+export default {
+  get(path) {
+    return new Value(oqe('get', path));
+  },
+
+  or(a, b) {
+    return oqe('or', a, b);
+  },
+
+  and(a, b) {
+    return oqe('and', a, b);
+  }
+};

--- a/lib/orbit/transform/builder.js
+++ b/lib/orbit/transform/builder.js
@@ -1,11 +1,15 @@
 import Transform from '../transform';
 
 export default class TransformBuilder {
+  constructor() {
+    this.operators = {};
+  }
+
   build(fn) {
-    this.transform = new Transform();
+    this.operators.operations = [];
 
-    fn(this);
+    fn(this.operators);
 
-    return this.transform;
+    return Transform.from(this.operators.operations);
   }
 }

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -50,9 +50,7 @@ test('#transform sets data and #get retrieves it', function(assert) {
 
   const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
 
-  cache.transform(t => {
-    t.addRecord(earth);
-  });
+  cache.transform(t => t.addRecord(earth));
 
   assert.deepEqual(cache.get('planet/1'), earth, 'objects match in value');
   assert.notStrictEqual(cache.get('planet/1'), earth, 'objects don\'t match by reference because a clone has been cached');
@@ -63,9 +61,7 @@ test('#has indicates whether a path exists', function(assert) {
 
   const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
 
-  cache.transform(t => {
-    t.addRecord(earth);
-  });
+  cache.transform(t => t.addRecord(earth));
 
   assert.equal(cache.has('planet'), true, 'path exists');
   assert.equal(cache.has('planet/1'), true, 'path exists');
@@ -79,9 +75,7 @@ test('#hasDeleted by default just returns the inverse of #has', function(assert)
 
   const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
 
-  cache.transform(t => {
-    t.addRecord(earth);
-  });
+  cache.transform(t => t.addRecord(earth));
 
   assert.equal(cache.hasDeleted('planet'), !cache.has('planet'), 'path exists');
   assert.equal(cache.hasDeleted('planet/1'), !cache.has('planet/1'), 'path exists');
@@ -138,9 +132,7 @@ test('#length returns the size of data at a path', function(assert) {
 
   assert.equal(cache.length('planet'), 2, 'returns count of objects at a path');
 
-  cache.transform(t => {
-    t.replaceAttribute({ type: 'planet', id: '1' }, 'stuff', ['a', 'b', 'c']);
-  });
+  cache.transform(t => t.replaceAttribute({ type: 'planet', id: '1' }, 'stuff', ['a', 'b', 'c']));
 
   assert.equal(cache.length('planet/1/attributes/stuff'), 3, 'returns size of an array at a path');
 });
@@ -148,9 +140,7 @@ test('#length returns the size of data at a path', function(assert) {
 test('#reset clears the cache by default', function(assert) {
   cache = new Cache(schema);
 
-  cache.transform(t => {
-    t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } });
-  });
+  cache.transform(t => t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } }));
 
   cache.reset();
 
@@ -160,9 +150,7 @@ test('#reset clears the cache by default', function(assert) {
 test('#reset overrides the cache completely with the value specified', function(assert) {
   cache = new Cache(schema);
 
-  cache.transform(t => {
-    t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } });
-  });
+  cache.transform(t => t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } }));
 
   const newData = { planet: { '2': { type: 'planet', id: '2', attributes: { name: 'Mars' } } } };
 
@@ -189,11 +177,9 @@ test('#transform tracks refs and clears them from hasOne relationships when a re
   const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: 'planet:p1' } } };
   const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: 'planet:p1' } } };
 
-  cache.transform(t => {
-    t.addRecord(jupiter);
-    t.addRecord(io);
-    t.addRecord(europa);
-  });
+  cache.transform(t => t.addRecord(jupiter)
+                        .addRecord(io)
+                        .addRecord(europa));
 
   assert.equal(cache.get('moon/m1/relationships/planet/data'), 'planet:p1', 'Jupiter has been assigned to Io');
   assert.equal(cache.get('moon/m2/relationships/planet/data'), 'planet:p1', 'Jupiter has been assigned to Europa');
@@ -215,24 +201,18 @@ test('#transform tracks refs and clears them from hasMany relationships when a r
   var europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
   var jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: { 'moon:m1': true, 'moon:m2': true } } } };
 
-  cache.transform(t => {
-    t.addRecord(io);
-    t.addRecord(europa);
-    t.addRecord(jupiter);
-  });
+  cache.transform(t => t.addRecord(io)
+                        .addRecord(europa)
+                        .addRecord(jupiter));
 
   assert.equal(cache.get('planet/p1/relationships/moons/data/moon:m1'), true, 'Jupiter has been assigned to Io');
   assert.equal(cache.get('planet/p1/relationships/moons/data/moon:m2'), true, 'Jupiter has been assigned to Europa');
 
-  cache.transform(t => {
-    t.removeRecord(io);
-  });
+  cache.transform(t => t.removeRecord(io));
 
   assert.equal(cache.get('moon/m1'), null, 'Io is GONE');
 
-  cache.transform(t => {
-    t.removeRecord(europa);
-  });
+  cache.transform(t => t.removeRecord(europa));
 
   assert.equal(cache.get('moon/m2'), null, 'Europa is GONE');
 
@@ -243,9 +223,7 @@ test('#transform tracks refs and clears them from hasMany relationships when a r
 test('#transform adds link to hasMany if record doesn\'t exist', function(assert) {
   cache = new Cache(schema);
 
-  cache.transform(t => {
-    t.addToHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' });
-  });
+  cache.transform(t => t.addToHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' }));
 
   assert.equal(cache.get('planet/p1/relationships/moons/data/moon:moon1'), true, 'relationship was added');
 });
@@ -259,9 +237,7 @@ test('#transform does not remove link from hasMany if record doesn\'t exist', fu
     ok(false, 'no operations were applied');
   });
 
-  cache.transform(t => {
-    t.removeFromHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' });
-  });
+  cache.transform(t => t.removeFromHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' }));
 
   assert.equal(cache.get('planet/p1'), undefined, 'planet does not exist');
 });
@@ -311,17 +287,13 @@ test('#transform does not add link to hasMany if link already exists', function(
 
   const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: { data: { 'moon:m1': true } } } };
 
-  cache.transform(t => {
-    t.addRecord(jupiter);
-  });
+  cache.transform(t => t.addRecord(jupiter));
 
   cache.on('patch', (op) => {
     assert.ok(false, 'no operations were applied');
   });
 
-  cache.transform(t => {
-    t.addToHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' });
-  });
+  cache.transform(t => t.addToHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' }));
 
   assert.ok(true, 'transform completed');
 });
@@ -333,17 +305,13 @@ test('#transform does not remove relationship from hasMany if relationship doesn
 
   const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: {} } };
 
-  cache.transform(t => {
-    t.addRecord(jupiter);
-  });
+  cache.transform(t => t.addRecord(jupiter));
 
   cache.on('patch', (op) => {
     ok(false, 'no operations were applied');
   });
 
-  cache.transform(t => {
-    t.removeFromHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' });
-  });
+  cache.transform(t => t.removeFromHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' }));
 
   assert.ok(true, 'transform completed');
 });
@@ -355,17 +323,13 @@ test('does not replace hasOne if relationship already exists', function(assert) 
 
   const europa = { id: 'm1', type: 'moon', attributes: { name: 'Europa' }, relationships: { planet: { data: 'planet:p1' } } };
 
-  cache.transform(t => {
-    t.addRecord(europa);
-  });
+  cache.transform(t => t.addRecord(europa));
 
   cache.on('patch', (op) => {
     assert.ok(false, 'no operations were applied');
   });
 
-  cache.transform(t => {
-    t.replaceHasOne(europa, 'planet', { type: 'planet', id: 'p1' });
-  });
+  cache.transform(t => t.replaceHasOne(europa, 'planet', { type: 'planet', id: 'p1' }));
 
   assert.ok(true, 'transform completed');
 });
@@ -377,17 +341,13 @@ test('does not remove hasOne if relationship doesn\'t exist', function(assert) {
 
   const europa = { type: 'moon', id: 'm1', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
 
-  cache.transform(t => {
-    t.addRecord(europa);
-  });
+  cache.transform(t => t.addRecord(europa));
 
   cache.on('patch', (op) => {
     assert.ok(false, 'no operations were applied');
   });
 
-  cache.transform(t => {
-    t.replaceHasOne(europa, 'planet', null);
-  });
+  cache.transform(t => t.replaceHasOne(europa, 'planet', null));
 
   assert.ok(true, 'transform completed');
 });
@@ -417,8 +377,7 @@ test('#transform removing model with a bi-directional hasOne', function(assert) 
       relationships: {
         two: { data: null }
       }
-    });
-    t.addRecord({
+    }).addRecord({
       id: '2',
       type: 'two',
       relationships: {
@@ -434,9 +393,7 @@ test('#transform removing model with a bi-directional hasOne', function(assert) 
   assert.equal(one.relationships.two.data, 'two:2', 'one links to two');
   assert.equal(two.relationships.one.data, 'one:1', 'two links to one');
 
-  cache.transform(t => {
-    t.removeRecord(two);
-  });
+  cache.transform(t => t.removeRecord(two));
 
   assert.strictEqual(one.relationships.two.data, null, 'ones link to two got removed');
 });
@@ -473,9 +430,7 @@ test('#transform removes dependent records', function(assert) {
   });
 
   // Removing the moon should remove the planet should remove the other moon
-  cache.transform(t => {
-    t.removeRecord(io);
-  });
+  cache.transform(t => t.removeRecord(io));
 
   // TODO-investigate why there's still a moon left
   // assert.equal(cache.length('moon'), 0, 'No moons left in store');
@@ -504,18 +459,16 @@ test('#transform does not remove non-dependent records', function() {
   const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: 'planet:p1' } } };
 
   cache.transform(t => {
-    t.addRecord(jupiter);
-    t.addRecord(io);
-    t.addRecord(europa);
-    t.addToHasMany(jupiter, 'moons', io);
-    t.addToHasMany(jupiter, 'moons', europa);
+    t.addRecord(jupiter)
+     .addRecord(io)
+     .addRecord(europa)
+     .addToHasMany(jupiter, 'moons', io)
+     .addToHasMany(jupiter, 'moons', europa);
   });
 
   // Since there are no dependent relationships, no other records will be
   // removed
-  cache.transform(t => {
-    t.removeRecord(io);
-  });
+  cache.transform(t => t.removeRecord(io));
 
   equal(cache.length('moon'), 1, 'One moon left in store');
   equal(cache.length('planet'), 1, 'One planet left in store');

--- a/test/tests/orbit-common/unit/cache/operation-processors/deletion-tracking-processor-test.js
+++ b/test/tests/orbit-common/unit/cache/operation-processors/deletion-tracking-processor-test.js
@@ -69,7 +69,7 @@ test('tracks deletions and makes them queryable through `hasDeleted`', function(
 
   assert.equal(cache.hasDeleted('planet/saturn'), false, 'Saturn has not been deleted yet');
 
-  cache.transform((t) => t.removeRecord(saturn));
+  cache.transform(t => t.removeRecord(saturn));
 
   assert.equal(cache.hasDeleted('planet/saturn'), true, 'Saturn has been deleted');
   assert.equal(cache.hasDeleted('planet/jupiter'), false, 'Jupiter has not been deleted');

--- a/test/tests/orbit-common/unit/query/builder-test.js
+++ b/test/tests/orbit-common/unit/query/builder-test.js
@@ -109,7 +109,7 @@ module('OC - QueryBuilder', function(hooks) {
     };
 
     const qb = new QueryBuilder({
-      terms: {
+      operators: {
         recordsOfType: { planet: planetScopes }
       }
     });

--- a/test/tests/orbit-common/unit/transform/builder-test.js
+++ b/test/tests/orbit-common/unit/transform/builder-test.js
@@ -134,10 +134,8 @@ test('can add multiple operations', function(assert) {
 
   let europa = { type: 'moon', id: 'Europa' };
 
-  let transform = builder.build((b) => {
-    b.addToHasMany(record, 'moons', io);
-    b.addToHasMany(record, 'moons', europa);
-  });
+  let transform = builder.build(b => b.addToHasMany(record, 'moons', io)
+                                      .addToHasMany(record, 'moons', europa));
 
   assert.deepEqual(transform.operations, [
     { op: 'addToHasMany', record, relationship: 'moons', relatedRecord: io },

--- a/test/tests/orbit/unit/transform/builder-test.js
+++ b/test/tests/orbit/unit/transform/builder-test.js
@@ -24,12 +24,12 @@ module('Orbit', function() {
       test('#build - takes a function and returns a Transform instance (empty by default)', function(assert) {
         assert.expect(3);
 
-        let t = builder.build((b) => {
-          assert.ok(b.transform instanceof Transform);
+        let transform = builder.build(t => {
+          assert.deepEqual(t.operations, [], 'transform builder has no operations');
         });
 
-        assert.ok(t instanceof Transform);
-        assert.deepEqual(t.operations, [], 'has no operations by default');
+        assert.ok(transform instanceof Transform, 'a Transform instance is returned');
+        assert.deepEqual(transform.operations, [], 'built transform has no operations');
       });
     });
   });


### PR DESCRIPTION
TransformBuilder and QueryBuilder now define operators on an
`operators` property.

Furthermore, each operator should return `operators`, which allows
operations to be chained.