### PR TITLE
Upgrade to rxjs 5.0.0-beta.10

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -113,28 +113,14 @@ packages.forEach(function(pkg) {
   });
 });
 
-var rxjs = (function() {
-  var original = new Funnel('node_modules', {
-    srcDir: 'rxjs-es',
-    include: ['**/*.js'],
-    destDir: 'rxjs'
-  });
-
-  var withAsyncFix = replace(original, {
-    files: [
-      'rxjs/Rx.DOM.js',
-      'rxjs/Rx.js'
-    ],
-    patterns: [
-      { match: /async,/, replace: 'async: async,' }
-    ]
-  });
-
-  return withAsyncFix;
-})();
+var rxjs = new Funnel('node_modules', {
+  srcDir: 'rxjs-es',
+  include: ['**/*.js'],
+  destDir: 'rxjs'
+});
 
 var symbolObservable = new Funnel('node_modules', {
-  srcDir: 'symbol-observable',
+  srcDir: 'rxjs-es/node_modules/symbol-observable/es',
   include: ['ponyfill.js'],
   destDir: '.',
   getDestinationPath: function() {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "immutable": "^3.7.6",
-    "rxjs-es": "5.0.0-beta.8",
-    "symbol-observable": "~0.2.4"
+    "rxjs-es": "5.0.0-beta.10"
   }
 }


### PR DESCRIPTION
The rxjs changelog from beta.8 to beta.10 claims no breaking changes.

This upgrade includes a workaround for Babel compiling issues, making
it possible to remove our own `withAsyncFix` workaround.

The rxjs-es package now includes symbol-observable 1.0.1 and I opted to
import `ponyfill.js` from that included dependency rather than
specifying it again in package.json.

@opsb, I don't know why we have to manually include the `symbol-observable` ponyfill file on our own, but I confirmed that build still breaks without this. As I recall this required some spelunking on your part that I'm not keen to repeat.

@opsb Could you give this a sanity check?