### PR TITLE
Ensure model type defined for record query

### DIFF
--- a/src/orbit-common/cache/query-operators.js
+++ b/src/orbit-common/cache/query-operators.js
@@ -1,8 +1,5 @@
 import { merge } from 'orbit/lib/objects';
-import {
-  RecordNotFoundException,
-  ModelNotRegisteredException
-} from '../lib/exceptions';
+import { RecordNotFoundException } from '../lib/exceptions';
 import { every, some } from 'orbit/lib/arrays';
 
 const EMPTY = () => {};
@@ -48,12 +45,16 @@ export default {
     return matches;
   },
 
-  record(context, recordIdentity) {
+  record(context, { type, id }) {
     const cache = this.target;
-    const record = cache.get([recordIdentity.type, recordIdentity.id]);
+    const schema = cache.schema;
+
+    schema.ensureModelTypeInitialized(type);
+
+    const record = cache.get([type, id]);
 
     if (!record) {
-      throw new RecordNotFoundException(`Record not found ${recordIdentity.type}:${recordIdentity.id}`);
+      throw new RecordNotFoundException(`Record not found ${type}:${id}`);
     }
 
     return record;
@@ -63,9 +64,7 @@ export default {
     const cache = this.target;
     const schema = cache.schema;
 
-    if (!schema.containsModel(type)) {
-      throw new ModelNotRegisteredException(`No model registered for ${type}`);
-    }
+    schema.ensureModelTypeInitialized(type);
 
     const records = cache.get([type]);
 

--- a/src/orbit-common/schema.js
+++ b/src/orbit-common/schema.js
@@ -1,7 +1,12 @@
 /* eslint-disable valid-jsdoc */
 import { clone } from 'orbit/lib/objects';
 import { uuid } from 'orbit/lib/uuid';
-import { OperationNotAllowed, ModelNotRegisteredException, KeyNotRegisteredException, RelationshipNotRegisteredException } from './lib/exceptions';
+import {
+  OperationNotAllowed,
+  ModelNotRegisteredException,
+  KeyNotRegisteredException,
+  RelationshipNotRegisteredException
+} from './lib/exceptions';
 import Evented from 'orbit/evented';
 
 /**
@@ -340,7 +345,7 @@ export default class Schema {
    @method modelNotDefined
    @param {String} [model] name of model
    */
-  // TODO modelNotDefined: null,
+  modelNotDefined() {}
 
   /**
    Look up a model definition.
@@ -352,15 +357,24 @@ export default class Schema {
    raised.
 
    @method modelDefinition
-   @param {String} [model] name of model
+   @param {String} type - type of model
    @return {Object} model definition
    */
-  modelDefinition(name) {
-    if (this.containsModel(name)) {
-      return this.models[name];
-    } else {
-      throw new ModelNotRegisteredException(name);
+  modelDefinition(type) {
+    let definition = this.models[type];
+
+    if (!definition) {
+      // Call a hook for lazy type definition
+      this.modelNotDefined(type);
+
+      definition = this.models[type];
+
+      if (!definition) {
+        throw new ModelNotRegisteredException(type);
+      }
     }
+
+    return definition;
   }
 
   initDefaults(record) {
@@ -486,15 +500,8 @@ export default class Schema {
     return relDef;
   }
 
-  containsModel(name) {
-    if (!!this.models[name]) {
-      return true;
-    }
-    if (this.modelNotDefined) {
-      this.modelNotDefined(name);
-      return !!this.models[name];
-    }
-    return false;
+  ensureModelTypeInitialized(type) {
+    this.modelDefinition(type);
   }
 
   _mergeModelSchemas(base) {

--- a/test/tests/orbit-common/unit/cache-test.js
+++ b/test/tests/orbit-common/unit/cache-test.js
@@ -585,6 +585,15 @@ test('#query - record - throws RecordNotFoundException if record doesn\'t exist'
   );
 });
 
+test('#query - record - throws ModelNotRegisteredException if record type doesn\'t exist', function(assert) {
+  let cache = new Cache({ schema, keyMap });
+
+  assert.throws(
+    () => cache.query(oqe('record', { type: 'black-hole', id: 'jupiter' })),
+    new ModelNotRegisteredException('black-hole')
+  );
+});
+
 test('#query - records - finds matching records', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
@@ -611,7 +620,7 @@ test('#query - records - throws ModelNotRegisteredException when model isn\'t re
 
   assert.throws(
     () => cache.query(oqe('records', 'black-hole')),
-    new ModelNotRegisteredException('No model registered for black-hole')
+    new ModelNotRegisteredException('black-hole')
   );
 });
 

--- a/test/tests/orbit-common/unit/schema-test.js
+++ b/test/tests/orbit-common/unit/schema-test.js
@@ -175,7 +175,7 @@ test('#modelDefinition throws an exception if a model is not registered', functi
 });
 
 test('#modelNotDefined can provide lazy registrations of models', function(assert) {
-  assert.expect(4);
+  assert.expect(2);
 
   const schema = new Schema({
     models: {
@@ -188,16 +188,16 @@ test('#modelNotDefined can provide lazy registrations of models', function(asser
     }
   };
 
-  assert.equal(schema.containsModel('planet'), false, 'model not registered');
-
   schema.modelNotDefined = function(type) {
     assert.equal(type, 'planet', 'modelNotDefined called as expected');
     schema.registerModel('planet', planetDefinition);
   };
 
-  assert.equal(schema.containsModel('planet'), true, 'model registered via modelNotDefined hook');
-
-  assert.deepEqual(schema.modelDefinition('planet').attributes, planetDefinition.attributes);
+  assert.deepEqual(
+    schema.modelDefinition('planet').attributes,
+    planetDefinition.attributes,
+    'model registered via modelNotDefined hook'
+  );
 });
 
 test('#normalize initializes a record with a unique primary key', function() {
@@ -339,10 +339,15 @@ test('#singularize simply removes a trailing `s` if present at the end of words'
   equal(schema.singularize('data'), 'data', 'no Latin knowledge here');
 });
 
-test('#containsModel', function(assert) {
+test('#ensureModelTypeInitialized throws an error when a model type has not been registered', function(assert) {
   const schema = new Schema({ models: { moon: {} } });
-  assert.ok(schema.containsModel('moon'), 'identifies when schema contains model');
-  assert.ok(!schema.containsModel('black-hole'), 'identifies when scheam does not contain model');
+
+  // No errors when the model is present
+  schema.ensureModelTypeInitialized('moon');
+
+  assert.throws(function() {
+    schema.ensureModelTypeInitialized('planet');
+  }, ModelNotRegisteredException, 'threw a OC.ModelNotRegisteredException');
 });
 
 test('#generateDefaultId', function(assert) {


### PR DESCRIPTION
To address https://github.com/orbitjs/ember-orbit/issues/116.

After looking through the flow of a `record` query from `ember-orbit` through `orbit` it seemed reasonable that querying for a type that did not exist with a `record` query would behave similarly to a `records` query.  After this change both a `record` and `records` query will allow lazy registration of the model type and throw `ModelNotRegisteredException` if no model can be registered. 

This change provides better error for the related issue by calling `modelNotDefined`, allowing Ember.Orbit to throw descriptive exceptions: https://github.com/orbitjs/ember-orbit/blob/03522ee0c77693d3f355003add28d752f3284692/addon/schema.js#L100.

Some small refactoring changes:

* `Schema#modelDefinition` retains its same behavior, but the implementation of `containsModel` has been inlined there.
* `Schema#containsModel` is removed in favor of a new method `Schema.ensureModelTypeInitialized` that seemed to better describe the new need to lazily register a model and possibly throw an exception.

Definitely open to other approaches, here. Let me know what you think.