### PR TITLE
JSONAPISource and LocalStorageSource implement Updatable.

### DIFF
--- a/src/orbit-common/jsonapi-source.js
+++ b/src/orbit-common/jsonapi-source.js
@@ -2,7 +2,7 @@
 import Orbit from 'orbit/main';
 import { assert } from 'orbit/lib/assert';
 import Fetchable from 'orbit/fetchable';
-import Transformable from 'orbit/transformable';
+import Updatable from 'orbit/updatable';
 import Source from './source';
 import Serializer from './serializer';
 import JSONAPISerializer from './jsonapi/serializer';
@@ -39,7 +39,7 @@ export default class JSONAPISource extends Source {
     super(options);
 
     Fetchable.extend(this);
-    Transformable.extend(this);
+    Updatable.extend(this); // implicitly extends Transformable
 
     this.name             = options.name || 'jsonapi';
     this.namespace        = options.namespace;

--- a/src/orbit-common/local-storage-source.js
+++ b/src/orbit-common/local-storage-source.js
@@ -2,7 +2,7 @@
 import Orbit from 'orbit/main';
 import Source from './source';
 import Fetchable from 'orbit/fetchable';
-import Transformable from 'orbit/transformable';
+import Updatable from 'orbit/updatable';
 import { assert } from 'orbit/lib/assert';
 import TransformOperators from './local-storage/transform-operators';
 import FetchOperators from './local-storage/fetch-operators';
@@ -33,7 +33,7 @@ export default class LocalStorageSource extends Source {
     super(options);
 
     Fetchable.extend(this);
-    Transformable.extend(this);
+    Updatable.extend(this); // implicitly extends Transformable
 
     this.name      = options.name || 'localStorage';
     this.namespace = options['namespace'] || 'orbit'; // local storage namespace

--- a/test/tests/orbit-common/unit/jsonapi-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-source-test.js
@@ -84,6 +84,11 @@ test('implements Fetchable', function(assert) {
   assert.ok(typeof source.fetch === 'function', 'has `fetch` method');
 });
 
+test('implements Updatable', function(assert) {
+  assert.ok(source._updatable, 'implements Updatable');
+  assert.ok(typeof source.update === 'function', 'has `update` method');
+});
+
 test('implements Transformable', function(assert) {
   assert.ok(source._transformable, 'implements Transformable');
   assert.ok(typeof source.transform === 'function', 'has `transform` method');

--- a/test/tests/orbit-common/unit/local-storage-source-test.js
+++ b/test/tests/orbit-common/unit/local-storage-source-test.js
@@ -48,6 +48,21 @@ test('its prototype chain is correct', function(assert) {
   assert.ok(source instanceof Source, 'instanceof Source');
 });
 
+test('implements Fetchable', function(assert) {
+  assert.ok(source._fetchable, 'implements Fetchable');
+  assert.ok(typeof source.fetch === 'function', 'has `fetch` method');
+});
+
+test('implements Updatable', function(assert) {
+  assert.ok(source._updatable, 'implements Updatable');
+  assert.ok(typeof source.update === 'function', 'has `update` method');
+});
+
+test('implements Transformable', function(assert) {
+  assert.ok(source._transformable, 'implements Transformable');
+  assert.ok(typeof source.transform === 'function', 'has `transform` method');
+});
+
 test('is assigned a default namespace and delimiter', function(assert) {
   assert.equal(source.namespace, 'orbit', 'namespace is `orbit` by default');
   assert.equal(source.delimiter, '/', 'delimiter is `/` by default');


### PR DESCRIPTION
The Updatable interface allow these sources to participate in the 
“request” flow for updates (such that events are raised that other
sources can engage with). Under the hood, Updatable implicitly 
includes Transformable, and `update` calls `transform` internally, so 
the implementation doesn’t really change.