### PR TITLE
Refactor Cache to handle operations, not transforms.

### DIFF
--- a/src/orbit-common/store.js
+++ b/src/orbit-common/store.js
@@ -1,11 +1,10 @@
 import Orbit from 'orbit/main';
 import { assert } from 'orbit/lib/assert';
+import { extend as assign } from 'orbit/lib/objects';
 import Source from './source';
 import Queryable from 'orbit/queryable';
 import Updatable from 'orbit/updatable';
-import Transformable from 'orbit/transformable';
 import Cache from './cache';
-import { extend as assign } from 'orbit/lib/objects';
 
 export default class Store extends Source {
   constructor({ schema, keyMap, cacheOptions, name } = {}) {
@@ -15,12 +14,13 @@ export default class Store extends Source {
 
     Queryable.extend(this);
     Updatable.extend(this);
-    Transformable.extend(this);
 
     this.keyMap = keyMap;
     this.name = name || 'store';
 
-    this.cache = new Cache(assign({}, { schema, keyMap }, cacheOptions));
+    this._transformInverses = {};
+
+    this.cache = new Cache(assign({ schema, keyMap }, cacheOptions));
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -28,7 +28,10 @@ export default class Store extends Source {
   /////////////////////////////////////////////////////////////////////////////
 
   _transform(transform) {
-    this.cache.transform(transform);
+    const inverse = this.cache.patch(transform.operations);
+
+    this._transformInverses[transform.id] = inverse;
+
     return Orbit.Promise.resolve([transform]);
   }
 
@@ -47,5 +50,30 @@ export default class Store extends Source {
   liveQuery(query) {
     this.query(query);
     return this.cache.liveQuery(query);
+  }
+
+  /**
+   Rolls back the Store to a particular transformId
+
+   @method rollback
+   @param {string} transformId The ID of the transform to roll back to
+   @returns {undefined}
+  */
+  rollback(transformId) {
+    this.transformLog
+      .after(transformId)
+      .reverse()
+      .forEach((id) => this._rollbackTransform(id));
+
+    this.transformLog.rollback(transformId);
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Private methods
+  /////////////////////////////////////////////////////////////////////////////
+
+  _rollbackTransform(transformId) {
+    const inverseOperations = this._transformInverses[transformId];
+    this.cache.patch(inverseOperations);
   }
 }

--- a/test/tests/integration/coordinator-test.js
+++ b/test/tests/integration/coordinator-test.js
@@ -168,7 +168,7 @@ module('Integration - Coordinator', function(hooks) {
   test('#update - replaceRecord', function(assert) {
     assert.expect(1);
 
-    store.cache.transform(
+    store.cache.patch(
       addRecord({ type: 'planet', id: 'pluto', attributes: { name: 'Pluto', classification: 'superior' } })
     );
 
@@ -187,7 +187,7 @@ module('Integration - Coordinator', function(hooks) {
 
     server.respondWith('DELETE', '/planets/pluto', stubbedResponses.deletePlanet);
 
-    store.cache.transform(addRecord(pluto));
+    store.cache.patch(addRecord(pluto));
 
     return store.update(removeRecord(pluto))
       .then(() => {
@@ -202,7 +202,7 @@ module('Integration - Coordinator', function(hooks) {
     const jupiter = { type: 'planet', id: 'jupiter' };
     const io = { type: 'moon', id: 'io' };
 
-    store.cache.transform([
+    store.cache.patch([
       addRecord(jupiter),
       addRecord(io)
     ]);
@@ -223,7 +223,7 @@ module('Integration - Coordinator', function(hooks) {
     const jupiter = { type: 'planet', id: 'jupiter' };
     const io = { type: 'moon', id: 'io' };
 
-    store.cache.transform([
+    store.cache.patch([
       addRecord(jupiter),
       addRecord(io),
       addToHasMany(jupiter, 'moons', io)
@@ -247,7 +247,7 @@ module('Integration - Coordinator', function(hooks) {
     const io = { type: 'moon', id: 'io' };
     const requestBody = { data: { id: 'io', type: 'moons', relationships: { planet: { data: { type: 'planets', id: 'earth' } } } } };
 
-    store.cache.transform([
+    store.cache.patch([
       addRecord(earth),
       addRecord(jupiter),
       addRecord(io),
@@ -272,7 +272,7 @@ module('Integration - Coordinator', function(hooks) {
     const europa = { type: 'moon', id: 'europa' };
     const expectedRequestBody = { data: { id: 'jupiter', type: 'planets', relationships: { moons: { data: [{ type: 'moons', id: 'io' }, { type: 'moons', id: 'europa' }] } } } };
 
-    store.cache.transform([
+    store.cache.patch([
       addRecord(jupiter),
       addRecord(io),
       addRecord(europa)

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -6,7 +6,6 @@ import {
   RecordNotFoundException,
   ModelNotRegisteredException
 } from 'orbit-common/lib/exceptions';
-import { identity } from 'orbit-common/lib/identifiers';
 import {
   addRecord,
   // replaceRecord,
@@ -55,12 +54,12 @@ test('it exists', function(assert) {
   assert.ok(cache);
 });
 
-test('#transform sets data and #get retrieves it', function(assert) {
+test('#patch sets data and #get retrieves it', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
   const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
 
-  cache.transform(addRecord(earth));
+  cache.patch(addRecord(earth));
 
   assert.deepEqual(cache.get('planet/1'), earth, 'objects match in value');
   assert.notStrictEqual(cache.get('planet/1'), earth, 'objects don\'t match by reference because a clone has been cached');
@@ -71,7 +70,7 @@ test('#has indicates whether a path exists', function(assert) {
 
   const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
 
-  cache.transform(addRecord(earth));
+  cache.patch(addRecord(earth));
 
   assert.equal(cache.has('planet'), true, 'path exists');
   assert.equal(cache.has('planet/1'), true, 'path exists');
@@ -85,64 +84,26 @@ test('#hasDeleted by default just returns the inverse of #has', function(assert)
 
   const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
 
-  cache.transform(addRecord(earth));
+  cache.patch(addRecord(earth));
 
   assert.equal(cache.hasDeleted('planet'), !cache.has('planet'), 'path exists');
   assert.equal(cache.hasDeleted('planet/1'), !cache.has('planet/1'), 'path exists');
   assert.equal(cache.hasDeleted('planet/1/id/bogus'), !cache.has('planet/1/id/bogus'), false, 'path does not exist');
 });
 
-// TODO
-// test('#prepareOperations - for `add` operations, applies a differential if the target path exists', function() {
-//   expect(1);
-//
-//   var planet = { type: 'planet', id: '1', attributes: { name: 'Saturn' } };
-//
-//   cache = new Cache(schema);
-//   cache.reset({ planet: { '1': planet } });
-//
-//   var op = {
-//     op: 'add',
-//     path: ['planet', '1'],
-//     value: { type: 'planet', id: '1', attributes: { name: 'Earth', hasRings: false } }
-//   };
-//
-//   var result = cache.prepareOperations([op]);
-//   deepEqual(result, [{ op: 'replace', path: 'planet/1/attributes/name', value: 'Earth' },
-//                     { op: 'add', path: 'planet/1/attributes/hasRings', value: false }]);
-// });
-//
-// test('#prepareOperations - for `replace` operations, applies a differential if the target path exists', function() {
-//   expect(1);
-//
-//   var planet = { type: 'planet', id: '1', attributes: { name: 'Saturn', hasRings: false } };
-//
-//   cache = new Cache(schema);
-//   cache.reset({ planet: { '1': planet } });
-//
-//   var op = {
-//     op: 'replace',
-//     path: ['planet', '1', 'hasRings'],
-//     value: true
-//   };
-//
-//   var result = cache.prepareOperations([op]);
-//   deepEqual(result, [{ op: 'replace', path: 'planet/1/hasRings', value: true }]);
-// });
-
 test('#length returns the size of data at a path', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
   assert.equal(cache.length('notthere'), 0, 'returns 0 when an object does not exist at a path');
 
-  cache.transform([
+  cache.patch([
     addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } }),
     addRecord({ type: 'planet', id: '2', attributes: { name: 'Mars' } })
   ]);
 
   assert.equal(cache.length('planet'), 2, 'returns count of objects at a path');
 
-  cache.transform(replaceAttribute({ type: 'planet', id: '1' }, 'stuff', { a: true, b: true, c: true }));
+  cache.patch(replaceAttribute({ type: 'planet', id: '1' }, 'stuff', { a: true, b: true, c: true }));
 
   assert.equal(cache.length('planet/1/attributes/stuff'), 3, 'returns size of an object at a path');
 });
@@ -150,7 +111,7 @@ test('#length returns the size of data at a path', function(assert) {
 test('#reset clears the cache by default', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
-  cache.transform(addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } }));
+  cache.patch(addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } }));
 
   cache.reset();
 
@@ -160,7 +121,7 @@ test('#reset clears the cache by default', function(assert) {
 test('#reset overrides the cache completely with the value specified', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
-  cache.transform(addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } }));
+  cache.patch(addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } }));
 
   const newData = { planet: { '2': { type: 'planet', id: '2', attributes: { name: 'Mars' } } } };
 
@@ -169,25 +130,31 @@ test('#reset overrides the cache completely with the value specified', function(
   assert.deepEqual(cache.get(), newData);
 });
 
-test('#transform still succeeds when an operation is a noop', function(assert) {
+test('#patch updates the cache and returns an array of inverse ops', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
-  cache.transform([
+  let inverse = cache.patch([
     addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } }),
     removeRecord({ type: 'planet', id: '2' })
   ]);
 
-  assert.ok(true, 'noop transform succeeds');
+  assert.deepEqual(
+    inverse,
+    [
+      removeRecord({ type: 'planet', id: '1' })
+    ],
+    'ignores ops that are noops'
+  );
 });
 
-test('#transform tracks refs and clears them from hasOne relationships when a referenced record is removed', function(assert) {
+test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
   const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: undefined } } };
   const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: 'planet:p1' } } };
   const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: 'planet:p1' } } };
 
-  cache.transform([
+  cache.patch([
     addRecord(jupiter),
     addRecord(io),
     addRecord(europa)
@@ -196,7 +163,7 @@ test('#transform tracks refs and clears them from hasOne relationships when a re
   assert.equal(cache.get('moon/m1/relationships/planet/data'), 'planet:p1', 'Jupiter has been assigned to Io');
   assert.equal(cache.get('moon/m2/relationships/planet/data'), 'planet:p1', 'Jupiter has been assigned to Europa');
 
-  cache.transform(removeRecord(jupiter));
+  cache.patch(removeRecord(jupiter));
 
   assert.equal(cache.get('planet/p1'), undefined, 'Jupiter is GONE');
 
@@ -204,14 +171,14 @@ test('#transform tracks refs and clears them from hasOne relationships when a re
   assert.equal(cache.get('moon/m2/relationships/planet/data'), undefined, 'Jupiter has been cleared from Europa');
 });
 
-test('#transform tracks refs and clears them from hasMany relationships when a referenced record is removed', function(assert) {
+test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
   var io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
   var europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
   var jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: { 'moon:m1': true, 'moon:m2': true } } } };
 
-  cache.transform([
+  cache.patch([
     addRecord(io),
     addRecord(europa),
     addRecord(jupiter)]);
@@ -219,11 +186,11 @@ test('#transform tracks refs and clears them from hasMany relationships when a r
   assert.equal(cache.get('planet/p1/relationships/moons/data/moon:m1'), true, 'Jupiter has been assigned to Io');
   assert.equal(cache.get('planet/p1/relationships/moons/data/moon:m2'), true, 'Jupiter has been assigned to Europa');
 
-  cache.transform(removeRecord(io));
+  cache.patch(removeRecord(io));
 
   assert.equal(cache.get('moon/m1'), null, 'Io is GONE');
 
-  cache.transform(removeRecord(europa));
+  cache.patch(removeRecord(europa));
 
   assert.equal(cache.get('moon/m2'), null, 'Europa is GONE');
 
@@ -231,15 +198,15 @@ test('#transform tracks refs and clears them from hasMany relationships when a r
   assert.equal(cache.get('planet/p1/relationships/moons/data/moon:m2'), null, 'Europa has been cleared from Jupiter');
 });
 
-test('#transform adds link to hasMany if record doesn\'t exist', function(assert) {
+test('#patch adds link to hasMany if record doesn\'t exist', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
-  cache.transform(addToHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' }));
+  cache.patch(addToHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' }));
 
   assert.equal(cache.get('planet/p1/relationships/moons/data/moon:moon1'), true, 'relationship was added');
 });
 
-test('#transform does not remove link from hasMany if record doesn\'t exist', function(assert) {
+test('#patch does not remove link from hasMany if record doesn\'t exist', function(assert) {
   assert.expect(1);
 
   let cache = new Cache({ schema, keyMap });
@@ -248,12 +215,12 @@ test('#transform does not remove link from hasMany if record doesn\'t exist', fu
     ok(false, 'no operations were applied');
   });
 
-  cache.transform(removeFromHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' }));
+  cache.patch(removeFromHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' }));
 
   assert.equal(cache.get('planet/p1'), undefined, 'planet does not exist');
 });
 
-test('#transform adds hasOne if record doesn\'t exist', function(assert) {
+test('#patch adds hasOne if record doesn\'t exist', function(assert) {
   assert.expect(1);
 
   let cache = new Cache({ schema, keyMap });
@@ -269,10 +236,10 @@ test('#transform adds hasOne if record doesn\'t exist', function(assert) {
     assert.deepEqual(op, operation, 'applied operation');
   });
 
-  cache.transform([operation]);
+  cache.patch([operation]);
 });
 
-test('#transform adds empty hasOne link even if record doesn\'t exist', function(assert) {
+test('#patch adds empty hasOne link even if record doesn\'t exist', function(assert) {
   assert.expect(1);
 
   let cache = new Cache({ schema, keyMap });
@@ -288,43 +255,43 @@ test('#transform adds empty hasOne link even if record doesn\'t exist', function
     assert.deepEqual(op, operation, 'applied operation');
   });
 
-  cache.transform([operation]);
+  cache.patch([operation]);
 });
 
-test('#transform does not add link to hasMany if link already exists', function(assert) {
+test('#patch does not add link to hasMany if link already exists', function(assert) {
   assert.expect(1);
 
   let cache = new Cache({ schema, keyMap });
 
   const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: { data: { 'moon:m1': true } } } };
 
-  cache.transform(addRecord(jupiter));
+  cache.patch(addRecord(jupiter));
 
   cache.on('patch', () => {
     assert.ok(false, 'no operations were applied');
   });
 
-  cache.transform(addToHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' }));
+  cache.patch(addToHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' }));
 
-  assert.ok(true, 'transform completed');
+  assert.ok(true, 'patch completed');
 });
 
-test('#transform does not remove relationship from hasMany if relationship doesn\'t exist', function(assert) {
+test('#patch does not remove relationship from hasMany if relationship doesn\'t exist', function(assert) {
   assert.expect(1);
 
   let cache = new Cache({ schema, keyMap });
 
   const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: {} } };
 
-  cache.transform(addRecord(jupiter));
+  cache.patch(addRecord(jupiter));
 
   cache.on('patch', () => {
     ok(false, 'no operations were applied');
   });
 
-  cache.transform(removeFromHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' }));
+  cache.patch(removeFromHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' }));
 
-  assert.ok(true, 'transform completed');
+  assert.ok(true, 'patch completed');
 });
 
 test('does not replace hasOne if relationship already exists', function(assert) {
@@ -334,15 +301,15 @@ test('does not replace hasOne if relationship already exists', function(assert) 
 
   const europa = { id: 'm1', type: 'moon', attributes: { name: 'Europa' }, relationships: { planet: { data: 'planet:p1' } } };
 
-  cache.transform(addRecord(europa));
+  cache.patch(addRecord(europa));
 
   cache.on('patch', () => {
     assert.ok(false, 'no operations were applied');
   });
 
-  cache.transform(replaceHasOne(europa, 'planet', { type: 'planet', id: 'p1' }));
+  cache.patch(replaceHasOne(europa, 'planet', { type: 'planet', id: 'p1' }));
 
-  assert.ok(true, 'transform completed');
+  assert.ok(true, 'patch completed');
 });
 
 test('does not remove hasOne if relationship doesn\'t exist', function(assert) {
@@ -352,18 +319,18 @@ test('does not remove hasOne if relationship doesn\'t exist', function(assert) {
 
   const europa = { type: 'moon', id: 'm1', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
 
-  cache.transform(addRecord(europa));
+  cache.patch(addRecord(europa));
 
   cache.on('patch', () => {
     assert.ok(false, 'no operations were applied');
   });
 
-  cache.transform(replaceHasOne(europa, 'planet', null));
+  cache.patch(replaceHasOne(europa, 'planet', null));
 
-  assert.ok(true, 'transform completed');
+  assert.ok(true, 'patch completed');
 });
 
-test('#transform removing model with a bi-directional hasOne', function(assert) {
+test('#patch removing model with a bi-directional hasOne', function(assert) {
   assert.expect(5);
 
   const hasOneSchema = new Schema({
@@ -383,7 +350,7 @@ test('#transform removing model with a bi-directional hasOne', function(assert) 
 
   let cache = new Cache({ schema: hasOneSchema, keyMap });
 
-  cache.transform([
+  cache.patch([
     addRecord({
       id: '1',
       type: 'one',
@@ -407,12 +374,12 @@ test('#transform removing model with a bi-directional hasOne', function(assert) 
   assert.equal(one.relationships.two.data, 'two:2', 'one links to two');
   assert.equal(two.relationships.one.data, 'one:1', 'two links to one');
 
-  cache.transform(removeRecord(two));
+  cache.patch(removeRecord(two));
 
   assert.equal(cache.get(['one', '1', 'relationships', 'two', 'data']), null, 'ones link to two got removed');
 });
 
-test('#transform removes dependent records', function(assert) {
+test('#patch removes dependent records', function(assert) {
   // By making this schema recursively dependent remove we check that recursive
   // works as well.
   const dependentSchema = new Schema({
@@ -436,7 +403,7 @@ test('#transform removes dependent records', function(assert) {
   const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: 'planet:p1' } } };
   const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: 'planet:p1' } } };
 
-  cache.transform([
+  cache.patch([
     addRecord(jupiter),
     addRecord(io),
     addRecord(europa),
@@ -445,14 +412,14 @@ test('#transform removes dependent records', function(assert) {
   ]);
 
   // Removing the moon should remove the planet should remove the other moon
-  cache.transform(removeRecord(io));
+  cache.patch(removeRecord(io));
 
   // TODO-investigate why there's still a moon left
   // assert.equal(cache.length('moon'), 0, 'No moons left in store');
   assert.equal(cache.length('planet'), 0, 'No planets left in store');
 });
 
-test('#transform does not remove non-dependent records', function() {
+test('#patch does not remove non-dependent records', function() {
   const dependentSchema = new Schema({
     models: {
       planet: {
@@ -474,7 +441,7 @@ test('#transform does not remove non-dependent records', function() {
   const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: 'planet:p1' } } };
   const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: 'planet:p1' } } };
 
-  cache.transform([
+  cache.patch([
     addRecord(jupiter),
     addRecord(io),
     addRecord(europa),
@@ -484,7 +451,7 @@ test('#transform does not remove non-dependent records', function() {
 
   // Since there are no dependent relationships, no other records will be
   // removed
-  cache.transform(removeRecord(io));
+  cache.patch(removeRecord(io));
 
   equal(cache.length('moon'), 1, 'One moon left in store');
   equal(cache.length('planet'), 1, 'One planet left in store');
@@ -692,40 +659,4 @@ test('#query - relatedRecord', function(assert) {
       jupiter
     }
   );
-});
-
-test('#rollback', function(assert) {
-  let cache = new Cache({ schema, keyMap });
-
-  const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
-  const recordB = { id: 'saturn', type: 'planet', attributes: { name: 'Saturn' } };
-  const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
-  const recordD = { id: 'neptune', type: 'planet', attributes: { name: 'Neptune' } };
-  const recordE = { id: 'uranus', type: 'planet', attributes: { name: 'Uranus' } };
-
-  const addRecordATransform = cache.transform(addRecord(recordA));
-  cache.transform(addRecord(recordB));
-  cache.transform(addRecord(recordC));
-  cache.transform([
-    addRecord(recordD),
-    addRecord(recordE)
-  ]);
-
-  const rollbackOperations = [];
-  cache.on('patch', (operation) => rollbackOperations.push(operation));
-
-  cache.rollback(addRecordATransform.id);
-
-  assert.deepEqual(
-    rollbackOperations,
-    [
-      { op: 'removeRecord', record: identity(recordE) },
-      { op: 'removeRecord', record: identity(recordD) },
-      { op: 'removeRecord', record: identity(recordC) },
-      { op: 'removeRecord', record: identity(recordB) }
-    ],
-    'emits inverse operations in correct order'
-  );
-
-  equal(cache.transformLog.head(), addRecordATransform.id, 'rolls back transform log');
 });

--- a/test/tests/orbit-common/unit/cache/live-queries-test.js
+++ b/test/tests/orbit-common/unit/cache/live-queries-test.js
@@ -63,7 +63,7 @@ module('OC - Cache - liveQuery', function(hooks) {
       done();
     });
 
-    cache.transform([
+    cache.patch([
       addRecord(pluto),
       replaceAttribute(pluto, 'name', 'Pluto2'),
       addRecord(jupiter)
@@ -82,7 +82,7 @@ module('OC - Cache - liveQuery', function(hooks) {
       done();
     });
 
-    cache.transform([
+    cache.patch([
       addRecord(pluto),
       addRecord(jupiter)
     ]);
@@ -103,7 +103,7 @@ module('OC - Cache - liveQuery', function(hooks) {
       done();
     });
 
-    cache.transform([
+    cache.patch([
       addRecord(pluto),
       removeRecord(pluto)
     ]);
@@ -122,7 +122,7 @@ module('OC - Cache - liveQuery', function(hooks) {
       done();
     });
 
-    cache.transform([
+    cache.patch([
       removeRecord(pluto),
       addRecord(pluto)
     ]);
@@ -131,7 +131,7 @@ module('OC - Cache - liveQuery', function(hooks) {
   test('filter - change attribute that causes removal from matches', function(assert) {
     const done = assert.async();
 
-    cache.transform(addRecord(pluto));
+    cache.patch(addRecord(pluto));
 
     const liveQuery = cache.liveQuery(
       qb.records('planet')
@@ -145,7 +145,7 @@ module('OC - Cache - liveQuery', function(hooks) {
       done();
     });
 
-    cache.transform(replaceAttribute({ type: 'planet', id: 'pluto' }, 'name', 'Jupiter'));
+    cache.patch(replaceAttribute({ type: 'planet', id: 'pluto' }, 'name', 'Jupiter'));
   });
 
   test('filter - change attribute that causes add to matches', function(assert) {
@@ -160,7 +160,7 @@ module('OC - Cache - liveQuery', function(hooks) {
       done();
     });
 
-    cache.transform([
+    cache.patch([
       addRecord({ type: 'planet', id: 'uranus', attributes: { name: 'Uranus' } }),
       replaceAttribute({ type: 'planet', id: 'uranus' }, 'name', 'Uranus2')
     ]);
@@ -174,7 +174,7 @@ module('OC - Cache - liveQuery', function(hooks) {
     const onOperation = sinon.stub();
     liveQuery.subscribe(onOperation);
 
-    cache.transform([
+    cache.patch([
       addRecord(pluto),
       removeRecord(pluto)
     ]);
@@ -196,7 +196,7 @@ module('OC - Cache - liveQuery', function(hooks) {
       done();
     });
 
-    cache.transform([
+    cache.patch([
       addRecord(pluto),
       addRecord(jupiter)
     ]);
@@ -205,7 +205,7 @@ module('OC - Cache - liveQuery', function(hooks) {
   test('filter - records with existing match in cache', function(assert) {
     const done = assert.async();
 
-    cache.transform(addRecord(pluto));
+    cache.patch(addRecord(pluto));
 
     const liveQuery = cache.liveQuery(qb.records('planet'));
 
@@ -218,7 +218,7 @@ module('OC - Cache - liveQuery', function(hooks) {
   test('record - existing record with removal', function(assert) {
     const done = assert.async();
 
-    cache.transform(addRecord(pluto));
+    cache.patch(addRecord(pluto));
     const liveQuery = cache.liveQuery(qb.record(identity(pluto)));
     // liveQuery.subscribe(op => console.log('op', op));
 
@@ -231,7 +231,7 @@ module('OC - Cache - liveQuery', function(hooks) {
       done();
     });
 
-    cache.transform(removeRecord(pluto));
+    cache.patch(removeRecord(pluto));
   });
 
   module('relatedRecord', function() {
@@ -251,7 +251,7 @@ module('OC - Cache - liveQuery', function(hooks) {
         done();
       });
 
-      cache.transform([
+      cache.patch([
         // this first transform should not match the liveQuery's filter
         replaceHasOne(io, 'planet', pluto),
         // subsequent transforms should match the liveQuery's filter
@@ -278,7 +278,7 @@ module('OC - Cache - liveQuery', function(hooks) {
         done();
       });
 
-      cache.transform([
+      cache.patch([
         // this first transform should not match the liveQuery's filter
         addToHasMany(pluto, 'moons', io),
         // subsequent transforms should match the liveQuery's filter

--- a/test/tests/orbit-common/unit/cache/observables/cache-observable-test.js
+++ b/test/tests/orbit-common/unit/cache/observables/cache-observable-test.js
@@ -130,7 +130,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
         assert.deepEqual(relatedRecords, [ganymede]);
       });
 
-    cache.transform([
+    cache.patch([
       addRecord(ganymede),
       addRecord(jupiter),
       addToHasMany(jupiter, 'moons', ganymede)
@@ -141,7 +141,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
     const jupiter = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const ganymede = { id: 'ganymede', type: 'moon', attributes: { name: 'Ganymede' } };
 
-    cache.transform([
+    cache.patch([
       addRecord(ganymede),
       addRecord(jupiter),
       addToHasMany(jupiter, 'moons', ganymede)
@@ -154,14 +154,14 @@ module('OC - Cache - CacheObservable', function(hooks) {
         assert.deepEqual(relatedRecords, []);
       });
 
-    cache.transform(removeFromHasMany(jupiter, 'moons', ganymede));
+    cache.patch(removeFromHasMany(jupiter, 'moons', ganymede));
   });
 
   test('patches for hasMany relatedRecords', function(assert) {
     const jupiter = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const ganymede = { id: 'ganymede', type: 'moon', attributes: { name: 'Ganymede' } };
 
-    cache.transform([
+    cache.patch([
       addRecord(ganymede),
       addRecord(jupiter),
       addToHasMany(jupiter, 'moons', ganymede)
@@ -175,7 +175,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
         assert.deepEqual(operation, { op: 'replaceAttribute', record: ganymede, attribute: 'colour', value: 'blue' });
       });
 
-    cache.transform(replaceAttribute(ganymede, 'colour', 'blue'));
+    cache.patch(replaceAttribute(ganymede, 'colour', 'blue'));
   });
 
   test('forHasOne', function(assert) {
@@ -210,7 +210,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
         ]);
       });
 
-    cache.transform([
+    cache.patch([
       addRecord(jupiter),
       addRecord(ganymede),
       replaceHasOne(ganymede, 'planet', jupiter),
@@ -222,7 +222,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
     const jupiter = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const ganymede = { id: 'ganymede', type: 'moon', attributes: { name: 'Ganymede' } };
 
-    cache.transform([
+    cache.patch([
       addRecord(jupiter),
       addRecord(ganymede),
       replaceHasOne(ganymede, 'planet', jupiter)
@@ -235,7 +235,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
         assert.deepEqual(operation, { op: 'removeRecord', record: jupiter });
       });
 
-    cache.transform(replaceHasOne(ganymede, 'planet', null));
+    cache.patch(replaceHasOne(ganymede, 'planet', null));
   });
 
   test('related record for hasOne after add', function(assert) {
@@ -249,7 +249,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
         assert.deepEqual(relatedRecord, jupiter);
       });
 
-    cache.transform([
+    cache.patch([
       addRecord(ganymede),
       addRecord(jupiter),
       replaceHasOne(ganymede, 'planet', jupiter)
@@ -260,7 +260,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
     const jupiter = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const ganymede = { id: 'ganymede', type: 'moon', attributes: { name: 'Ganymede' } };
 
-    cache.transform([
+    cache.patch([
       addRecord(ganymede),
       addRecord(jupiter),
       replaceHasOne(ganymede, 'planet', jupiter)
@@ -273,14 +273,14 @@ module('OC - Cache - CacheObservable', function(hooks) {
         assert.deepEqual(relatedRecord, null);
       });
 
-    cache.transform(replaceHasOne(ganymede, 'planet', null));
+    cache.patch(replaceHasOne(ganymede, 'planet', null));
   });
 
   test('patches for hasOne relatedRecord', function(assert) {
     const jupiter = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const ganymede = { id: 'ganymede', type: 'moon', attributes: { name: 'Ganymede' } };
 
-    cache.transform([
+    cache.patch([
       addRecord(ganymede),
       addRecord(jupiter),
       replaceHasOne(ganymede, 'planet', jupiter)
@@ -299,7 +299,7 @@ module('OC - Cache - CacheObservable', function(hooks) {
         });
       });
 
-    cache.transform(replaceAttribute(jupiter, 'colour', 'blue'));
+    cache.patch(replaceAttribute(jupiter, 'colour', 'blue'));
   });
 
   QUnit.skip('filter');

--- a/test/tests/orbit-common/unit/cache/operation-processors/deletion-tracking-processor-test.js
+++ b/test/tests/orbit-common/unit/cache/operation-processors/deletion-tracking-processor-test.js
@@ -67,7 +67,7 @@ test('tracks deletions and makes them queryable through `hasDeleted`', function(
 
   assert.equal(cache.hasDeleted('planet/saturn'), false, 'Saturn has not been deleted yet');
 
-  cache.transform(removeRecord(saturn));
+  cache.patch(removeRecord(saturn));
 
   assert.equal(cache.hasDeleted('planet/saturn'), true, 'Saturn has been deleted');
   assert.equal(cache.hasDeleted('planet/jupiter'), false, 'Jupiter has not been deleted');


### PR DESCRIPTION
Refactors Cache#transform -> Cache#patch. The name `patch` is already
used to represent application of operations (vs. full Transforms), so
it’s consistent here.

Moves rollback capabilities to the Store class.