### PR TITLE
Eliminate uses of for...of

### DIFF
--- a/src/orbit-common/cache/query-operators.js
+++ b/src/orbit-common/cache/query-operators.js
@@ -5,38 +5,30 @@ import {
   RecordNotFoundException,
   ModelNotRegisteredException
 } from '../lib/exceptions';
+import { every, some } from 'orbit/lib/arrays';
+
+const EMPTY = () => {};
 
 export default {
   and(context, ...expressions) {
-    for (let expression of expressions) {
-      if (!this.evaluate(expression, context)) {
-        return false;
-      }
-    }
-    return true;
+    return every(expressions, (exp) => this.evaluate(exp, context));
   },
 
   or(context, ...expressions) {
-    for (let expression of expressions) {
-      if (!!this.evaluate(expression, context)) { return true; }
-    }
-    return false;
+    return some(expressions, (exp) => this.evaluate(exp, context));
   },
 
   equal(context, ...expressions) {
-    let value;
-    let valueSet = false;
+    let value = EMPTY;
 
-    for (let expression of expressions) {
-      if (!valueSet) {
+    return every(expressions, (expression) => {
+      if (value === EMPTY) {
         value = this.evaluate(expression, context);
-        valueSet = true;
-      } else if (value !== this.evaluate(expression, context)) {
-        return false;
+        return true;
       }
-    }
 
-    return true;
+      return value === this.evaluate(expression, context);
+    });
   },
 
   filter(context, select, where) {
@@ -45,7 +37,7 @@ export default {
     let eachContext;
     let matches = {};
 
-    for (let value of Object.keys(values)) {
+    Object.keys(values).forEach(value => {
       eachContext = merge(context, {
         basePath: basePath.concat(value)
       });
@@ -53,7 +45,7 @@ export default {
       if (this.evaluate(where, eachContext)) {
         matches[value] = values[value];
       }
-    }
+    });
 
     return matches;
   },

--- a/src/orbit/lib/arrays.js
+++ b/src/orbit/lib/arrays.js
@@ -1,0 +1,27 @@
+function every(array, predicate) {
+  let index = -1;
+  let length = array.length;
+
+  while (++index < length) {
+    if (!predicate(array[index], index)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function some(array, predicate) {
+  let index = -1;
+  let length = array.length;
+
+  while (++index < length) {
+    if (predicate(array[index], index)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export { every, some };


### PR DESCRIPTION
Babel's `for...of` relies on a polyfill for Symbol. Assuming `expressions` are just arrays, we can use other strategies. In particular, the need for an early return can be met with utility functions like `every` and `some`.

This removes our need for the Symbol polyfill and allows the tests for https://github.com/orbitjs/ember-orbit/pull/106 to pass.