### PR TITLE
Let users skip lint tests in the QUnit runner

### DIFF
--- a/test/test-support/test-loader.js
+++ b/test/test-support/test-loader.js
@@ -1,19 +1,17 @@
 /* globals requirejs, require */
 
-var moduleName, shouldLoad;
-
 QUnit.config.autostart = false;
-QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint' });
+QUnit.config.urlConfig.push({ id: 'nolint', label: 'Disable Linting' });
 
 // TODO: load based on params
 setTimeout(function() {
-  for (moduleName in requirejs.entries) {
-    shouldLoad = false;
+  for (var moduleName in requirejs.entries) {
+    var isTest = moduleName.match(/[-_]test$/);
+    var isSkippedLintTest = QUnit.urlParams.nolint && moduleName.match(/\.lint-test$/);
 
-    if (moduleName.match(/[-_]test$/)) { shouldLoad = true; }
-    if (!QUnit.urlParams.nojshint && moduleName.match(/\.jshint$/)) { shouldLoad = true; }
-
-    if (shouldLoad) { require(moduleName); }
+    if (isTest && !isSkippedLintTest) {
+      require(moduleName);
+    }
   }
   QUnit.start();
 }, 250);


### PR DESCRIPTION
After #312 we lost the ability to filter out linting tests in the QUnit test runner. This swaps out the JSHint specific code for something more general which will work with the ESLint tests.