### PR TITLE
Refactor cache operation processors to handle `replaceRecord` ops

### DIFF
--- a/src/orbit-common/cache/operation-processors/schema-consistency-processor.js
+++ b/src/orbit-common/cache/operation-processors/schema-consistency-processor.js
@@ -1,6 +1,6 @@
-import { isArray, isObject, isNone } from 'orbit/lib/objects';
+import { isObject } from 'orbit/lib/objects';
 import OperationProcessor from './operation-processor';
-import { parseIdentifier } from './../../lib/identifiers';
+import { identity, toIdentifier, parseIdentifier, eqIdentity } from './../../lib/identifiers';
 
 /**
  An operation processor that ensures that a cache's data is consistent with
@@ -17,11 +17,17 @@ import { parseIdentifier } from './../../lib/identifiers';
 export default class SchemaConsistencyProcessor extends OperationProcessor {
   after(operation) {
     switch (operation.op) {
+      case 'addRecord':
+        return this._recordAdded(operation.record);
+
+      case 'addToHasMany':
+        return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
+
       case 'replaceHasOne':
-        return this._relatedRecordRemoved(operation.record, operation.relationship);
+        return this._relatedRecordReplaced(operation.record, operation.relationship, operation.relatedRecord);
 
       case 'replaceHasMany':
-        return this._relatedRecordsRemoved(operation.record, operation.relationship);
+        return this._relatedRecordsReplaced(operation.record, operation.relationship, operation.relatedRecords);
 
       case 'removeFromHasMany':
         return this._relatedRecordRemoved(operation.record, operation.relationship, operation.relatedRecord);
@@ -29,24 +35,8 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
       case 'removeRecord':
         return this._recordRemoved(operation.record);
 
-      default:
-        return [];
-    }
-  }
-
-  finally(operation) {
-    switch (operation.op) {
-      case 'replaceHasOne':
-        return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
-
-      case 'replaceHasMany':
-        return this._relatedRecordsAdded(operation.record, operation.relationship, operation.relatedRecords);
-
-      case 'addToHasMany':
-        return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
-
-      case 'addRecord':
-        return this._recordAdded(operation.record);
+      case 'replaceRecord':
+        return this._recordReplaced(operation.record);
 
       default:
         return [];
@@ -98,6 +88,34 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     return ops;
   }
 
+  _relatedRecordReplaced(record, relationship, relatedRecord) {
+    const ops = [];
+    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const inverseRelationship = relationshipDef.inverse;
+
+    if (inverseRelationship) {
+      const prevRelationshipData = this.cache.get([record.type, record.id, 'relationships', relationship, 'data']);
+      let prevRelatedRecord;
+
+      if (prevRelationshipData) {
+        prevRelatedRecord = parseIdentifier(prevRelationshipData);
+      }
+
+      if (!eqIdentity(prevRelatedRecord, relatedRecord)) {
+        if (prevRelatedRecord) {
+          ops.push(this._removeRelationshipOp(prevRelatedRecord, inverseRelationship, record));
+        }
+
+        if (relatedRecord) {
+          ops.push(this._addRelationshipOp(relatedRecord, inverseRelationship, record));
+        }
+      }
+    }
+
+    return ops;
+  }
+
+
   _relatedRecordsRemoved(record, relationship, relatedRecords) {
     const ops = [];
     const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
@@ -107,7 +125,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
       if (relatedRecords === undefined) {
         const relationshipData = this.cache.get([record.type, record.id, 'relationships', relationship, 'data']);
         if (relationshipData) {
-          relatedRecords = recordsFromData(relationshipData);
+          relatedRecords = recordArrayFromData(relationshipData);
         }
       }
 
@@ -119,17 +137,45 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     return ops;
   }
 
+  _relatedRecordsReplaced(record, relationship, relatedRecords) {
+    const ops = [];
+    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const prevRelationshipData = this.cache.get([record.type, record.id, 'relationships', relationship, 'data']);
+    const prevRelatedRecordMap = recordMapFromData(prevRelationshipData);
+    const relatedRecordMap = recordMapFromArray(relatedRecords);
+
+    const removedRecords = Object.keys(prevRelatedRecordMap)
+      .filter(id => !relatedRecordMap[id])
+      .map(id => parseIdentifier(id));
+
+    Array.prototype.push.apply(ops, this._removeRelatedRecordsOps(record, relationshipDef, removedRecords));
+
+    const addedRecords = Object.keys(relatedRecordMap)
+      .filter(id => !prevRelatedRecordMap[id])
+      .map(id => parseIdentifier(id));
+
+    Array.prototype.push.apply(ops, this._addRelatedRecordsOps(record, relationshipDef, addedRecords));
+
+    return ops;
+  }
+
   _recordAdded(record) {
     const ops = [];
     const relationships = record.relationships;
 
     if (relationships) {
+      const modelDef = this.cache.schema.modelDefinition(record.type);
+      const recordIdentity = identity(record);
+
       Object.keys(relationships).forEach(relationship => {
-        const relationshipData = relationships[relationship] && relationships[relationship].data;
-        if (relationshipData) {
-          const relatedRecords = recordsFromData(relationshipData);
-          Array.prototype.push.apply(ops, this._relatedRecordsAdded(record, relationship, relatedRecords));
-        }
+        const relationshipDef = modelDef.relationships[relationship];
+
+        const relationshipData = relationships[relationship] &&
+                                 relationships[relationship].data;
+
+        const relatedRecords = recordArrayFromData(relationshipData);
+
+        Array.prototype.push.apply(ops, this._addRelatedRecordsOps(recordIdentity, relationshipDef, relatedRecords));
       });
     }
 
@@ -141,23 +187,69 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     const relationships = this.cache.get([record.type, record.id, 'relationships']);
 
     if (relationships) {
-      Object.keys(relationships).forEach((relationship) => {
-        const relationshipData = relationships[relationship] && relationships[relationship].data;
-        if (relationshipData) {
-          const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
-          const relatedRecords = recordsFromData(relationshipData);
+      const modelDef = this.cache.schema.modelDefinition(record.type);
+      const recordIdentity = identity(record);
 
-          if (relationshipDef.dependent === 'remove') {
-            // TODO - needs test!
-            Array.prototype.push.apply(ops, this._removeDependentRecords(relatedRecords));
-          } else {
-            Array.prototype.push.apply(ops, this._relatedRecordsRemoved(record, relationship, relatedRecords));
-          }
-        }
+      Object.keys(relationships).forEach(relationship => {
+        const relationshipDef = modelDef.relationships[relationship];
+        const relationshipData = relationships[relationship] &&
+                                 relationships[relationship].data;
+        const relatedRecords = recordArrayFromData(relationshipData);
+
+        Array.prototype.push.apply(ops, this._removeRelatedRecordsOps(recordIdentity, relationshipDef, relatedRecords));
       });
     }
 
     return ops;
+  }
+
+  _recordReplaced(record) {
+    const ops = [];
+    const modelDef = this.cache.schema.modelDefinition(record.type);
+    const recordIdentity = identity(record);
+
+    for (let relationship in modelDef.relationships) {
+      const relationshipDef = modelDef.relationships[relationship];
+      const prevRelationshipData = this.cache.get([record.type, record.id, 'relationships', relationship, 'data']);
+      const prevRelatedRecordMap = recordMapFromData(prevRelationshipData);
+      const relationshipData = record &&
+                               record.relationships &&
+                               record.relationships[relationship] &&
+                               record.relationships[relationship].data;
+      const relatedRecordMap = recordMapFromData(relationshipData);
+
+      const removedRecords = Object.keys(prevRelatedRecordMap)
+        .filter(id => !relatedRecordMap[id])
+        .map(id => parseIdentifier(id));
+
+      Array.prototype.push.apply(ops, this._removeRelatedRecordsOps(recordIdentity, relationshipDef, removedRecords));
+
+      const addedRecords = Object.keys(relatedRecordMap)
+        .filter(id => !prevRelatedRecordMap[id])
+        .map(id => parseIdentifier(id));
+
+      Array.prototype.push.apply(ops, this._addRelatedRecordsOps(recordIdentity, relationshipDef, addedRecords));
+    }
+
+    return ops;
+  }
+
+  _addRelatedRecordsOps(record, relationshipDef, relatedRecords) {
+    if (relatedRecords.length > 0 && relationshipDef.inverse) {
+      return relatedRecords.map(relatedRecord => this._addRelationshipOp(relatedRecord, relationshipDef.inverse, record));
+    }
+    return [];
+  }
+
+  _removeRelatedRecordsOps(record, relationshipDef, relatedRecords) {
+    if (relatedRecords.length > 0) {
+      if (relationshipDef.dependent === 'remove') {
+        return this._removeDependentRecords(relatedRecords);
+      } else if (relationshipDef.inverse) {
+        return relatedRecords.map(relatedRecord => this._removeRelationshipOp(relatedRecord, relationshipDef.inverse, record));
+      }
+    }
+    return [];
   }
 
   _addRelationshipOp(record, relationship, relatedRecord) {
@@ -200,20 +292,34 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
   }
 }
 
-function recordsFromData(data) {
+function recordArrayFromData(data) {
   let ids;
 
-  if (isArray(data)) {
-    ids = data;
-  } else if (isObject(data)) {
+  if (isObject(data)) {
     ids = Object.keys(data);
-  } else if (isNone(data)) {
-    ids = [];
-  } else {
+  } else if (typeof data === 'string') {
     ids = [data];
+  } else {
+    ids = [];
   }
 
-  return ids.map(id => {
-    return parseIdentifier(id);
+  return ids.map(id => parseIdentifier(id));
+}
+
+function recordMapFromData(data) {
+  if (isObject(data)) {
+    return data;
+  } else if (typeof data === 'string') {
+    return {[data]: true};
+  } else {
+    return {};
+  }
+}
+
+function recordMapFromArray(records) {
+  let map = {};
+  records.forEach(record => {
+    map[toIdentifier(record)] = true;
   });
+  return map;
 }

--- a/test/tests/orbit-common/unit/cache/operation-processors/cache-integrity-processor-test.js
+++ b/test/tests/orbit-common/unit/cache/operation-processors/cache-integrity-processor-test.js
@@ -15,7 +15,7 @@ const schemaDefinition = {
       },
       relationships: {
         moons: { type: 'hasMany', model: 'moon', inverse: 'planet', actsAsSet: true },
-        races: { type: 'hasMany', model: 'race', inverse: 'planets' },
+        inhabitants: { type: 'hasMany', model: 'inhabitant', inverse: 'planets' },
         next: { type: 'hasOne', model: 'planet', inverse: 'previous' },
         previous: { type: 'hasOne', model: 'planet', inverse: 'next' }
       }
@@ -28,12 +28,12 @@ const schemaDefinition = {
         planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
       }
     },
-    race: {
+    inhabitant: {
       attributes: {
         name: { type: 'string' }
       },
       relationships: {
-        planets: { type: 'hasMany', model: 'planet', inverse: 'races' }
+        planets: { type: 'hasMany', model: 'planet', inverse: 'inhabitants' }
       }
     }
   }
@@ -72,8 +72,8 @@ test('reset empty cache', function(assert) {
                    relationships: { planet: { data: 'planet:jupiter' } } };
 
   cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter },
-    moon: { titan: titan, europa: europa }
+    planet: { saturn, jupiter },
+    moon: { titan, europa }
   });
 
   assert.deepEqual(processor._rev, {
@@ -114,8 +114,8 @@ test('add to hasOne => hasMany', function(assert) {
                    relationships: { planet: { data: 'planet:jupiter' } } };
 
   cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter },
-    moon: { titan: titan, europa: europa }
+    planet: { saturn, jupiter },
+    moon: { titan, europa }
   });
 
   assert.deepEqual(processor._rev, {
@@ -198,8 +198,8 @@ test('replace hasOne => hasMany', function(assert) {
                    relationships: { planet: { data: 'planet:jupiter' } } };
 
   cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter },
-    moon: { titan: titan, europa: europa }
+    planet: { saturn, jupiter },
+    moon: { titan, europa }
   });
 
   assert.deepEqual(processor._rev, {
@@ -275,8 +275,8 @@ test('replace hasMany => hasOne with empty array', function(assert) {
                   relationships: { planet: { data: 'planet:saturn' } } };
 
   cache.reset({
-    planet: { saturn: saturn },
-    moon: { titan: titan }
+    planet: { saturn },
+    moon: { titan }
   });
 
   assert.deepEqual(processor._rev, {
@@ -341,8 +341,8 @@ test('replace hasMany => hasOne with populated array', function(assert) {
                   relationships: { planet: { data: 'planet:saturn' } } };
 
   cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter },
-    moon: { titan: titan }
+    planet: { saturn, jupiter },
+    moon: { titan }
   });
 
   assert.deepEqual(processor._rev, {
@@ -412,8 +412,8 @@ test('replace hasMany => hasOne with populated array, when already populated', f
                    relationships: { planet: { data: 'planet:jupiter' } } };
 
   cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter },
-    moon: { titan: titan, europa: europa }
+    planet: { saturn, jupiter },
+    moon: { titan, europa }
   });
 
   assert.deepEqual(processor._rev, {
@@ -477,51 +477,51 @@ test('replace hasMany => hasOne with populated array, when already populated', f
 });
 
 test('replace hasMany => hasMany', function(assert) {
-  const human = { type: 'race', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
-  const earth = { type: 'planet', id: 'earth', relationships: { races: { data: { 'race:human': true } } } };
+  const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
+  const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
 
   cache.reset({
-    race: { human: human },
-    planet: { earth: earth }
+    inhabitant: { human },
+    planet: { earth }
   });
 
   assert.deepEqual(processor._rev, {
     'planet': {
       'earth': {
-        'race/human/relationships/planets/data/planet:earth': true
+        'inhabitant/human/relationships/planets/data/planet:earth': true
       }
     },
-    'race': {
+    'inhabitant': {
       'human': {
-        'planet/earth/relationships/races/data/race:human': true
+        'planet/earth/relationships/inhabitants/data/inhabitant:human': true
       }
     }
   }, 'rev links match');
 
-  const clearRacesOp = {
+  const clearInhabitantsOp = {
     op: 'replaceHasMany',
     record: earth,
-    relationship: 'races',
+    relationship: 'inhabitants',
     relatedRecords: []
   };
 
   assert.deepEqual(
-    processor.after(clearRacesOp),
+    processor.after(clearInhabitantsOp),
     []
   );
 
   assert.deepEqual(
-    processor.finally(clearRacesOp),
+    processor.finally(clearInhabitantsOp),
     []
   );
 
   assert.deepEqual(processor._rev, {
     'planet': {
       'earth': {
-        'race/human/relationships/planets/data/planet:earth': true
+        'inhabitant/human/relationships/planets/data/planet:earth': true
       }
     },
-    'race': {
+    'inhabitant': {
       'human': {
       }
     }
@@ -546,8 +546,8 @@ test('remove hasOne => hasMany', function(assert) {
                    relationships: { planet: { data: 'planet:jupiter' } } };
 
   cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter },
-    moon: { titan: titan, europa: europa }
+    planet: { saturn, jupiter },
+    moon: { titan, europa }
   });
 
   assert.deepEqual(processor._rev, {
@@ -624,7 +624,7 @@ test('add to hasOne => hasOne', function(assert) {
                   attributes: { name: 'Earth' } };
 
   cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter, earth: earth }
+    planet: { saturn, jupiter, earth }
   });
 
   assert.deepEqual(processor._rev, {
@@ -686,7 +686,7 @@ test('replace hasOne => hasOne with existing value', function(assert) {
                   attributes: { name: 'Earth' } };
 
   cache.reset({
-    planet: { saturn: saturn, jupiter: jupiter, earth: earth }
+    planet: { saturn, jupiter, earth }
   });
 
   assert.deepEqual(processor._rev, {
@@ -737,11 +737,11 @@ test('replace hasOne => hasOne with existing value', function(assert) {
 
 test('add to hasMany => hasMany', function(assert) {
   const earth = { type: 'planet', id: 'earth' };
-  const human = { type: 'race', id: 'human' };
+  const human = { type: 'inhabitant', id: 'human' };
 
   cache.reset({
-    planet: { earth: earth },
-    race: { human: human }
+    planet: { earth },
+    inhabitant: { human }
   });
 
   assert.deepEqual(processor._rev, {}, 'empty rev links');
@@ -771,30 +771,30 @@ test('add to hasMany => hasMany', function(assert) {
   assert.deepEqual(processor._rev, {
     'planet': {
       'earth': {
-        'race/human/relationships/planets/data/planet:earth': true
+        'inhabitant/human/relationships/planets/data/planet:earth': true
       }
     }
   }, 'rev links match');
 });
 
 test('remove from hasMany => hasMany', function(assert) {
-  const earth = { type: 'planet', id: 'earth', relationships: { races: { data: { 'race:human': true } } } };
-  const human = { type: 'race', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
+  const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
+  const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
 
   cache.reset({
-    planet: { earth: earth },
-    race: { human: human }
+    planet: { earth },
+    inhabitant: { human }
   });
 
   assert.deepEqual(processor._rev, {
     'planet': {
       'earth': {
-        'race/human/relationships/planets/data/planet:earth': true
+        'inhabitant/human/relationships/planets/data/planet:earth': true
       }
     },
-    'race': {
+    'inhabitant': {
       'human': {
-        'planet/earth/relationships/races/data/race:human': true
+        'planet/earth/relationships/inhabitants/data/inhabitant:human': true
       }
     }
   }, 'rev links match');
@@ -826,60 +826,60 @@ test('remove from hasMany => hasMany', function(assert) {
       'earth': {
       }
     },
-    'race': {
+    'inhabitant': {
       'human': {
-        'planet/earth/relationships/races/data/race:human': true
+        'planet/earth/relationships/inhabitants/data/inhabitant:human': true
       }
     }
   }, 'rev links match');
 });
 
 test('remove record with hasMany relationships', function(assert) {
-  const earth = { type: 'planet', id: 'earth', relationships: { races: { data: { 'race:human': true } } } };
-  const human = { type: 'race', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
+  const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
+  const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
 
   cache.reset({
     planet: { earth },
-    race: { human }
+    inhabitant: { human }
   });
 
   assert.deepEqual(processor._rev, {
     'planet': {
       'earth': {
-        'race/human/relationships/planets/data/planet:earth': true
+        'inhabitant/human/relationships/planets/data/planet:earth': true
       }
     },
-    'race': {
+    'inhabitant': {
       'human': {
-        'planet/earth/relationships/races/data/race:human': true
+        'planet/earth/relationships/inhabitants/data/inhabitant:human': true
       }
     }
   }, 'rev links match');
 
-  const removeRaceOp = {
+  const removeInhabitantOp = {
     op: 'removeRecord',
     record: human
   };
 
   assert.deepEqual(
-    processor.before(removeRaceOp),
+    processor.before(removeInhabitantOp),
     []
   );
 
   assert.deepEqual(
-    processor.after(removeRaceOp),
+    processor.after(removeInhabitantOp),
     [
       {
         op: 'removeFromHasMany',
         record: identity(earth),
-        relationship: 'races',
+        relationship: 'inhabitants',
         relatedRecord: identity(human)
       }
     ]
   );
 
   assert.deepEqual(
-    processor.finally(removeRaceOp),
+    processor.finally(removeInhabitantOp),
     []
   );
 
@@ -888,7 +888,55 @@ test('remove record with hasMany relationships', function(assert) {
       'earth': {
       }
     },
-    'race': {
+    'inhabitant': {
+    }
+  }, 'rev links match');
+});
+
+test('replaceRecord', function(assert) {
+  const earth = { type: 'planet', id: 'earth' };
+  const human = { type: 'inhabitant', id: 'human' };
+
+  cache.reset({
+    planet: { earth },
+    inhabitant: { human }
+  });
+
+  assert.deepEqual(processor._rev, {}, 'empty rev links');
+
+  const humanOnEarth = {
+    type: 'inhabitant',
+    id: 'human',
+    relationships: {
+      planets: { data: { 'planet:earth': true } }
+    }
+  };
+
+  const replaceHumanOp = {
+    op: 'replaceRecord',
+    record: humanOnEarth
+  };
+
+  assert.deepEqual(
+    processor.before(replaceHumanOp),
+    []
+  );
+
+  assert.deepEqual(
+    processor.after(replaceHumanOp),
+    []
+  );
+
+  assert.deepEqual(
+    processor.finally(replaceHumanOp),
+    []
+  );
+
+  assert.deepEqual(processor._rev, {
+    'planet': {
+      'earth': {
+        'inhabitant/human/relationships/planets/data/planet:earth': true
+      }
     }
   }, 'rev links match');
 });

--- a/test/tests/orbit-common/unit/cache/operation-processors/deletion-tracking-processor-test.js
+++ b/test/tests/orbit-common/unit/cache/operation-processors/deletion-tracking-processor-test.js
@@ -18,7 +18,7 @@ const schemaDefinition = {
       },
       relationships: {
         moons: { type: 'hasMany', model: 'moon', inverse: 'planet', actsAsSet: true },
-        races: { type: 'hasMany', model: 'race', inverse: 'planets' },
+        inhabitants: { type: 'hasMany', model: 'inhabitant', inverse: 'planets' },
         next: { type: 'hasOne', model: 'planet', inverse: 'previous' },
         previous: { type: 'hasOne', model: 'planet', inverse: 'next' }
       }
@@ -31,12 +31,12 @@ const schemaDefinition = {
         planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
       }
     },
-    race: {
+    inhabitant: {
       attributes: {
         name: { type: 'string' }
       },
       relationships: {
-        planets: { type: 'hasMany', model: 'planet', inverse: 'races' }
+        planets: { type: 'hasMany', model: 'planet', inverse: 'inhabitants' }
       }
     }
   }


### PR DESCRIPTION
Refactor `CacheIntegrityProcessor` and `SchemaConsistencyProcessor` to handle the `replaceRecord` op and to optimize replacement of relationships in general.

[Fixes #325]