### PR TITLE
Query builder and expressions support record identity.

### DIFF
--- a/lib/orbit-common/cache/live-query-operators.js
+++ b/lib/orbit-common/cache/live-query-operators.js
@@ -1,7 +1,7 @@
 import { eq } from 'orbit/lib/eq';
 import { parseIdentifier } from 'orbit-common/lib/identifiers';
 import { queryExpression as oqe } from 'orbit/query/expression';
-import { toIdentifier } from 'orbit-common/lib/identifiers';
+import { toIdentifier, eqIdentity } from 'orbit-common/lib/identifiers';
 import Query from 'orbit/query';
 
 function extractRecordFromHasOne(value) {
@@ -107,11 +107,9 @@ export default {
     return Rx.Observable.concat(membershipChanges, memberUpdates);
   },
 
-  record(context, type, recordId) {
+  record(context, record) {
     return this.target.patches.filter(operation => {
-      const record = operation.record;
-
-      return record.type === type && record.id === recordId;
+      return eqIdentity(operation.record, record);
     });
   },
 

--- a/lib/orbit-common/cache/query-operators.js
+++ b/lib/orbit-common/cache/query-operators.js
@@ -58,12 +58,12 @@ export default {
     return matches;
   },
 
-  record(context, type, recordId) {
+  record(context, recordIdentity) {
     const cache = this.target;
-    const record = cache.get([type, recordId]);
+    const record = cache.get([recordIdentity.type, recordIdentity.id]);
 
     if (!record) {
-      throw new RecordNotFoundException(`Record not found ${type}:${recordId}`);
+      throw new RecordNotFoundException(`Record not found ${recordIdentity.type}:${recordIdentity.id}`);
     }
 
     return record;
@@ -84,9 +84,9 @@ export default {
     return records;
   },
 
-  relatedRecords(context, type, recordId, relationship) {
+  relatedRecords(context, record, relationship) {
     const cache = this.target;
-    const data = cache.get([type, recordId, 'relationships', relationship, 'data']);
+    const data = cache.get([record.type, record.id, 'relationships', relationship, 'data']);
     const results = {};
 
     Object.keys(data || {}).forEach(identifier => {
@@ -97,9 +97,9 @@ export default {
     return results;
   },
 
-  relatedRecord(context, type, recordId, relationship) {
+  relatedRecord(context, record, relationship) {
     const cache = this.target;
-    const data = cache.get([type, recordId, 'relationships', relationship, 'data']);
+    const data = cache.get([record.type, record.id, 'relationships', relationship, 'data']);
 
     if (!data) { return null; }
 

--- a/lib/orbit-common/jsonapi/fetch-requests.js
+++ b/lib/orbit-common/jsonapi/fetch-requests.js
@@ -35,16 +35,16 @@ export const FetchRequestProcessors = {
   },
 
   record(source, request) {
-    const { type, id } = request;
+    const { record } = request;
 
-    return source.ajax(source.resourceURL(type, id), 'GET')
+    return source.ajax(source.resourceURL(record.type, record.id), 'GET')
       .then(data => deserialize(source, data));
   },
 
   relationship(source, request) {
-    const { type, id, relationship } = request;
+    const { record, relationship } = request;
 
-    return source.ajax(source.resourceRelationshipURL(type, id, relationship), 'GET')
+    return source.ajax(source.resourceRelationshipURL(record.type, record.id, relationship), 'GET')
       .then(raw => {
         let relId = source.serializer.deserializeRelationship(raw.data);
         return relId;
@@ -52,9 +52,9 @@ export const FetchRequestProcessors = {
   },
 
   relatedRecords(source, request) {
-    const { type, id, relationship } = request;
+    const { record, relationship } = request;
 
-    return source.ajax(source.relatedResourceURL(type, id, relationship), 'GET')
+    return source.ajax(source.relatedResourceURL(record.type, record.id, relationship), 'GET')
       .then(data => deserialize(source, data));
   }
 };
@@ -90,8 +90,7 @@ const ExpressionToRequestMap = {
     }
 
     request.op = 'record';
-    request.type = expression.args[0];
-    request.id = expression.args[1];
+    request.record = expression.args[0];
   },
 
   filter(expression, request) {

--- a/lib/orbit-common/query/operators.js
+++ b/lib/orbit-common/query/operators.js
@@ -9,16 +9,16 @@ export default {
     return new TypeTerm(oqe('recordsOfType', type));
   },
 
-  record(type, id) {
-    return new Record(type, id);
+  record(recordIdentity) {
+    return new Record(recordIdentity);
   },
 
-  relatedRecord(type, id, relationship) {
-    return new RelatedRecord(type, id, relationship);
+  relatedRecord(record, relationship) {
+    return new RelatedRecord(record, relationship);
   },
 
-  relatedRecords(type, id, relationship) {
-    return new RelatedRecords(type, id, relationship);
+  relatedRecords(record, relationship) {
+    return new RelatedRecords(record, relationship);
   },
 
   or(a, b) {

--- a/lib/orbit-common/query/terms.js
+++ b/lib/orbit-common/query/terms.js
@@ -12,8 +12,8 @@ export class RecordCursor extends Cursor {
 }
 
 export class Record extends TermBase {
-  constructor(type, id) {
-    super(oqe('record', type, id));
+  constructor(record) {
+    super(oqe('record', record));
   }
 }
 
@@ -49,13 +49,13 @@ export class Records extends TermBase {
 }
 
 export class RelatedRecord extends TermBase {
-  constructor(type, id, relationship) {
-    super(oqe('relatedRecord', type, id, relationship));
+  constructor(record, relationship) {
+    super(oqe('relatedRecord', record.type, record.id, relationship));
   }
 }
 
 export class RelatedRecords extends TermBase {
-  constructor(type, id, relationship) {
-    super(oqe('relatedRecords', type, id, relationship));
+  constructor(record, relationship) {
+    super(oqe('relatedRecords', record.type, record.id, relationship));
   }
 }

--- a/test/tests/integration/jsonapi-test.js
+++ b/test/tests/integration/jsonapi-test.js
@@ -289,7 +289,7 @@ module('Integration - JSONAPI', function(hooks) {
     server.respondWith('GET', '/planets/12345', jsonResponse(200, { data }));
 
     return store
-      .query(q => q.record('planet', '12345'))
+      .query(q => q.record({ type: 'planet', id: '12345' }))
       .then(record => {
         assert.equal(record.type, 'planet');
         assert.equal(record.id, '12345');

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -481,7 +481,7 @@ test('#query can retrieve an individual record with `record`', function(assert) 
   cache.reset({ planet: { jupiter } });
 
   assert.deepEqual(
-    cache.query(oqe('record', 'planet', 'jupiter')),
+    cache.query(oqe('record', { type: 'planet', id: 'jupiter' })),
     jupiter
   );
 });
@@ -572,7 +572,7 @@ test('#query - record', function(assert) {
   cache.reset({ planet: { jupiter } });
 
   assert.deepEqual(
-    cache.query(oqe('record', 'planet', 'jupiter')),
+    cache.query(oqe('record', { type: 'planet', id: 'jupiter' })),
     jupiter
   );
 });
@@ -588,7 +588,7 @@ test('#query - record - finds record', function(assert) {
   cache.reset({ planet: { jupiter } });
 
   assert.deepEqual(
-    cache.query(oqe('record', 'planet', 'jupiter')),
+    cache.query(oqe('record', { type: 'planet', id: 'jupiter' })),
     jupiter
   );
 });
@@ -597,7 +597,7 @@ test('#query - record - throws RecordNotFoundException if record doesn\'t exist'
   cache = new Cache(schema);
 
   assert.throws(
-    () => cache.query(oqe('record', 'planet', 'jupiter')),
+    () => cache.query(oqe('record', { type: 'planet', id: 'jupiter' })),
     new RecordNotFoundException('Record not found planet:jupiter')
   );
 });
@@ -648,7 +648,7 @@ test('#query - relatedRecords', function(assert) {
   cache.reset({ planet: { jupiter }, moon: { callisto } });
 
   assert.deepEqual(
-    cache.query(oqe('relatedRecords', 'planet', 'jupiter', 'moons')),
+    cache.query(oqe('relatedRecords', { type: 'planet', id: 'jupiter' }, 'moons')),
     {
       callisto
     }
@@ -671,7 +671,7 @@ test('#query - relatedRecord', function(assert) {
   cache.reset({ planet: { jupiter }, moon: { callisto } });
 
   assert.deepEqual(
-    cache.query(oqe('relatedRecord', 'moon', 'callisto', 'planet')),
+    cache.query(oqe('relatedRecord', { type: 'moon', id: 'callisto' }, 'planet')),
     {
       jupiter
     }

--- a/test/tests/orbit-common/unit/cache/live-queries-test.js
+++ b/test/tests/orbit-common/unit/cache/live-queries-test.js
@@ -220,7 +220,7 @@ module('OC - Cache - liveQuery', function(hooks) {
   test('record - responds to record added/removed', function(assert) {
     const done = assert.async();
 
-    const liveQuery = cache.liveQuery(q => q.record('planet', 'pluto'));
+    const liveQuery = cache.liveQuery(q => q.record({ type: 'planet', id: 'pluto' }));
 
     liveQuery.toArray().subscribe(operations => {
       assert.deepEqual(operations, [
@@ -245,7 +245,7 @@ module('OC - Cache - liveQuery', function(hooks) {
 
       cache.patches.subscribe(operation => console.log('patch', operation));
 
-      const liveQuery = cache.liveQuery(q => q.relatedRecord('moon', 'callisto', 'planet'));
+      const liveQuery = cache.liveQuery(q => q.relatedRecord({ type: 'moon', id: 'callisto' }, 'planet'));
 
       liveQuery.toArray().subscribe(operations => {
         assert.deepEqual(operations, [
@@ -269,7 +269,7 @@ module('OC - Cache - liveQuery', function(hooks) {
 
       cache.reset({ planet: { jupiter }, moon: { callisto } });
 
-      const liveQuery = cache.liveQuery(q => q.relatedRecords('planet', 'jupiter', 'moons'));
+      const liveQuery = cache.liveQuery(q => q.relatedRecords({ type: 'planet', id: 'jupiter' }, 'moons'));
 
       liveQuery.toArray().subscribe(operations => {
         assert.deepEqual(operations, [

--- a/test/tests/orbit-common/unit/jsonapi-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-source-test.js
@@ -435,7 +435,7 @@ test('#fetch - record', function(assert) {
                 JSON.stringify({ data }));
   });
 
-  return source.fetch(q => q.record('planet', planet.id))
+  return source.fetch(q => q.record({ type: 'planet', id: planet.id }))
     .then(transforms => {
       assert.equal(transforms.length, 1, 'one transform returned');
       assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);

--- a/test/tests/orbit-common/unit/memory-source-test.js
+++ b/test/tests/orbit-common/unit/memory-source-test.js
@@ -107,7 +107,7 @@ module('OC - MemorySource', function(hooks) {
 
     assert.equal(source.cache.length('planet'), 1, 'cache should contain one planet');
 
-    source.query(q => q.record('planet', '1'))
+    source.query(q => q.record({ type: 'planet', id: '1' }))
       .then(function(foundPlanet) {
         strictEqual(foundPlanet, jupiter, 'found planet matches original');
         done();

--- a/test/tests/orbit-common/unit/query/builder-test.js
+++ b/test/tests/orbit-common/unit/query/builder-test.js
@@ -12,9 +12,9 @@ module('OC - QueryBuilder', function(hooks) {
 
   test('record', function(assert) {
     assert.deepEqual(
-      qb.build(q => q.record('planet', '123')).expression,
+      qb.build(q => q.record({ type: 'planet', id: '123' })).expression,
 
-      oqe('record', 'planet', '123')
+      oqe('record', { type: 'planet', id: '123' })
     );
   });
 

--- a/test/tests/orbit-common/unit/store-test.js
+++ b/test/tests/orbit-common/unit/store-test.js
@@ -51,7 +51,7 @@ module('OC - Store', function(hooks) {
 
     store.on('fetchRequest', query => store.confirmFetch(query, [addRecordTransform]));
 
-    return store.query(q => q.record('planet', 'earth'))
+    return store.query(q => q.record({ type: 'planet', id: 'earth' }))
       .then(foundPlanet => assert.deepEqual(foundPlanet, earth, 'correct planet has been found'));
   });
 
@@ -60,7 +60,7 @@ module('OC - Store', function(hooks) {
 
     store.on('fetchRequest', query => store.confirmFetch(query, []));
 
-    return store.query(q => q.record('planet', 'earth'))
+    return store.query(q => q.record({ type: 'planet', id: 'earth' }))
       .catch(e => assert.ok(e instanceof RecordNotFoundException));
   });
 


### PR DESCRIPTION
Instead of accepting `type, id` args, the query expressions `record`,
`relatedRecord` and `relatedRecords` accept a `recordIdentity` arg.
This is an object of the form `{ type, id }`.

[Closes #285]