### PR TITLE
JSONAPISource should not register key mappings for `id`.

### DIFF
--- a/src/orbit-common/jsonapi/transform-requests.js
+++ b/src/orbit-common/jsonapi/transform-requests.js
@@ -13,7 +13,7 @@ export const TransformRequestProcessors = {
     return source.ajax(source.resourceURL(record.type), 'POST', { data: json })
       .then((raw) => {
         let resourceKey = serializer.resourceKey(record.type);
-        if (resourceKey) {
+        if (resourceKey && resourceKey !== 'id') {
           schema.registerKeyMapping(record.type, record.id, resourceKey, raw.data.id);
         }
 


### PR DESCRIPTION
Introduces a new test suite for JSONAPISource with no secondary keys in
the schema.