### PR TITLE
Remove some Evented imports

### DIFF
--- a/src/orbit/queryable.js
+++ b/src/orbit/queryable.js
@@ -1,5 +1,4 @@
 import Orbit from './main';
-import Evented from './evented';
 import { extend } from './lib/objects';
 import Query from './query';
 

--- a/src/orbit/transform/queue.js
+++ b/src/orbit/transform/queue.js
@@ -1,9 +1,7 @@
-import Evented from 'orbit/evented';
 import ActionQueue from 'orbit/action-queue';
 
 export default class TransformQueue {
   constructor() {
-    Evented.extend(this);
     this._transforms = new ActionQueue();
   }
 

--- a/src/orbit/transformable.js
+++ b/src/orbit/transformable.js
@@ -1,5 +1,4 @@
 import Orbit from './main';
-import Evented from './evented';
 import { extend } from './lib/objects';
 import Transform from './transform';
 import TransformLog from './transform/log';


### PR DESCRIPTION
As I'm starting to explore replacing event emitter patterns with observables, I noticed there were a few places where `Evented` was imported but not used.

In 2 cases, the import is obviously unused. However `src/orbit/transform/queue.js` did extend `Evented` so this is less clear. It seems that `Queue` is intended to wrap an `ActionQueue` so this may be vestigial but this case needs some review to make sure I'm not removing an intentional public API. 