### PR TITLE
Allow QueryBuilder to register custom terms.

### DIFF
--- a/lib/orbit-common/query/builder.js
+++ b/lib/orbit-common/query/builder.js
@@ -1,31 +1,12 @@
 import { merge } from 'orbit/lib/objects';
 import OrbitQueryBuilder from 'orbit/query/builder';
 import Operators from './operators';
-import { Records } from 'orbit-common/query/terms';
-
-function _createTypeTerms(typeOptions) {
-  if (!typeOptions) { return {}; }
-
-  const typeTerms = {};
-
-  Object.keys(typeOptions).forEach(type => {
-    const scopes = typeOptions[type];
-    typeTerms[type] = Records.withScopes(scopes);
-  });
-
-  return typeTerms;
-}
 
 export default class QueryBuilder extends OrbitQueryBuilder {
   constructor(options = {}) {
     super(options);
 
     this.operators = merge(this.operators, Operators);
-
-    if (options.operators) {
-      this.operators._typeTerms = _createTypeTerms(options.operators.recordsOfType);
-    } else {
-      this.operators._typeTerms = {};
-    }
+    this.operators._terms = merge(this.operators._terms || {}, options.terms || {});
   }
 }

--- a/lib/orbit-common/query/operators.js
+++ b/lib/orbit-common/query/operators.js
@@ -1,9 +1,10 @@
+import { capitalize } from 'orbit/lib/strings';
 import { queryExpression as oqe } from 'orbit/query/expression';
 import { Records, Record } from 'orbit-common/query/terms';
 
 export default {
   recordsOfType(type) {
-    const TypeTerm = this._typeTerms[type] || Records;
+    const TypeTerm = this._terms[`${ capitalize(type) }Records`] || Records;
 
     return new TypeTerm(oqe('recordsOfType', type));
   },

--- a/test/tests/orbit-common/unit/query/builder-test.js
+++ b/test/tests/orbit-common/unit/query/builder-test.js
@@ -1,6 +1,7 @@
 import 'tests/test-helper';
 import { queryExpression as oqe } from 'orbit/query/expression';
 import QueryBuilder from 'orbit-common/query/builder';
+import { Records } from 'orbit-common/query/terms';
 
 module('OC - QueryBuilder', function(hooks) {
   let qb;
@@ -102,16 +103,14 @@ module('OC - QueryBuilder', function(hooks) {
   });
 
   test('recordsOfType with scopes', function(assert) {
-    const planetScopes = {
+    class PlanetRecords extends Records {
       namedPluto() {
         return this.filterAttributes({ name: 'Pluto' });
       }
-    };
+    }
 
     const qb = new QueryBuilder({
-      operators: {
-        recordsOfType: { planet: planetScopes }
-      }
+      terms: { PlanetRecords }
     });
 
     assert.deepEqual(


### PR DESCRIPTION
Provides cleaner and more flexible custom scopes and other usages of
custom terms from within operators.