### PR TITLE
Implement Store#liveQuery.

### DIFF
--- a/src/orbit-common/store.js
+++ b/src/orbit-common/store.js
@@ -51,10 +51,11 @@ export default class Store extends Source {
   }
 
   /////////////////////////////////////////////////////////////////////////////
-  // LiveQuery interface implementation
+  // Public methods
   /////////////////////////////////////////////////////////////////////////////
 
-  liveQuery(/* expression */) {
-    throw new Error('coming soon');
+  liveQuery(query) {
+    this.query(query);
+    return this.cache.liveQuery(query);
   }
 }


### PR DESCRIPTION
Store calls `query` and then synchronously returns `cache.liveQuery`
without regard for the return value of `query()`.