### PR TITLE
Improve LocalStorageSource

### DIFF
--- a/src/orbit-common/local-storage-source.js
+++ b/src/orbit-common/local-storage-source.js
@@ -34,7 +34,8 @@ export default class LocalStorageSource extends Source {
 
     this.schema    = options.schema;
     this.name      = options.name || 'localStorage';
-    this.namespace = options.namespace || 'orbit'; // local storage key
+    this.namespace = options['namespace'] || 'orbit'; // local storage namespace
+    this.delimiter = options['delimiter'] || '/'; // local storage key
     this._autosave = options.autosave !== undefined ? options.autosave : true;
     let autoload   = options.autoload !== undefined ? options.autoload : true;
 
@@ -48,6 +49,16 @@ export default class LocalStorageSource extends Source {
 
     if (autoload) { this.load(); }
   }
+
+  // load: function() {
+  //   for (var key in window.localStorage) {
+  //     if (key.indexOf(this.namespace) === 0) {
+  //       var path = key.split(this.delimiter);
+  //       var item = JSON.parse(window.localStorage.getItem(key));
+  //       this._cache._doc._data[path[1]][path[2]] = item;
+  //     }
+  //   }
+  // },
 
   load() {
     var storage = window.localStorage.getItem(this.namespace);
@@ -68,6 +79,10 @@ export default class LocalStorageSource extends Source {
       this._autosave = false;
     }
   }
+
+  // getKey: function(path) {
+  //   return [this.namespace, path[0], path[1]].join(this.delimiter);
+  // },
 
   /////////////////////////////////////////////////////////////////////////////
   // Transformable interface implementation
@@ -90,4 +105,20 @@ export default class LocalStorageSource extends Source {
     window.localStorage.setItem(this.namespace, JSON.stringify(this.cache.get()));
     this._isDirty = false;
   }
+
+  // _saveData: function(operation) {
+  //   if (!this._autosave && !operation) {
+  //     this._isDirty = true;
+  //     return;
+  //   }
+  //   var obj = this.retrieve([operation.path[0], operation.path[1]]);
+  //
+  //   if (operation.op === 'add' || operation.op === 'replace') {
+  //     window.localStorage.setItem(this.getKey(operation.path), JSON.stringify(obj));
+  //   }
+  //   if (operation.op === 'remove') {
+  //     window.localStorage.removeItem(this.getKey(operation.path));
+  //   }
+  //   this._isDirty = false;
+  // }
 }

--- a/src/orbit-common/local-storage/fetch-operators.js
+++ b/src/orbit-common/local-storage/fetch-operators.js
@@ -1,0 +1,60 @@
+import Transform from 'orbit/transform';
+import { isNone } from 'orbit/lib/objects';
+
+export default {
+  records(source, expression) {
+    const operations = [];
+    let allowedTypes = expression.args;
+    let skipTypeCheck = (allowedTypes.length === 0 || (allowedTypes.length === 1 && isNone(allowedTypes[0])));
+
+    for (let key in window.localStorage) {
+      if (key.indexOf(source.namespace) === 0) {
+        let typesMatch = skipTypeCheck;
+
+        if (!typesMatch) {
+          let fragments = key.split(source.delimiter);
+          let type = fragments[1];
+          typesMatch = allowedTypes.indexOf(type) !== -1;
+        }
+
+        if (typesMatch) {
+          let record = JSON.parse(window.localStorage.getItem(key));
+
+          operations.push({
+            op: 'addRecord',
+            record
+          });
+        }
+      }
+    }
+
+    return [Transform.from(operations)];
+  },
+
+  record(source, expression) {
+    const operations = [];
+    let requestedRecord = expression.args[0];
+
+    for (let key in window.localStorage) {
+      if (key.indexOf(source.namespace) === 0) {
+        let fragments = key.split(source.delimiter);
+        let type = fragments[1];
+        let id = fragments[2];
+
+        if (type === requestedRecord.type &&
+            id === requestedRecord.id) {
+          let record = JSON.parse(window.localStorage.getItem(key));
+
+          operations.push({
+            op: 'addRecord',
+            record
+          });
+
+          break;
+        }
+      }
+    }
+
+    return [Transform.from(operations)];
+  }
+};

--- a/src/orbit-common/local-storage/transform-operators.js
+++ b/src/orbit-common/local-storage/transform-operators.js
@@ -1,0 +1,85 @@
+import { toIdentifier } from '../lib/identifiers';
+
+export default {
+  addRecord(source, operation) {
+    source.putRecord(operation.record);
+  },
+
+  replaceRecord(source, operation) {
+    source.putRecord(operation.record);
+  },
+
+  removeRecord(source, operation) {
+    source.removeRecord(operation.record);
+  },
+
+  replaceKey(source, operation) {
+    let record = source.getRecord(operation.record) || {
+      type: operation.record.type,
+      id: operation.record.id
+    };
+    record.keys = record.keys || {};
+    record.keys[operation.key] = operation.value;
+    source.putRecord(record);
+  },
+
+  replaceAttribute(source, operation) {
+    let record = source.getRecord(operation.record) || {
+      type: operation.record.type,
+      id: operation.record.id
+    };
+    record.attributes = record.attributes || {};
+    record.attributes[operation.attribute] = operation.value;
+    source.putRecord(record);
+  },
+
+  addToHasMany(source, operation) {
+    let record = source.getRecord(operation.record) || {
+      type: operation.record.type,
+      id: operation.record.id
+    };
+    record.relationships = record.relationships || {};
+    record.relationships[operation.relationship] = record.relationships[operation.relationship] || {};
+    record.relationships[operation.relationship].data = record.relationships[operation.relationship].data || {};
+    record.relationships[operation.relationship].data[toIdentifier(operation.relatedRecord)] = true;
+    source.putRecord(record);
+  },
+
+  removeFromHasMany(source, operation) {
+    let record = source.getRecord(operation.record);
+    if (record &&
+        record.relationships &&
+        record.relationships[operation.relationship] &&
+        record.relationships[operation.relationship].data &&
+        record.relationships[operation.relationship].data[toIdentifier(operation.relatedRecord)]
+    ) {
+      delete record.relationships[operation.relationship].data[toIdentifier(operation.relatedRecord)];
+      source.putRecord(record);
+    }
+  },
+
+  replaceHasMany(source, operation) {
+    let record = source.getRecord(operation.record) || {
+      type: operation.record.type,
+      id: operation.record.id
+    };
+    record.relationships = record.relationships || {};
+    record.relationships[operation.relationship] = record.relationships[operation.relationship] || {};
+    record.relationships[operation.relationship].data = {};
+    operation.relatedRecords.forEach(relatedRecord => {
+      record.relationships[operation.relationship].data[toIdentifier(relatedRecord)] = true;
+    });
+    source.putRecord(record);
+  },
+
+  replaceHasOne(source, operation) {
+    let record = source.getRecord(operation.record) || {
+      type: operation.record.type,
+      id: operation.record.id
+    };
+    record.relationships = record.relationships || {};
+    record.relationships[operation.relationship] = record.relationships[operation.relationship] || {};
+    record.relationships[operation.relationship].data = operation.relatedRecord ? toIdentifier(operation.relatedRecord) : null;
+    source.putRecord(record);
+  }
+};

--- a/test/tests/orbit-common/unit/local-storage-source-test.js
+++ b/test/tests/orbit-common/unit/local-storage-source-test.js
@@ -1,28 +1,41 @@
-import { verifyLocalStorageContainsRecord, verifyLocalStorageIsEmpty } from 'tests/test-helper';
+import {
+  verifyLocalStorageContainsRecord,
+  verifyLocalStorageDoesNotContainRecord,
+  verifyLocalStorageIsEmpty
+} from 'tests/test-helper';
 import Source from 'orbit/source';
 import Schema from 'orbit-common/schema';
 import LocalStorageSource from 'orbit-common/local-storage-source';
 import {
-  addRecord
+  addRecord,
+  replaceRecord,
+  removeRecord,
+  replaceKey,
+  replaceAttribute,
+  addToHasMany,
+  removeFromHasMany,
+  replaceHasMany,
+  replaceHasOne
 } from 'orbit-common/transform/operators';
+import qb from 'orbit-common/query/builder';
 
 let schema, source;
 
 ///////////////////////////////////////////////////////////////////////////////
 
 module('OC - LocalStorageSource', {
-  setup: function() {
+  setup() {
     schema = new Schema({
       models: {
-        planet: {}
+        planet: {},
+        moon: {}
       }
     });
 
-    source = new LocalStorageSource({ schema: schema, autoload: false });
+    source = new LocalStorageSource({ schema });
   },
 
-  teardown: function() {
-    window.localStorage.removeItem(source.namespace);
+  teardown() {
     schema = source = null;
   }
 });
@@ -35,49 +48,479 @@ test('its prototype chain is correct', function(assert) {
   assert.ok(source instanceof Source, 'instanceof Source');
 });
 
-test('#transform - can update the cache AND local storage', function(assert) {
-  assert.expect(4);
-
-  let planet = schema.normalize({ type: 'planet', attributes: { name: 'Jupiter', classification: 'gas giant' } });
-
-  assert.equal(source.cache.length('planet'), 0, 'source should be empty');
-
-  return source.transform(addRecord(planet))
-    .then(function() {
-      assert.equal(source.cache.length('planet'), 1, 'source should be empty');
-      assert.deepEqual(source.cache.get(['planet', planet.id]), planet, 'planet matches');
-      verifyLocalStorageContainsRecord(source.namespace, 'planet', planet.id, planet);
-    });
+test('is assigned a default namespace and delimiter', function(assert) {
+  assert.equal(source.namespace, 'orbit', 'namespace is `orbit` by default');
+  assert.equal(source.delimiter, '/', 'delimiter is `/` by default');
 });
 
-test('it can use a custom local storage namespace for storing data', function(assert) {
+test('#getKeyForRecord returns the local storage key that will be used for a record', function(assert) {
+  assert.equal(
+    source.getKeyForRecord({type: 'planet', id: 'jupiter'}),
+    'orbit/planet/jupiter'
+  );
+});
+
+test('#transform - addRecord', function(assert) {
   assert.expect(1);
 
-  let planet = schema.normalize({ type: 'planet', attributes: { name: 'Jupiter', classification: 'gas giant' } });
-
-  source.namespace = 'planets';
+  let planet = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    }
+  });
 
   return source.transform(addRecord(planet))
-    .then(function() {
-      verifyLocalStorageContainsRecord(source.namespace, 'planet', planet.id, planet);
+    .then(() => verifyLocalStorageContainsRecord(source, planet));
+});
+
+test('#transform - replaceRecord', function(assert) {
+  assert.expect(1);
+
+  let original = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    }
+  });
+
+  let revised = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant',
+      revised: true
+    }
+  });
+
+  return source.transform(addRecord(original))
+    .then(() => source.transform(replaceRecord(revised)))
+    .then(() => verifyLocalStorageContainsRecord(source, revised));
+});
+
+test('#transform - removeRecord', function(assert) {
+  assert.expect(1);
+
+  let planet = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    }
+  });
+
+  return source.transform(addRecord(planet))
+    .then(() => source.transform(removeRecord(planet)))
+    .then(() => verifyLocalStorageDoesNotContainRecord(source, planet));
+});
+
+test('#transform - replaceKey', function(assert) {
+  assert.expect(1);
+
+  let original = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    }
+  });
+
+  let revised = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    keys: {
+      remoteId: '123'
+    }
+  });
+
+  return source.transform(addRecord(original))
+    .then(() => source.transform(replaceKey(original, 'remoteId', '123')))
+    .then(() => verifyLocalStorageContainsRecord(source, revised));
+});
+
+test('#transform - replaceAttribute', function(assert) {
+  assert.expect(1);
+
+  let original = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    }
+  });
+
+  let revised = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant',
+      order: 5
+    }
+  });
+
+  return source.transform(addRecord(original))
+    .then(() => source.transform(replaceAttribute(original, 'order', 5)))
+    .then(() => verifyLocalStorageContainsRecord(source, revised));
+});
+
+test('#transform - addToHasMany', function(assert) {
+  assert.expect(1);
+
+  let original = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      moons: {
+        data: {}
+      }
+    }
+  });
+
+  let revised = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      moons: {
+        data: {
+          'moon:moon1': true
+        }
+      }
+    }
+  });
+
+  return source.transform(addRecord(original))
+    .then(() => source.transform(addToHasMany(original, 'moons', { type: 'moon', id: 'moon1' })))
+    .then(() => verifyLocalStorageContainsRecord(source, revised));
+});
+
+test('#transform - removeFromHasMany', function(assert) {
+  assert.expect(1);
+
+  let original = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      moons: {
+        data: {
+          'moon:moon1': true,
+          'moon:moon2': true
+        }
+      }
+    }
+  });
+
+  let revised = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      moons: {
+        data: {
+          'moon:moon1': true
+        }
+      }
+    }
+  });
+
+  return source.transform(addRecord(original))
+    .then(() => source.transform(removeFromHasMany(original, 'moons', { type: 'moon', id: 'moon2' })))
+    .then(() => verifyLocalStorageContainsRecord(source, revised));
+});
+
+test('#transform - replaceHasMany', function(assert) {
+  assert.expect(1);
+
+  let original = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      moons: {
+        data: {
+          'moon:moon1': true
+        }
+      }
+    }
+  });
+
+  let revised = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      moons: {
+        data: {
+          'moon:moon2': true,
+          'moon:moon3': true
+        }
+      }
+    }
+  });
+
+  return source.transform(addRecord(original))
+    .then(() => source.transform(replaceHasMany(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }])))
+    .then(() => verifyLocalStorageContainsRecord(source, revised));
+});
+
+test('#transform - replaceHasOne - record', function(assert) {
+  assert.expect(1);
+
+  let original = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      solarSystem: {
+        data: null
+      }
+    }
+  });
+
+  let revised = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      solarSystem: {
+        data: 'solarSystem:ss1'
+      }
+    }
+  });
+
+  return source.transform(addRecord(original))
+    .then(() => source.transform(replaceHasOne(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' })))
+    .then(() => verifyLocalStorageContainsRecord(source, revised));
+});
+
+test('#transform - replaceHasOne - null', function(assert) {
+  assert.expect(1);
+
+  let original = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      solarSystem: {
+        data: 'solarSystem:ss1'
+      }
+    }
+  });
+
+  let revised = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    },
+    relationships: {
+      solarSystem: {
+        data: null
+      }
+    }
+  });
+
+  return source.transform(addRecord(original))
+    .then(() => source.transform(replaceHasOne(original, 'solarSystem', null)))
+    .then(() => verifyLocalStorageContainsRecord(source, revised));
+});
+
+test('#reset - clears records for source', function(assert) {
+  assert.expect(2);
+
+  let planet = schema.normalize({
+    type: 'planet',
+    id: 'jupiter'
+  });
+
+  return source.transform(addRecord(planet))
+    .then(() => {
+      verifyLocalStorageContainsRecord(source, planet);
+      source.reset();
+    })
+    .then(() => verifyLocalStorageIsEmpty(source));
+});
+
+test('#fetch - all records', function(assert) {
+  assert.expect(2);
+
+  let earth = schema.normalize({
+    type: 'planet',
+    id: 'earth',
+    attributes: {
+      name: 'Earth',
+      classification: 'terrestrial'
+    }
+  });
+
+  let jupiter = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    }
+  });
+
+  let io = schema.normalize({
+    type: 'moon',
+    id: 'io',
+    attributes: {
+      name: 'Io'
+    }
+  });
+
+  source.reset();
+
+  return source.transform([
+    addRecord(earth),
+    addRecord(jupiter),
+    addRecord(io)
+  ])
+    .then(() => source.fetch(qb.records()))
+    .then(transforms => {
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(
+        transforms[0].operations.map(o => o.op),
+        ['addRecord', 'addRecord', 'addRecord'],
+        'operations match expectations'
+      );
     });
 });
 
-test('autosave can be disabled to delay writing to local storage', function(assert) {
-  assert.expect(4);
+test('#fetch - records of one type', function(assert) {
+  assert.expect(2);
 
-  let planet = schema.normalize({ type: 'planet', attributes: { name: 'Jupiter', classification: 'gas giant' } });
+  let earth = schema.normalize({
+    type: 'planet',
+    id: 'earth',
+    attributes: {
+      name: 'Earth',
+      classification: 'terrestrial'
+    }
+  });
 
-  source.disableAutosave();
+  let jupiter = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    }
+  });
 
-  assert.equal(source.cache.length('planet'), 0, 'source should be empty');
+  let io = schema.normalize({
+    type: 'moon',
+    id: 'io',
+    attributes: {
+      name: 'Io'
+    }
+  });
 
-  return source.transform(addRecord(planet))
-    .then(function() {
-      assert.equal(source.cache.length('planet'), 1, 'source should contain one record');
-      verifyLocalStorageIsEmpty(source.namespace);
+  source.reset();
 
-      source.enableAutosave();
-      verifyLocalStorageContainsRecord(source.namespace, 'planet', planet.id, planet);
+  return source.transform([
+    addRecord(earth),
+    addRecord(jupiter),
+    addRecord(io)
+  ])
+    .then(() => source.fetch(qb.records('planet')))
+    .then(transforms => {
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(
+        transforms[0].operations.map(o => o.op),
+        ['addRecord', 'addRecord'],
+        'operations match expectations'
+      );
+    });
+});
+
+test('#fetch - a specific record', function(assert) {
+  assert.expect(2);
+
+  let earth = schema.normalize({
+    type: 'planet',
+    id: 'earth',
+    attributes: {
+      name: 'Earth',
+      classification: 'terrestrial'
+    }
+  });
+
+  let jupiter = schema.normalize({
+    type: 'planet',
+    id: 'jupiter',
+    attributes: {
+      name: 'Jupiter',
+      classification: 'gas giant'
+    }
+  });
+
+  let io = schema.normalize({
+    type: 'moon',
+    id: 'io',
+    attributes: {
+      name: 'Io'
+    }
+  });
+
+  source.reset();
+
+  return source.transform([
+    addRecord(earth),
+    addRecord(jupiter),
+    addRecord(io)
+  ])
+    .then(() => source.fetch(qb.record(jupiter)))
+    .then(transforms => {
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(
+        transforms[0].operations.map(o => o.op),
+        ['addRecord'],
+        'operations match expectations'
+      );
     });
 });

--- a/test/tests/support/local-storage.js
+++ b/test/tests/support/local-storage.js
@@ -1,30 +1,35 @@
-function verifyLocalStorageContainsRecord(namespace, type, id, record, ignoreFields) {
-  let recordKey = [namespace, type, id].join('/');
+function getRecord(source, record) {
+  let recordKey = [source.namespace, record.type, record.id].join(source.delimiter);
 
-  let actual = JSON.parse(window.localStorage.getItem(recordKey));
+  return JSON.parse(window.localStorage.getItem(recordKey));
+}
+
+export function verifyLocalStorageContainsRecord(source, record, ignoreFields) {
+  let actual = getRecord(source, record);
 
   if (ignoreFields) {
     for (let i = 0, l = ignoreFields.length, field; i < l; i++) {
       field = ignoreFields[i];
-      actual[id][field] = record[field];
+      actual[record.id][field] = record[field];
     }
   }
 
-  deepEqual(actual,
-            expected,
-            'data in local storage matches expectations');
+  deepEqual(actual, record, 'local storage contains record');
 }
 
-function verifyLocalStorageIsEmpty(namespace) {
-  var contents = JSON.parse(window.localStorage.getItem(namespace));
-  if (contents === null) {
-    equal(contents, null, 'local storage should still be empty');
-  } else {
-    deepEqual(contents, {}, 'local storage should still be empty');
+export function verifyLocalStorageDoesNotContainRecord(source, record) {
+  let actual = getRecord(source, record);
+
+  equal(actual, null, 'local storage does not contain record');
+}
+
+export function verifyLocalStorageIsEmpty(source) {
+  let isEmpty = true;
+  for (let key in window.localStorage) {
+    if (key.indexOf(source.namespace) === 0) {
+      isEmpty = false;
+      break;
+    }
   }
+  ok(isEmpty, 'local storage does not contain records for source');
 }
-
-export {
-  verifyLocalStorageIsEmpty,
-  verifyLocalStorageContainsRecord
-};

--- a/test/tests/support/local-storage.js
+++ b/test/tests/support/local-storage.js
@@ -1,12 +1,10 @@
 function verifyLocalStorageContainsRecord(namespace, type, id, record, ignoreFields) {
-  var expected = {};
-  expected[id] = record;
+  let recordKey = [namespace, type, id].join('/');
 
-  var actual = JSON.parse(window.localStorage.getItem(namespace));
-  if (type) { actual = actual[type]; }
+  let actual = JSON.parse(window.localStorage.getItem(recordKey));
 
   if (ignoreFields) {
-    for (var i = 0, l = ignoreFields.length, field; i < l; i++) {
+    for (let i = 0, l = ignoreFields.length, field; i < l; i++) {
       field = ignoreFields[i];
       actual[id][field] = record[field];
     }

--- a/test/tests/test-helper.js
+++ b/test/tests/test-helper.js
@@ -16,13 +16,14 @@ import {
 
 import {
   verifyLocalStorageIsEmpty,
-  verifyLocalStorageContainsRecord
+  verifyLocalStorageContainsRecord,
+  verifyLocalStorageDoesNotContainRecord
+
 } from './support/local-storage';
 
 import { planetsSchema } from './support/schemas';
 
 import './support/rsvp';
-
 
 export {
   serializeOps,
@@ -32,5 +33,6 @@ export {
   failedOperation,
   verifyLocalStorageIsEmpty,
   verifyLocalStorageContainsRecord,
+  verifyLocalStorageDoesNotContainRecord,
   planetsSchema
 };


### PR DESCRIPTION
Removes Cache from LocalStorageSource, favoring direct access to local storage instead.

Also uses the approach taken in #135 (rebased) to store one record per local storage key, instead of storing data all in one key (which hits size/speed limits).
