### PR TITLE
Minor cleanup for JSONAPI source and serializer

### DIFF
--- a/src/orbit-common/cache.js
+++ b/src/orbit-common/cache.js
@@ -107,7 +107,7 @@ export default class Cache {
     const query = Query.from(_query);
     const results = this._initialLiveQueryResults(query, context);
     const liveResults = this.liveQueryEvaluator.evaluate(query.expression, context)
-                            .matching({ op: ['addRecord', 'removeRecord'] });
+                            .matching({ op: ['addRecord', 'removeRecord', 'replaceRecord'] });
 
     return liveResults.startWith(...results);
   }
@@ -313,7 +313,7 @@ export default class Cache {
     const patchTransform = PatchTransforms[ op.op ];
     const patchOp = patchTransform(op);
 
-    // console.log('_transformDoc', patchOp.op, patchOp.path, patchOp.value);
+    // console.debug('Cache#_transformDoc', patchOp.op, patchOp.path, patchOp.value);
 
     if (patchOp.op === 'remove') {
       if (this.hasDeleted(patchOp.path)) {
@@ -337,6 +337,8 @@ export default class Cache {
         }
       }
     }
+
+    // console.debug('Cache#patch', op);
 
     this.emit('patch', op);
   }

--- a/src/orbit-common/jsonapi-source.js
+++ b/src/orbit-common/jsonapi-source.js
@@ -33,9 +33,9 @@ export default class JSONAPISource extends Source {
 
     this.schema           = options.schema;
     this.name             = options.name || 'jsonapi';
-    this.namespace        = options.namespace || this.namespace;
-    this.host             = options.host || this.host;
-    this.headers          = options.headers || this.headers;
+    this.namespace        = options.namespace;
+    this.host             = options.host;
+    this.headers          = options.headers || { Accept: 'application/vnd.api+json' };
 
     const SerializerClass = options.SerializerClass || JSONAPISerializer;
     this.serializer       = new SerializerClass(this.schema);

--- a/src/orbit-common/jsonapi-source.js
+++ b/src/orbit-common/jsonapi-source.js
@@ -95,56 +95,44 @@ export default class JSONAPISource extends Source {
   // Publicly accessible methods particular to JSONAPISource
   /////////////////////////////////////////////////////////////////////////////
 
-  ajax(url, method, hash) {
+  ajax(url, method, settings = {}) {
     return new Orbit.Promise((resolve, reject) => {
-      hash = hash || {};
-      hash.url = url;
-      hash.type = method;
-      hash.dataType = 'json';
-      hash.context = this;
+      settings.url = url;
+      settings.type = method;
+      settings.dataType = 'json';
+      settings.context = this;
 
-      // console.log('ajax start', method, url);
-
-      if (hash.data && method !== 'GET') {
-        if (!hash.contentType) {
-          hash.contentType = this.ajaxContentType(hash);
+      if (settings.data && method !== 'GET') {
+        if (!settings.contentType) {
+          settings.contentType = this.ajaxContentType(settings);
         }
-        hash.data = JSON.stringify(hash.data);
+        settings.data = JSON.stringify(settings.data);
       }
 
-      if (this.ajaxHeaders) {
-        let headers = this.ajaxHeaders();
-        hash.beforeSend = function (xhr) {
-          for (let key in headers) {
-            if (headers.hasOwnProperty(key)) {
-              xhr.setRequestHeader(key, headers[key]);
-            }
-          }
-        };
+      if (!settings.headers) {
+        settings.headers = this.ajaxHeaders(settings);
       }
 
-      hash.success = function(json) {
-        // console.log('ajax success', method, json);
+      settings.success = function(json) {
         resolve(json);
       };
 
-      hash.error = function(jqXHR) {
+      settings.error = function(jqXHR) {
         if (jqXHR) {
           jqXHR.then = null;
         }
-        // console.log('ajax error', method, jqXHR);
         reject(jqXHR);
       };
 
-      Orbit.ajax(hash);
+      Orbit.ajax(settings);
     });
   }
 
-  ajaxContentType(/* url, method */) {
+  ajaxContentType(/* settings */) {
     return 'application/vnd.api+json; charset=utf-8';
   }
 
-  ajaxHeaders() {
+  ajaxHeaders(/* settings */) {
     return this.headers;
   }
 

--- a/src/orbit-common/jsonapi/serializer.js
+++ b/src/orbit-common/jsonapi/serializer.js
@@ -235,21 +235,19 @@ export default class JSONAPISerializer extends Serializer {
   }
 
   deserializeRelationship(record, relationship, value) {
-    var relationshipData;
+    let data;
 
     if (isArray(value)) {
-      relationshipData = {};
+      data = {};
       value.forEach(each => {
-        relationshipData[this.deserializeIdentifier(each)] = true;
+        data[this.deserializeIdentifier(each)] = true;
       });
     } else if (isObject(value)) {
-      relationshipData = this.deserializeIdentifier(value);
+      data = this.deserializeIdentifier(value);
     }
 
     record.relationships = record.relationships || {};
-    record.relationships[relationship] = {
-      data: relationshipData
-    };
+    record.relationships[relationship] = { data };
   }
 
   deserializeIdentifier(resourceIdentifier) {

--- a/src/orbit-common/jsonapi/serializer.js
+++ b/src/orbit-common/jsonapi/serializer.js
@@ -150,7 +150,9 @@ export default class JSONAPISerializer extends Serializer {
         value = this.serializeIdentifier(parseIdentifier(value));
       }
 
-      json.relationships[relationship] = {
+      const resourceRelationship = this.resourceRelationship(record.type, relationship);
+
+      json.relationships[resourceRelationship] = {
         data: value
       };
     }

--- a/test/tests/orbit-common/unit/jsonapi-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-source-test.js
@@ -123,6 +123,10 @@ test('#resourceRelationshipURL - constructs relationship URLs based upon base re
   assert.equal(source.resourceRelationshipURL('planet', '1', 'moons'), '/planets/a/relationships/moons', 'resourceRelationshipURL appends /relationships/[relationship] to resourceURL');
 });
 
+test('#ajaxHeaders - include JSONAPI Accept header by default', function(assert) {
+  assert.deepEqual(source.ajaxHeaders(), { Accept: 'application/vnd.api+json' }, 'Default headers should include JSONAPI Accept header');
+});
+
 test('#transform - can add records', function(assert) {
   assert.expect(4);
 


### PR DESCRIPTION
* Set the JSONAPI Accept header by default.
* Refactor JSONAPISource#ajax to be more idiomatic.
* Fix serialization of relationship names to use translated resource names.
* Ensure that LiveQuery results observe `replaceRecord` operations (in addition to `addRecord` and `removeRecord`).
