### PR TITLE
Update Transaction with coalesce method and fixes.

### DIFF
--- a/lib/orbit-common/transaction.js
+++ b/lib/orbit-common/transaction.js
@@ -25,6 +25,7 @@ import { coalesceOperations } from 'orbit-common/lib/operations';
  @param {Object}    [options]
  @param {OC.Store}  [options.baseStore] The transaction's base store (required).
  @param {Boolean}   [options.active=true] Should this transaction begin immediately on creation?
+ @param {Boolean}   [options.autoCoalesce=true] Should operations be coalesced automatically on commit?
  @constructor
  */
 export default class Transaction extends Store {
@@ -38,8 +39,7 @@ export default class Transaction extends Store {
 
     this.baseStore = options.baseStore;
     this.active = false;
-    this.operations = null;
-    this.inverseOperations = null;
+    this.autoCoalesce = options.autoCoalesce === undefined ? true : options.autoCoalesce;
 
     if (options.active !== false) {
       this.begin();
@@ -48,7 +48,6 @@ export default class Transaction extends Store {
 
   begin() {
     this.operations = [];
-    this.inverseOperations = [];
 
     this._activate();
   }
@@ -56,14 +55,15 @@ export default class Transaction extends Store {
   commit() {
     this._deactivate();
 
-    var operations = this.operations;
-
-    if (operations.length > 0) {
-      operations = coalesceOperations(operations);
-      return this.baseStore.transform(operations);
-    } else {
-      return Orbit.Promise.resolve();
+    if (this.autoCoalesce) {
+      this.coalesce();
     }
+
+    return this.baseStore.update(this.operations);
+  }
+
+  coalesce() {
+    this.operations = coalesceOperations(this.operations);
   }
 
   _activate() {


### PR DESCRIPTION
New `autoCoalesce` option determines whether operations are coalesced
automatically on `commit()`.

New `coalesce` method performs coalescing of operations at any point.

Inverse operations are no longer tracked.