### PR TITLE
Refactor `recordsOfType` => `records`.

### DIFF
--- a/src/orbit-common/cache/live-query-operators.js
+++ b/src/orbit-common/cache/live-query-operators.js
@@ -12,7 +12,7 @@ function removeRecordOperation(record) {
 }
 
 export default {
-  recordsOfType(context, type) {
+  records(context, type) {
     return this.target.patches.matching({ record: { type } });
   },
 

--- a/src/orbit-common/cache/query-operators.js
+++ b/src/orbit-common/cache/query-operators.js
@@ -59,7 +59,7 @@ export default {
     return record;
   },
 
-  recordsOfType(context, type) {
+  records(context, type) {
     const cache = this.target;
     const schema = cache.schema;
 

--- a/src/orbit-common/jsonapi/fetch-requests.js
+++ b/src/orbit-common/jsonapi/fetch-requests.js
@@ -21,7 +21,7 @@ function deserialize(source, data) {
 }
 
 export const FetchRequestProcessors = {
-  recordsOfType(source, request) {
+  records(source, request) {
     const { type } = request;
     const hash = {};
 
@@ -75,12 +75,12 @@ function buildFetchRequest(expression, request = {}) {
 }
 
 const ExpressionToRequestMap = {
-  recordsOfType(expression, request) {
+  records(expression, request) {
     if (request.op) {
       throw new QueryExpressionParseError('Query request `op` can not be redefined.', expression);
     }
 
-    request.op = 'recordsOfType';
+    request.op = 'records';
     request.type = expression.args[0];
   },
 

--- a/src/orbit-common/query/builder.js
+++ b/src/orbit-common/query/builder.js
@@ -2,8 +2,8 @@ import { Records, Record, RelatedRecord, RelatedRecords } from 'orbit-common/que
 import { queryExpression as oqe } from 'orbit/query/expression';
 
 export default {
-  recordsOfType(type) {
-    return new Records(oqe('recordsOfType', type));
+  records(type) {
+    return new Records(oqe('records', type));
   },
 
   record(recordIdentity) {

--- a/test/tests/integration/coordinator-test.js
+++ b/test/tests/integration/coordinator-test.js
@@ -299,7 +299,7 @@ module('Integration - Coordinator', function(hooks) {
 
     server.respondWith('GET', '/planets', jsonResponse(200, { data }));
 
-    return store.query(qb.recordsOfType('planet'))
+    return store.query(qb.records('planet'))
       .then(planets => {
         assert.deepEqual(Object.keys(planets).map(k => planets[k].attributes.name), ['Jupiter']);
       });
@@ -331,7 +331,7 @@ module('Integration - Coordinator', function(hooks) {
     server.respondWith('GET', `/planets?${encodeURIComponent('filter[name]')}=Jupiter`, jsonResponse(200, { data }));
 
     return store
-      .query(qb.recordsOfType('planet')
+      .query(qb.records('planet')
                .filterAttributes({ name: 'Jupiter' }))
       .then(planets => {
         assert.deepEqual(Object.keys(planets).map(k => planets[k].attributes.name), ['Jupiter']);

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -494,7 +494,7 @@ test('#query can perform a simple matching filter', function(assert) {
   assert.deepEqual(
     cache.query(
       oqe('filter',
-          oqe('recordsOfType', 'planet'),
+          oqe('records', 'planet'),
           oqe('equal', oqe('attribute', 'name'), 'Jupiter'))
     ),
     {
@@ -516,7 +516,7 @@ test('#query can perform a complex conditional `and` filter', function(assert) {
   assert.deepEqual(
     cache.query(
       oqe('filter',
-          oqe('recordsOfType', 'planet'),
+          oqe('records', 'planet'),
           oqe('and',
             oqe('equal', oqe('attribute', 'classification'), 'terrestrial'),
             oqe('equal', oqe('attribute', 'atmosphere'), true)
@@ -542,7 +542,7 @@ test('#query can perform a complex conditional `or` filter', function(assert) {
   assert.deepEqual(
     cache.query(
       oqe('filter',
-          oqe('recordsOfType', 'planet'),
+          oqe('records', 'planet'),
           oqe('or',
               oqe('equal', oqe('attribute', 'classification'), 'gas giant'),
               oqe('equal', oqe('attribute', 'atmosphere'), true)
@@ -597,7 +597,7 @@ test('#query - record - throws RecordNotFoundException if record doesn\'t exist'
   );
 });
 
-test('#query - recordsOfType - finds matching records', function(assert) {
+test('#query - records - finds matching records', function(assert) {
   cache = new Cache(schema);
 
   const jupiter = {
@@ -613,16 +613,16 @@ test('#query - recordsOfType - finds matching records', function(assert) {
   cache.reset({ planet: { jupiter }, moon: { callisto } });
 
   assert.deepEqual(
-    cache.query(oqe('recordsOfType', 'planet')),
+    cache.query(oqe('records', 'planet')),
     { jupiter }
   );
 });
 
-test('#query - recordsOfType - throws ModelNotRegisteredException when model isn\'t registered in schema', function(assert) {
+test('#query - records - throws ModelNotRegisteredException when model isn\'t registered in schema', function(assert) {
   cache = new Cache(schema);
 
   assert.throws(
-    () => cache.query(oqe('recordsOfType', 'black-hole')),
+    () => cache.query(oqe('records', 'black-hole')),
     new ModelNotRegisteredException('No model registered for black-hole')
   );
 });

--- a/test/tests/orbit-common/unit/cache/live-queries-test.js
+++ b/test/tests/orbit-common/unit/cache/live-queries-test.js
@@ -46,9 +46,9 @@ module('OC - Cache - liveQuery', function(hooks) {
     cache = new Cache(planetsSchema);
   });
 
-  test('recordsOfType', function(assert) {
+  test('records', function(assert) {
     const done = assert.async();
-    const liveQuery = cache.liveQuery(qb.recordsOfType('planet'));
+    const liveQuery = cache.liveQuery(qb.records('planet'));
 
     liveQuery.take(2).toArray().subscribe((operations) => {
       assert.deepEqual(operations, [
@@ -70,7 +70,7 @@ module('OC - Cache - liveQuery', function(hooks) {
     const done = assert.async();
 
     const liveQuery = cache.liveQuery(
-      qb.recordsOfType('planet').filterAttributes({ name: 'Pluto' })
+      qb.records('planet').filterAttributes({ name: 'Pluto' })
     );
 
     liveQuery.take(1).toArray().subscribe((operations) => {
@@ -88,7 +88,7 @@ module('OC - Cache - liveQuery', function(hooks) {
     const done = assert.async();
 
     const liveQuery = cache.liveQuery(
-      qb.recordsOfType('planet').filterAttributes({ name: 'Pluto' })
+      qb.records('planet').filterAttributes({ name: 'Pluto' })
     );
 
     liveQuery.take(2).toArray().subscribe(operations => {
@@ -109,7 +109,7 @@ module('OC - Cache - liveQuery', function(hooks) {
     const done = assert.async();
 
     const liveQuery = cache.liveQuery(
-      qb.recordsOfType('planet').filterAttributes({ name: 'Pluto' })
+      qb.records('planet').filterAttributes({ name: 'Pluto' })
     );
 
     liveQuery.subscribe(operation => {
@@ -130,7 +130,7 @@ module('OC - Cache - liveQuery', function(hooks) {
     cache.transform(t => t.addRecord(pluto));
 
     const liveQuery = cache.liveQuery(
-      qb.recordsOfType('planet')
+      qb.records('planet')
        .filterAttributes({ name: 'Pluto' })
     );
 
@@ -148,7 +148,7 @@ module('OC - Cache - liveQuery', function(hooks) {
     const done = assert.async();
 
     const liveQuery = cache.liveQuery(
-      qb.recordsOfType('planet').filterAttributes({ name: 'Uranus2' })
+      qb.records('planet').filterAttributes({ name: 'Uranus2' })
     );
 
     liveQuery.subscribe(operation => {
@@ -164,7 +164,7 @@ module('OC - Cache - liveQuery', function(hooks) {
 
   test('filter - ignores remove record that isn\'t included in matches', function(assert) {
     const liveQuery = cache.liveQuery(
-      qb.recordsOfType('planet').filterAttributes({ name: 'Jupiter' })
+      qb.records('planet').filterAttributes({ name: 'Jupiter' })
     );
 
     const onOperation = sinon.stub();
@@ -180,7 +180,7 @@ module('OC - Cache - liveQuery', function(hooks) {
     const done = assert.async();
 
     const liveQuery = cache.liveQuery(
-      qb.recordsOfType('planet')
+      qb.records('planet')
        .filterAttributes({ name: 'Pluto' })
        .filterAttributes({ name: 'Pluto' })
     );
@@ -196,12 +196,12 @@ module('OC - Cache - liveQuery', function(hooks) {
     });
   });
 
-  test('filter - recordsOfType with existing match in cache', function(assert) {
+  test('filter - records with existing match in cache', function(assert) {
     const done = assert.async();
 
     cache.transform(t => t.addRecord(pluto));
 
-    const liveQuery = cache.liveQuery(qb.recordsOfType('planet'));
+    const liveQuery = cache.liveQuery(qb.records('planet'));
 
     liveQuery.subscribe(operation => {
       assert.deepEqual(operation, { op: 'addRecord', record: pluto });

--- a/test/tests/orbit-common/unit/jsonapi-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-source-test.js
@@ -433,7 +433,7 @@ test('#fetch - record', function(assert) {
     });
 });
 
-test('#fetch - recordsOfType', function(assert) {
+test('#fetch - records', function(assert) {
   assert.expect(4);
 
   const data = [
@@ -449,7 +449,7 @@ test('#fetch - recordsOfType', function(assert) {
                 JSON.stringify({ data }));
   });
 
-  return source.fetch(qb.recordsOfType('planet'))
+  return source.fetch(qb.records('planet'))
     .then(transforms => {
       assert.equal(transforms.length, 1, 'one transform returned');
       assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
@@ -457,7 +457,7 @@ test('#fetch - recordsOfType', function(assert) {
     });
 });
 
-test('#fetch - recordsOfType with filter', function(assert) {
+test('#fetch - records with filter', function(assert) {
   assert.expect(4);
 
   const data = [
@@ -471,7 +471,7 @@ test('#fetch - recordsOfType with filter', function(assert) {
                 JSON.stringify({ data }));
   });
 
-  return source.fetch(qb.recordsOfType('planet')
+  return source.fetch(qb.records('planet')
                             .filterAttributes({ name: 'Jupiter' }))
     .then(transforms => {
       assert.equal(transforms.length, 1, 'one transform returned');

--- a/test/tests/orbit-common/unit/query/builder-test.js
+++ b/test/tests/orbit-common/unit/query/builder-test.js
@@ -19,29 +19,29 @@ module('OC - QueryBuilder', function() {
     );
   });
 
-  test('recordsOfType', function(assert) {
+  test('records', function(assert) {
     assert.deepEqual(
-      qb.recordsOfType('planet').toQueryExpression(),
+      qb.records('planet').toQueryExpression(),
 
-      oqe('recordsOfType', 'planet')
+      oqe('records', 'planet')
     );
   });
 
-  test('recordsOfType/filter/equal/get', function(assert) {
+  test('records/filter/equal/get', function(assert) {
     assert.deepEqual(
-      qb.recordsOfType('planet')
+      qb.records('planet')
         .filter(record => record.attribute('name').equal('Pluto'))
         .toQueryExpression(),
 
       oqe('filter',
-        oqe('recordsOfType', 'planet'),
+        oqe('records', 'planet'),
         oqe('equal', oqe('attribute', 'name'), 'Pluto'))
     );
   });
 
-  test('recordsOfType/filter/equal/get/or', function(assert) {
+  test('records/filter/equal/get/or', function(assert) {
     assert.deepEqual(
-      qb.recordsOfType('planet')
+      qb.records('planet')
         .filter(record =>
           qb.or(
             record.attribute('name').equal('Jupiter'),
@@ -51,16 +51,16 @@ module('OC - QueryBuilder', function() {
         .toQueryExpression(),
 
       oqe('filter',
-        oqe('recordsOfType', 'planet'),
+        oqe('records', 'planet'),
           oqe('or',
             oqe('equal', oqe('attribute', 'name'), 'Jupiter'),
             oqe('equal', oqe('attribute', 'name'), 'Pluto')))
     );
   });
 
-  test('recordsOfType/filter/equal/get/and', function(assert) {
+  test('records/filter/equal/get/and', function(assert) {
     assert.deepEqual(
-      qb.recordsOfType('planet')
+      qb.records('planet')
         .filter(record =>
           qb.and(
             record.attribute('name').equal('Jupiter'),
@@ -70,16 +70,16 @@ module('OC - QueryBuilder', function() {
         .toQueryExpression(),
 
       oqe('filter',
-        oqe('recordsOfType', 'planet'),
+        oqe('records', 'planet'),
           oqe('and',
             oqe('equal', oqe('attribute', 'name'), 'Jupiter'),
             oqe('equal', oqe('attribute', 'name'), 'Pluto')))
     );
   });
 
-  test('recordsOfType/filter/equal/attribute/and', function(assert) {
+  test('records/filter/equal/attribute/and', function(assert) {
     assert.deepEqual(
-      qb.recordsOfType('planet')
+      qb.records('planet')
         .filter(record =>
           qb.and(
             record.attribute('name').equal('Jupiter'),
@@ -89,21 +89,21 @@ module('OC - QueryBuilder', function() {
         .toQueryExpression(),
 
       oqe('filter',
-        oqe('recordsOfType', 'planet'),
+        oqe('records', 'planet'),
           oqe('and',
             oqe('equal', oqe('attribute', 'name'), 'Jupiter'),
             oqe('equal', oqe('attribute', 'name'), 'Pluto')))
     );
   });
 
-  test('recordsOfType/filterAttributes', function(assert) {
+  test('records/filterAttributes', function(assert) {
     assert.deepEqual(
-      qb.recordsOfType('planet')
+      qb.records('planet')
         .filterAttributes({ 'name': 'Jupiter', 'age': '23000000' })
         .toQueryExpression(),
 
       oqe('filter',
-        oqe('recordsOfType', 'planet'),
+        oqe('records', 'planet'),
           oqe('and',
             oqe('equal', oqe('attribute', 'name'), 'Jupiter'),
             oqe('equal', oqe('attribute', 'age'), '23000000')))

--- a/test/tests/orbit-common/unit/store-test.js
+++ b/test/tests/orbit-common/unit/store-test.js
@@ -116,7 +116,7 @@ module('OC - Store', function(hooks) {
                                           .addRecord(jupiter));
 
     setupStore.then(() => {
-      const liveQuery = store.liveQuery(qb.recordsOfType('planet'));
+      const liveQuery = store.liveQuery(qb.records('planet'));
       liveQuery.subscribe(op => console.log(op));
 
       liveQuery.take(2).toArray().subscribe(operations => {

--- a/test/tests/orbit/unit/query-test.js
+++ b/test/tests/orbit/unit/query-test.js
@@ -36,7 +36,7 @@ module('Orbit', function() {
     });
 
     test('.from should call toQueryExpression() if available', function(assert) {
-      const expression = oqe('recordsOfType', 'planet');
+      const expression = oqe('records', 'planet');
       const queryFactory = {
         toQueryExpression() {
           return expression;


### PR DESCRIPTION
The less verbose form is more consistent with other query operators.

Furthermore, this name will allow a transition to supporting 
`records(...types)` instead of simply `records(type)`.