### PR TITLE
Remove `poll` method from Evented and Notifier.

### DIFF
--- a/src/orbit/evented.js
+++ b/src/orbit/evented.js
@@ -63,26 +63,6 @@ function removeNotifierForEvent(object, eventName) {
  source.emit('greeting salutation', 'hello', 'bonjour', 'guten tag');
  ```
 
- Last but not least, listeners can be polled
- (note that spaces can't be used in event names):
-
- ```javascript
- source.on('question', function(question) {
-   if (question === 'favorite food?') return 'beer';
- });
-
- source.on('question', function(question) {
-   if (question === 'favorite food?') return 'wasabi almonds';
- });
-
- source.on('question', function(question) {
-   // this listener doesn't return anything, and therefore won't participate
-   // in the poll
- });
-
- source.poll('question', 'favorite food?'); // returns ['beer', 'wasabi almonds']
- ```
-
  @class Evented
  @namespace Orbit
  @extension
@@ -154,19 +134,6 @@ export default {
           notifier.emit.apply(notifier, args);
         }
       });
-    },
-
-    poll(eventNames, ...args) {
-      let responses = [];
-
-      eventNames.split(/\s+/).forEach((eventName) => {
-        let notifier = notifierForEvent(this, eventName);
-        if (notifier) {
-          responses = responses.concat(notifier.poll.apply(notifier, args));
-        }
-      });
-
-      return responses;
     },
 
     listeners(eventNames) {

--- a/src/orbit/notifier.js
+++ b/src/orbit/notifier.js
@@ -16,25 +16,7 @@
  notifier.emit('hello'); // logs "I heard hello" and "I also heard hello"
  ```
 
- Notifiers can also poll listeners with an event and return their responses:
-
- ```javascript
- var dailyQuestion = new Orbit.Notifier();
- dailyQuestion.addListener(function(question) {
-   if (question === 'favorite food?') return 'beer';
- });
- dailyQuestion.addListener(function(question) {
-   if (question === 'favorite food?') return 'wasabi almonds';
- });
- dailyQuestion.addListener(function(question) {
-   // this listener doesn't return anything, and therefore won't participate
-   // in the poll
- });
-
- dailyQuestion.poll('favorite food?'); // returns ['beer', 'wasabi almonds']
- ```
-
- Calls to `emit` and `poll` will send along all of their arguments.
+ Calls to `emit` will send along all of their arguments.
 
  @class Notifier
  @namespace Orbit
@@ -91,25 +73,5 @@ export default class Notifier {
     this.listeners.slice(0).forEach((listener) => {
       listener[0].apply(listener[1], args);
     });
-  }
-
-  /**
-   Poll registered listeners.
-
-   Any responses from listeners will be returned in an array.
-
-   @method poll
-   @param {*} Any number of parameters to be sent to listeners
-   @returns {Array} Array of responses
-   */
-  poll(...args) {
-    let allResponses = [];
-
-    this.listeners.slice(0).forEach((listener) => {
-      let response = listener[0].apply(listener[1], args);
-      if (response !== undefined) { allResponses.push(response); }
-    });
-
-    return allResponses;
   }
 }

--- a/test/tests/orbit/unit/evented-test.js
+++ b/test/tests/orbit/unit/evented-test.js
@@ -194,54 +194,6 @@ test('#emit - can emit multiple events with the same arguments sequentially', fu
   evented.emit('greeting salutation', 'hello');
 });
 
-test('#poll - can poll listeners with an event and return all the responses in an array', function() {
-  expect(4);
-
-  let listener1 = function(message) {
-    equal(message, 'hello', 'notification message should match');
-    // note: no return value
-  };
-  let listener2 = function(message) {
-    equal(message, 'hello', 'notification message should match');
-    return 'bonjour';
-  };
-  let listener3 = function(message) {
-    equal(message, 'hello', 'notification message should match');
-    return 'sup';
-  };
-
-  evented.on('greeting', listener1);
-  evented.on('greeting', listener2);
-  evented.on('greeting', listener3);
-
-  deepEqual(evented.poll('greeting', 'hello'), ['bonjour', 'sup'], 'poll response should include the responses of all listeners');
-});
-
-test('#poll - can poll listeners with multiple events and return all the responses in a single array', function() {
-  expect(2);
-
-  let greeting1 = function() {
-    return 'Hello';
-  };
-  let greeting2 = function() {
-    return 'Bon jour';
-  };
-  let parting1 = function() {
-    return 'Goodbye';
-  };
-  let parting2 = function() {
-    return 'Au revoir';
-  };
-
-  evented.on('greeting', greeting1);
-  evented.on('greeting', greeting2);
-  evented.on('parting', parting1);
-  evented.on('parting', parting2);
-
-  deepEqual(evented.poll('greeting parting'), ['Hello', 'Bon jour', 'Goodbye', 'Au revoir'], 'poll response should include the responses of all listeners in order');
-  deepEqual(evented.poll('parting greeting'), ['Goodbye', 'Au revoir', 'Hello', 'Bon jour'], 'poll response should include the responses of all listeners in order');
-});
-
 test('#listeners - can return all the listeners (and bindings) for an event', function() {
   expect(1);
 

--- a/test/tests/orbit/unit/notifier-test.js
+++ b/test/tests/orbit/unit/notifier-test.js
@@ -86,26 +86,3 @@ test('it notifies listeners when publishing any number of arguments', function()
 
   notifier.emit('hello', 'world');
 });
-
-test('it notifies listeners when polling with a simple message and returns any responses', function() {
-  expect(4);
-
-  let listener1 = function(message) {
-    equal(message, 'hello', 'notification message should match');
-    // note: no return value
-  };
-  let listener2 = function(message) {
-    equal(message, 'hello', 'notification message should match');
-    return 'bonjour';
-  };
-  let listener3 = function(message) {
-    equal(message, 'hello', 'notification message should match');
-    return 'sup';
-  };
-
-  notifier.addListener(listener1);
-  notifier.addListener(listener2);
-  notifier.addListener(listener3);
-
-  deepEqual(notifier.poll('hello'), ['bonjour', 'sup'], 'poll response should include the responses of all listeners');
-});

--- a/test/tests/orbit/unit/source-test.js
+++ b/test/tests/orbit/unit/source-test.js
@@ -18,7 +18,7 @@ module('Orbit - Source', function(hooks) {
   });
 
   test('it should mixin Evented', function(assert) {
-    ['on', 'off', 'emit', 'poll'].forEach(function(prop) {
+    ['on', 'off', 'emit'].forEach(function(prop) {
       assert.ok(source[prop], 'should have Evented properties');
     });
   });


### PR DESCRIPTION
Method is no longer used by Orbit or Ember-Orbit.