### PR TITLE
Reintroduces Orbit.Source.

### DIFF
--- a/src/orbit-common/source.js
+++ b/src/orbit-common/source.js
@@ -1,5 +1,5 @@
 import { assert } from 'orbit/lib/assert';
-import Transformable from 'orbit/transformable';
+import OrbitSource from 'orbit/source';
 
 /**
  Base class for sources.
@@ -11,35 +11,12 @@ import Transformable from 'orbit/transformable';
  @param {String}    options.name - Name for source
  @constructor
  */
-export default class Source {
-  constructor({ schema, name }) {
-    assert('Source\'s `schema` must be specified in `options.schema` constructor argument', schema);
+export default class Source extends OrbitSource {
+  constructor(options = {}) {
+    assert('Source\'s `schema` must be specified in `options.schema` constructor argument', options.schema);
 
-    this.schema = schema;
-    this.name   = name;
+    super(...arguments);
 
-    Transformable.extend(this);
-  }
-
-  /**
-   Truncates the Source's logged and tracked transforms to remove everything
-   before a particular `transformId`.
-
-   @method truncateHistory
-   @param {string} transformId - The ID of the transform to truncate history to.
-   @returns {undefined}
-  */
-  truncateHistory(transformId) {
-    this.transformLog.truncate(transformId);
-  }
-
-  /**
-   Clears the Source's logged and tracked transforms entirely.
-
-   @method clearHistory
-   @returns {undefined}
-  */
-  clearHistory() {
-    this.transformLog.clear();
+    this.schema = options.schema;
   }
 }

--- a/src/orbit/fetchable.js
+++ b/src/orbit/fetchable.js
@@ -1,6 +1,7 @@
-import Query from './query';
-import Transformable from './transformable';
+import { assert } from './lib/assert';
 import { extend } from './lib/objects';
+import Query from './query';
+import Source from './source';
 
 export default {
   /**
@@ -12,7 +13,7 @@ export default {
    */
   extend(source) {
     if (source._fetchable === undefined) {
-      Transformable.extend(source);
+      assert('Fetchable interface can only be applied to a Source', source instanceof Source);
       extend(source, this.interface);
     }
     return source;

--- a/src/orbit/queryable.js
+++ b/src/orbit/queryable.js
@@ -1,7 +1,8 @@
 import Orbit from './main';
+import { assert } from './lib/assert';
 import { extend } from './lib/objects';
 import Query from './query';
-import Evented from './evented';
+import Source from './source';
 
 export default {
   /**
@@ -13,7 +14,7 @@ export default {
    */
   extend(source) {
     if (source._queryable === undefined) {
-      Evented.extend(source);
+      assert('Queryable interface can only be applied to a Source', source instanceof Source);
       extend(source, this.interface);
     }
     return source;

--- a/src/orbit/source.js
+++ b/src/orbit/source.js
@@ -1,0 +1,69 @@
+import Orbit from './main';
+import Evented from './evented';
+import TransformLog from './transform/log';
+
+/**
+ Base class for sources.
+
+ @class Source
+ @namespace Orbit
+ @param {Object} [options] - Options for source
+ @param {String} [options.name] - Name for source
+ @constructor
+ */
+export default class Source {
+  constructor(options = {}) {
+    this.name = options.name;
+    Evented.extend(this);
+    this.transformLog = new TransformLog();
+  }
+
+  /**
+   Notifies listeners that this source has been transformed by emitting the
+   `transform` event.
+
+   Resolves when any promises returned to event listeners are resolved.
+
+   Also, adds an entry to the Source's `transformLog` for each transform.
+
+   @method transformed
+   @param {Array} transforms - Transforms that have occurred.
+   @returns {Promise} Promise that resolves to transforms.
+  */
+  transformed(transforms) {
+    return transforms
+      .reduce((chain, transform) => {
+        return chain.then(() => {
+          if (this.transformLog.contains(transform.id)) {
+            return Orbit.Promise.resolve();
+          }
+
+          this.transformLog.append(transform.id);
+          return this.settle('transform', transform);
+        });
+      }, Orbit.Promise.resolve())
+      .then(() => transforms);
+  }
+
+  /**
+   Truncates the source's logged and tracked transforms to remove everything
+   before a particular `transformId`.
+
+   @method truncateHistory
+   @param {string} transformId - The ID of the transform to truncate history to.
+   @returns {undefined}
+  */
+  truncateHistory(transformId) {
+    this.transformLog.truncate(transformId);
+  }
+
+  /**
+   Clears the source's logged and tracked transforms entirely.
+
+   @method clearHistory
+   @returns {undefined}
+  */
+  clearHistory() {
+    this.transformLog.clear();
+  }
+}

--- a/src/orbit/transformable.js
+++ b/src/orbit/transformable.js
@@ -1,8 +1,8 @@
 import Orbit from './main';
+import { assert } from './lib/assert';
 import { extend } from './lib/objects';
-import Evented from './evented';
 import Transform from './transform';
-import TransformLog from './transform/log';
+import Source from './source';
 
 export default {
   /**
@@ -14,9 +14,8 @@ export default {
    */
   extend(source) {
     if (source._transformable === undefined) {
-      Evented.extend(source);
+      assert('Transformable interface can only be applied to a Source', source instanceof Source);
       extend(source, this.interface);
-      source.transformLog = new TransformLog();
     }
     return source;
   },
@@ -33,21 +32,6 @@ export default {
 
       return this._transform(transform)
         .then(result => this.transformed(result));
-    },
-
-    transformed(transforms) {
-      return transforms
-        .reduce((chain, transform) => {
-          return chain.then(() => {
-            if (this.transformLog.contains(transform.id)) {
-              return Orbit.Promise.resolve();
-            }
-
-            this.transformLog.append(transform.id);
-            return this.settle('transform', transform);
-          });
-        }, Orbit.Promise.resolve())
-        .then(() => transforms);
     }
   }
 };

--- a/src/orbit/updatable.js
+++ b/src/orbit/updatable.js
@@ -1,6 +1,8 @@
 import Orbit from './main';
+import Source from './source';
 import Transform from './transform';
 import Transformable from './transformable';
+import { assert } from './lib/assert';
 import { extend } from './lib/objects';
 
 export default {
@@ -13,6 +15,7 @@ export default {
    */
   extend(source) {
     if (source._updatable === undefined) {
+      assert('Updatable interface can only be applied to a Source', source instanceof Source);
       Transformable.extend(source);
       extend(source, this.interface);
     }

--- a/test/tests/orbit-common/unit/source-test.js
+++ b/test/tests/orbit-common/unit/source-test.js
@@ -1,6 +1,6 @@
 import Source from 'orbit-common/source';
 import Schema from 'orbit-common/schema';
-import Transform from 'orbit/transform';
+import OrbitSource from 'orbit/source';
 
 const schemaDefinition = {
   models: {
@@ -15,10 +15,6 @@ const schemaDefinition = {
 let schema;
 
 module('OC - Source', function(hooks) {
-  const transformA = Transform.from({ op: 'addRecord', value: {} });
-  const transformB = Transform.from({ op: 'addRecord', value: {} });
-  const transformC = Transform.from({ op: 'addRecord', value: {} });
-
   let source;
 
   hooks.beforeEach(function() {
@@ -30,48 +26,16 @@ module('OC - Source', function(hooks) {
     assert.ok(source);
   });
 
+  test('it extends Orbit.Source', function(assert) {
+    assert.ok(source instanceof OrbitSource);
+  });
+
   test('it should require a schema to be passed in', function(assert) {
     assert.throws(
-      () => new Source(),
-      'Assertion failed: Source\'s `schema` must be specified in `options.schema` constructor argument'
+      () => {
+        source = new Source();
+      },
+      Error('Assertion failed: Source\'s `schema` must be specified in `options.schema` constructor argument')
     );
-  });
-
-  test('it is Transformable', function(assert) {
-    assert.ok(source._transformable, 'Transformable mixin has been applied');
-  });
-
-  test('it can truncate its transform history', function(assert) {
-    return source.transformed([transformA, transformB, transformC])
-      .then(() => {
-        assert.deepEqual(
-          source.transformLog.entries(),
-          [transformA, transformB, transformC].map(t => t.id),
-          'transform log is correct');
-
-        source.truncateHistory(transformB.id);
-
-        assert.deepEqual(
-          source.transformLog.entries(),
-          [transformB, transformC].map(t => t.id),
-          'transform log has been truncated');
-      });
-  });
-
-  test('it can clear its transform history', function(assert) {
-    return source.transformed([transformA, transformB, transformC])
-      .then(() => {
-        assert.deepEqual(
-          source.transformLog.entries(),
-          [transformA, transformB, transformC].map(t => t.id),
-          'transform log is correct');
-
-        source.clearHistory();
-
-        assert.deepEqual(
-          source.transformLog.entries(),
-          [],
-          'transform log has been cleared');
-      });
   });
 });

--- a/test/tests/orbit/unit/fetchable-test.js
+++ b/test/tests/orbit/unit/fetchable-test.js
@@ -1,13 +1,14 @@
+import Source from 'orbit/source';
 import Fetchable from 'orbit/fetchable';
 import Transform from 'orbit/transform';
 import { Promise } from 'rsvp';
 import { successfulOperation, failedOperation } from 'tests/test-helper';
 
-var source;
+let source;
 
 module('Orbit - Fetchable', {
   setup: function() {
-    source = {};
+    source = new Source();
     Fetchable.extend(source);
   },
 
@@ -18,6 +19,15 @@ module('Orbit - Fetchable', {
 
 test('it exists', function(assert) {
   assert.ok(source);
+});
+
+test('it should be applied to a Source', function(assert) {
+  assert.throws(function() {
+    let pojo = {};
+    Fetchable.extend(pojo);
+  },
+  Error('Assertion failed: Fetchable interface can only be applied to a Source'),
+  'assertion raised');
 });
 
 test('it should resolve as a failure when _fetch fails', function(assert) {

--- a/test/tests/orbit/unit/queryable-test.js
+++ b/test/tests/orbit/unit/queryable-test.js
@@ -1,12 +1,13 @@
 import Queryable from 'orbit/queryable';
+import Source from 'orbit/source';
 import { Promise } from 'rsvp';
 import { successfulOperation, failedOperation } from 'tests/test-helper';
 
-var source;
+let source;
 
 module('Orbit - Queryable', {
   setup: function() {
-    source = {};
+    source = new Source();
     Queryable.extend(source);
   },
 
@@ -17,6 +18,15 @@ module('Orbit - Queryable', {
 
 test('it exists', function(assert) {
   assert.ok(source);
+});
+
+test('it should be applied to a Source', function(assert) {
+  assert.throws(function() {
+    let pojo = {};
+    Queryable.extend(pojo);
+  },
+  Error('Assertion failed: Queryable interface can only be applied to a Source'),
+  'assertion raised');
 });
 
 test('it should resolve as a failure when _query fails', function(assert) {

--- a/test/tests/orbit/unit/source-test.js
+++ b/test/tests/orbit/unit/source-test.js
@@ -1,0 +1,92 @@
+import Source from 'orbit/source';
+import Transform from 'orbit/transform';
+
+module('Orbit - Source', function(hooks) {
+  const transformA = Transform.from({ op: 'addRecord', value: {} });
+  const transformB = Transform.from({ op: 'addRecord', value: {} });
+  const transformC = Transform.from({ op: 'addRecord', value: {} });
+
+  let source;
+
+  hooks.beforeEach(function() {
+    source = new Source();
+  });
+
+  test('it exists', function(assert) {
+    assert.ok(source);
+    assert.ok(source.transformLog, 'has a transform log');
+  });
+
+  test('it should mixin Evented', function(assert) {
+    ['on', 'off', 'emit', 'poll'].forEach(function(prop) {
+      assert.ok(source[prop], 'should have Evented properties');
+    });
+  });
+
+  test('it defines `transformed`', function(assert) {
+    assert.equal(typeof source.transformed, 'function', 'transformed exists');
+  });
+
+  test('#transformed should trigger `transform` event BEFORE resolving', function(assert) {
+    assert.expect(3);
+
+    let order = 0;
+    const appliedTransform = Transform.from({ op: 'addRecord', value: {} });
+
+    source.on('transform', (transform) => {
+      assert.equal(++order, 1, '`transform` event triggered after action performed successfully');
+      assert.strictEqual(transform, appliedTransform, 'applied transform matches');
+    });
+
+    return source.transformed([appliedTransform])
+      .then(() => {
+        assert.equal(++order, 2, 'transformed promise resolved last');
+      });
+  });
+
+  test('#transformLog contains transforms applied', function(assert) {
+    assert.expect(2);
+
+    const appliedTransform = Transform.from({ op: 'addRecord', value: {} });
+
+    assert.ok(!source.transformLog.contains(appliedTransform.id));
+
+    return source
+      .transformed([appliedTransform])
+      .then(() => assert.ok(source.transformLog.contains(appliedTransform.id)));
+  });
+
+  test('it can truncate its transform history', function(assert) {
+    return source.transformed([transformA, transformB, transformC])
+      .then(() => {
+        assert.deepEqual(
+          source.transformLog.entries(),
+          [transformA, transformB, transformC].map(t => t.id),
+          'transform log is correct');
+
+        source.truncateHistory(transformB.id);
+
+        assert.deepEqual(
+          source.transformLog.entries(),
+          [transformB, transformC].map(t => t.id),
+          'transform log has been truncated');
+      });
+  });
+
+  test('it can clear its transform history', function(assert) {
+    return source.transformed([transformA, transformB, transformC])
+      .then(() => {
+        assert.deepEqual(
+          source.transformLog.entries(),
+          [transformA, transformB, transformC].map(t => t.id),
+          'transform log is correct');
+
+        source.clearHistory();
+
+        assert.deepEqual(
+          source.transformLog.entries(),
+          [],
+          'transform log has been cleared');
+      });
+  });
+});

--- a/test/tests/orbit/unit/transformable-test.js
+++ b/test/tests/orbit/unit/transformable-test.js
@@ -1,14 +1,13 @@
 import Orbit from 'orbit/main';
+import Source from 'orbit/source';
 import Transformable from 'orbit/transformable';
 import Transform from 'orbit/transform';
 
 let source;
 
-///////////////////////////////////////////////////////////////////////////////
-
 module('Orbit - Transformable', {
   setup() {
-    source = {};
+    source = new Source();
     Transformable.extend(source);
   },
 
@@ -19,46 +18,19 @@ module('Orbit - Transformable', {
 
 test('it exists', function(assert) {
   assert.ok(source);
-  assert.ok(source.transformLog, 'has a transform log');
 });
 
-test('it should mixin Evented', function(assert) {
-  ['on', 'off', 'emit', 'poll'].forEach(function(prop) {
-    assert.ok(source[prop], 'should have Evented properties');
-  });
+test('it should be applied to a Source', function(assert) {
+  assert.throws(function() {
+    let pojo = {};
+    Transformable.extend(pojo);
+  },
+  Error('Assertion failed: Transformable interface can only be applied to a Source'),
+  'assertion raised');
 });
 
-test('it defines `transformed`', function(assert) {
-  assert.equal(typeof source.transformed, 'function', 'transformed exists');
-});
-
-test('#transformed should trigger `transform` event BEFORE resolving', function(assert) {
-  assert.expect(3);
-
-  let order = 0;
-  const appliedTransform = Transform.from({ op: 'addRecord', value: {} });
-
-  source.on('transform', (transform) => {
-    assert.equal(++order, 1, '`transform` event triggered after action performed successfully');
-    assert.strictEqual(transform, appliedTransform, 'applied transform matches');
-  });
-
-  return source.transformed([appliedTransform])
-    .then(() => {
-      assert.equal(++order, 2, 'transformed promise resolved last');
-    });
-});
-
-test('#transformLog contains transforms applied', function(assert) {
-  assert.expect(2);
-
-  const appliedTransform = Transform.from({ op: 'addRecord', value: {} });
-
-  assert.ok(!source.transformLog.contains(appliedTransform.id));
-
-  return source
-    .transformed([appliedTransform])
-    .then(() => assert.ok(source.transformLog.contains(appliedTransform.id)));
+test('it defines `transform`', function(assert) {
+  assert.equal(typeof source.transform, 'function', 'transform function exists');
 });
 
 test('#transform should convert non-Transforms into Transforms', function(assert) {

--- a/test/tests/orbit/unit/updatable-test.js
+++ b/test/tests/orbit/unit/updatable-test.js
@@ -1,13 +1,14 @@
+import Source from 'orbit/source';
 import Updatable from 'orbit/updatable';
 import Transform from 'orbit/transform';
 import { Promise } from 'rsvp';
 import { successfulOperation, failedOperation } from 'tests/test-helper';
 
-var source;
+let source;
 
 module('Orbit - Updatable', {
   setup: function() {
-    source = {};
+    source = new Source();
     Updatable.extend(source);
   },
 
@@ -18,6 +19,15 @@ module('Orbit - Updatable', {
 
 test('it exists', function(assert) {
   assert.ok(source);
+});
+
+test('it should be applied to a Source', function(assert) {
+  assert.throws(function() {
+    let pojo = {};
+    Updatable.extend(pojo);
+  },
+  Error('Assertion failed: Updatable interface can only be applied to a Source'),
+  'assertion raised');
 });
 
 test('it should mixin Updatable', function(assert) {


### PR DESCRIPTION
Orbit.Source provides a baseline for all sources and simplifies the
implementations of interfaces such as Transformable, Queryable, and
Fetchable. 

Every source has a `transformLog`, `transformed` method, and implements
`Evented`.

This allows for a distinction between sources that can emit transform
events but not have transforms applied. The latter is still covered by
the `Transformable` interface, which now simply adds the `transform`
method and is more inline with the other *able mixins.

----

_Sorry for the churn around the (Orbit/OC) Source classes. This change brings Orbit more inline with what @opsb and I settled on a while back, but still allows for the transform history tracking required by the recent refactor._