### PR TITLE
Improve separation of request / sync flows in the Coordinator.

### DIFF
--- a/src/orbit-common/coordinator.js
+++ b/src/orbit-common/coordinator.js
@@ -86,16 +86,14 @@ export default class Coordinator {
       case 'query':
         return node.queryableSource;
 
+      case 'beforeFetch':
       case 'fetch':
         return node.fetchableSource;
-
-      case 'transform':
-        return node.transformableSource;
     }
   }
 
-  sourceForRequest(node, event) {
-    switch (event) {
+  sourceForRequest(node, request) {
+    switch (request) {
       case 'update':
         return node.updatableSource;
 
@@ -104,9 +102,6 @@ export default class Coordinator {
 
       case 'fetch':
         return node.fetchableSource;
-
-      case 'transform':
-        return node.transformableSource;
     }
   }
 
@@ -147,7 +142,7 @@ export default class Coordinator {
       source.on(strategy.sourceEvent, request => {
         const promise = this.queueRequest(target, strategy.targetRequest, request)
           .then(result => {
-            if (result && strategy.mergeTransforms) {
+            if (result && strategy.syncResults) {
               return result.reduce((chain, t) => {
                 return chain.then(() => this.queueTransform(source, t));
               }, Orbit.Promise.resolve());
@@ -158,10 +153,10 @@ export default class Coordinator {
           return promise;
         }
       });
-    } else if (strategy.type === 'transform') {
+    } else if (strategy.type === 'sync') {
       const sourceNode = this.nodes[strategy.sourceNode];
       const targetNode = this.nodes[strategy.targetNode];
-      const target = this.sourceForRequest(targetNode, 'transform');
+      const target = targetNode.transformableSource;
 
       Object.keys(sourceNode.sources).forEach(name => {
         const source = sourceNode.sources[name];


### PR DESCRIPTION
Request flows include monitoring events and triggering methods related
to “requestable” interfaces like `Updatable`, `Queryable`, and
`Fetchable`.

Sync flows include monitoring the `transform` event and triggering the
`transform` method on a target `Transformable` source.

Request strategies can now include the `syncResults` option to have the
results of a request sync’d back to the source node (`syncResults` was
previously named `mergeTransforms`).

Also, the coordinator integration tests now include a sync strategy for
backing up to local storage.