### PR TITLE
Mixins should extend class prototypes.

### DIFF
--- a/src/orbit-common/cache.js
+++ b/src/orbit-common/cache.js
@@ -35,8 +35,6 @@ import 'orbit-common/rxjs/add/observable/from-orbit-event';
  */
 export default class Cache {
   constructor(options = {}) {
-    Evented.extend(this);
-
     this.keyMap = options.keyMap;
     this.schema = options.schema;
 
@@ -316,3 +314,5 @@ export default class Cache {
     this.emit('patch', op);
   }
 }
+
+Evented.extend(Cache.prototype);

--- a/src/orbit-common/jsonapi-source.js
+++ b/src/orbit-common/jsonapi-source.js
@@ -38,9 +38,6 @@ export default class JSONAPISource extends Source {
 
     super(options);
 
-    Fetchable.extend(this);
-    Updatable.extend(this); // implicitly extends Transformable
-
     this.name             = options.name || 'jsonapi';
     this.namespace        = options.namespace;
     this.host             = options.host;
@@ -210,3 +207,6 @@ export default class JSONAPISource extends Source {
     return result.then(() => transforms);
   }
 }
+
+Fetchable.extend(JSONAPISource.prototype);
+Updatable.extend(JSONAPISource.prototype); // implicitly extends Transformable

--- a/src/orbit-common/local-storage-source.js
+++ b/src/orbit-common/local-storage-source.js
@@ -32,9 +32,6 @@ export default class LocalStorageSource extends Source {
 
     super(options);
 
-    Fetchable.extend(this);
-    Updatable.extend(this); // implicitly extends Transformable
-
     this.name      = options.name || 'localStorage';
     this.namespace = options['namespace'] || 'orbit'; // local storage namespace
     this.delimiter = options['delimiter'] || '/'; // local storage key
@@ -96,3 +93,6 @@ export default class LocalStorageSource extends Source {
     return Orbit.Promise.resolve(transforms);
   }
 }
+
+Fetchable.extend(LocalStorageSource.prototype);
+Updatable.extend(LocalStorageSource.prototype); // implicitly extends Transformable

--- a/src/orbit-common/schema.js
+++ b/src/orbit-common/schema.js
@@ -286,8 +286,6 @@ export default class Schema {
       this.singularize = options.singularize;
     }
 
-    Evented.extend(this);
-
     // register provided model schema
     this.models = {};
     if (options.models) {
@@ -540,3 +538,5 @@ export default class Schema {
     }
   }
 }
+
+Evented.extend(Schema.prototype);

--- a/src/orbit-common/store.js
+++ b/src/orbit-common/store.js
@@ -12,12 +12,9 @@ import {
 
 export default class Store extends Source {
   constructor({ schema, keyMap, cacheOptions, name } = {}) {
-    assert('Store\'s `keyMap` must be specified in `options.keyMap` constructor argument', keyMap);
-
     super(...arguments);
 
-    Queryable.extend(this);
-    Updatable.extend(this);
+    assert('Store\'s `keyMap` must be specified in `options.keyMap` constructor argument', keyMap);
 
     this.keyMap = keyMap;
     this.name = name || 'store';
@@ -200,3 +197,6 @@ export default class Store extends Source {
     delete this._transformInverses[transformId];
   }
 }
+
+Queryable.extend(Store.prototype);
+Updatable.extend(Store.prototype);

--- a/src/orbit/action-queue.js
+++ b/src/orbit/action-queue.js
@@ -50,8 +50,6 @@ export default class ActionQueue {
   constructor(options) {
     assert('ActionQueue requires Orbit.Promise to be defined', Orbit.Promise);
 
-    Evented.extend(this);
-
     options = options || {};
     this.autoProcess = options.autoProcess !== undefined ? options.autoProcess : true;
 
@@ -121,3 +119,5 @@ export default class ActionQueue {
     }
   }
 }
+
+Evented.extend(ActionQueue.prototype);

--- a/src/orbit/evented.js
+++ b/src/orbit/evented.js
@@ -4,7 +4,10 @@ import { assert } from './lib/assert';
 import { extend } from './lib/objects';
 
 function notifierForEvent(object, eventName, createIfUndefined) {
-  var notifier = object._eventedNotifiers[eventName];
+  if (object._eventedNotifiers === undefined) {
+    object._eventedNotifiers = {};
+  }
+  let notifier = object._eventedNotifiers[eventName];
   if (!notifier && createIfUndefined) {
     notifier = object._eventedNotifiers[eventName] = new Notifier();
   }
@@ -12,7 +15,9 @@ function notifierForEvent(object, eventName, createIfUndefined) {
 }
 
 function removeNotifierForEvent(object, eventName) {
-  delete object._eventedNotifiers[eventName];
+  if (object._eventedNotifiers && object._eventedNotifiers[eventName]) {
+    delete object._eventedNotifiers[eventName];
+  }
 }
 
 /**
@@ -81,8 +86,8 @@ export default {
 
     if (object._evented === undefined) {
       extend(object, this.interface);
-      object._eventedNotifiers = {};
     }
+
     return object;
   },
 

--- a/src/orbit/source.js
+++ b/src/orbit/source.js
@@ -14,7 +14,6 @@ import TransformLog from './transform/log';
 export default class Source {
   constructor(options = {}) {
     this.name = options.name;
-    Evented.extend(this);
     this.transformLog = new TransformLog();
   }
 
@@ -67,3 +66,5 @@ export default class Source {
     this.transformLog.clear();
   }
 }
+
+Evented.extend(Source.prototype);


### PR DESCRIPTION
Moving mixin extensions out of constructors and instead applying them
to class prototypes provides a slight performance win and allows for 
method overrides in subclasses.