### PR TITLE
Updatable#update now returns transforms applied to source.

### DIFF
--- a/src/orbit/updatable.js
+++ b/src/orbit/updatable.js
@@ -26,18 +26,22 @@ export default {
     _updatable: true,
 
     update(transformOrOperations) {
-      const transform = Transform.from(transformOrOperations);
+      const requestedTransform = Transform.from(transformOrOperations);
+      let appliedTransforms;
 
-      if (this.transformLog.contains(transform.id)) {
+      if (this.transformLog.contains(requestedTransform.id)) {
         return Orbit.Promise.resolve([]);
       }
 
-      return this.series('beforeUpdate', transform)
-        .then(() => this.transform(transform))
-        .then(() => this.settle('update', transform))
-        .then(() => transform)
+      return this.series('beforeUpdate', requestedTransform)
+        .then(() => this.transform(requestedTransform))
+        .then(transforms => {
+          appliedTransforms = transforms;
+          return this.settle('update', requestedTransform, appliedTransforms);
+        })
+        .then(() => appliedTransforms)
         .catch(error => {
-          return this.settle('updateFail', transform, error)
+          return this.settle('updateFail', requestedTransform, error)
             .then(() => { throw error; });
         });
     }

--- a/test/tests/orbit/unit/updatable-test.js
+++ b/test/tests/orbit/unit/updatable-test.js
@@ -87,7 +87,7 @@ test('it should trigger `update` event after a successful action in which `trans
   return source.update(addRecordTransform)
     .then((result) => {
       assert.equal(++order, 6, 'promise resolved last');
-      assert.strictEqual(result, addRecordTransform, 'transform is returned on success');
+      assert.deepEqual(result, resultingTransforms, 'applied transforms are returned on success');
     });
 });
 
@@ -161,7 +161,7 @@ test('it should resolve all promises returned from `beforeUpdate` before calling
   return source.update(addRecordTransform)
     .then((result) => {
       assert.equal(++order, 6, 'promise resolved last');
-      assert.strictEqual(result, addRecordTransform, 'transform is returned on success');
+      assert.deepEqual(result, resultingTransforms, 'applied transforms are returned on success');
     });
 });
 


### PR DESCRIPTION
The return value of `update` is now consistent with `fetch` and 
`transform` - in all cases a promise is returned that resolves to the 
transforms applied to a source as a direct result of the method call.
Note that this will not include transforms applied as side effects from
event handlers, such as `beforeUpdate` or `update`.