### PR TITLE
Introduce classes for coordination strategies.

### DIFF
--- a/src/orbit-common/coordinator.js
+++ b/src/orbit-common/coordinator.js
@@ -1,4 +1,3 @@
-import Orbit from 'orbit/main';
 import { assert } from 'orbit/lib/assert';
 import ActionQueue from 'orbit/action-queue';
 
@@ -129,47 +128,5 @@ export default class Coordinator {
     });
 
     return action.complete;
-  }
-
-  defineStrategy(strategy) {
-    if (strategy.type === 'request') {
-      const sourceNode = this.nodes[strategy.sourceNode];
-      const targetNode = this.nodes[strategy.targetNode];
-      const source = this.sourceForEvent(sourceNode, strategy.sourceEvent);
-      const target = this.sourceForRequest(targetNode, strategy.targetRequest);
-
-      // TODO move event management to a Strategy object
-      source.on(strategy.sourceEvent, request => {
-        const promise = this.queueRequest(target, strategy.targetRequest, request)
-          .then(result => {
-            if (result && strategy.syncResults) {
-              return result.reduce((chain, t) => {
-                return chain.then(() => this.queueTransform(source, t));
-              }, Orbit.Promise.resolve());
-            }
-          });
-
-        if (strategy.blocking) {
-          return promise;
-        }
-      });
-    } else if (strategy.type === 'sync') {
-      const sourceNode = this.nodes[strategy.sourceNode];
-      const targetNode = this.nodes[strategy.targetNode];
-      const target = targetNode.transformableSource;
-
-      Object.keys(sourceNode.sources).forEach(name => {
-        const source = sourceNode.sources[name];
-
-        // TODO move event management to a Strategy object
-        source.on('transform', transform => {
-          const promise = this.queueTransform(target, transform);
-
-          if (strategy.blocking) {
-            return promise;
-          }
-        });
-      });
-    }
   }
 }

--- a/src/orbit-common/strategies/request-strategy.js
+++ b/src/orbit-common/strategies/request-strategy.js
@@ -1,0 +1,52 @@
+import Orbit from 'orbit/main';
+
+export default class RequestStrategy {
+  constructor({ coordinator, sourceNode, targetNode, sourceEvent, targetRequest, syncResults, blocking, autoActivate }) {
+    this.coordinator = coordinator;
+    this.sourceNode = coordinator.nodes[sourceNode];
+    this.targetNode = coordinator.nodes[targetNode];
+    this.sourceEvent = sourceEvent;
+    this.targetRequest = targetRequest;
+    this.syncResults = syncResults;
+    this.blocking = blocking;
+
+    this.source = coordinator.sourceForEvent(this.sourceNode, sourceEvent);
+    this.target = coordinator.sourceForRequest(this.targetNode, targetRequest);
+
+    if (autoActivate || autoActivate === undefined) {
+      this.activate();
+    }
+  }
+
+  activate() {
+    const { coordinator, source, target, sourceEvent, targetRequest, syncResults, blocking } = this;
+
+    const eventListener = (request) => {
+      const promise = coordinator.queueRequest(target, targetRequest, request)
+        .then(result => {
+          if (result && syncResults) {
+            return result.reduce((chain, t) => {
+              return chain.then(() => coordinator.queueTransform(source, t));
+            }, Orbit.Promise.resolve());
+          }
+        });
+
+      if (blocking) {
+        return promise;
+      }
+    };
+
+    source.on(sourceEvent, eventListener);
+
+    this.eventListener = eventListener;
+  }
+
+  deactivate() {
+    const { source, sourceEvent, eventListener } = this;
+
+    if (eventListener) {
+      source.off(sourceEvent, eventListener);
+      delete this.eventListener;
+    }
+  }
+}

--- a/src/orbit-common/strategies/sync-strategy.js
+++ b/src/orbit-common/strategies/sync-strategy.js
@@ -1,0 +1,50 @@
+export default class SyncStrategy {
+  constructor({ coordinator, sourceNode, targetNode, blocking, autoActivate }) {
+    this.coordinator = coordinator;
+    this.sourceNode = coordinator.nodes[sourceNode];
+    this.targetNode = coordinator.nodes[targetNode];
+    this.blocking = blocking;
+
+    if (autoActivate || autoActivate === undefined) {
+      this.activate();
+    }
+  }
+
+  activate() {
+    const { sourceNode, targetNode } = this;
+    const target = targetNode.transformableSource;
+
+    this.eventListeners = {};
+
+    Object.keys(sourceNode.sources).forEach(name => {
+      const source = sourceNode.sources[name];
+
+      const listener = (transform) => {
+        const promise = this.coordinator.queueTransform(target, transform);
+
+        if (this.blocking) {
+          return promise;
+        }
+      };
+
+      source.on('transform', listener);
+
+      this.eventListeners[name] = listener;
+    });
+  }
+
+  deactivate() {
+    const { sourceNode, eventListeners } = this;
+
+    if (eventListeners) {
+      Object.keys(eventListeners).forEach(name => {
+        const source = sourceNode.sources[name];
+        const listener = eventListeners[name];
+
+        source.off('transform', listener);
+      });
+
+      delete this.eventListeners;
+    }
+  }
+}

--- a/test/tests/integration/coordinator-test.js
+++ b/test/tests/integration/coordinator-test.js
@@ -1,5 +1,7 @@
 import { planetsSchema } from 'tests/test-helper';
 import Coordinator from 'orbit-common/coordinator';
+import SyncStrategy from 'orbit-common/strategies/sync-strategy';
+import RequestStrategy from 'orbit-common/strategies/request-strategy';
 import Store from 'orbit-common/store';
 import JsonApiSource from 'orbit-common/jsonapi-source';
 import LocalStorageSource from 'orbit-common/local-storage-source';
@@ -89,6 +91,9 @@ module('Integration - Coordinator', function(hooks) {
   let localStorage;
   let jsonApiSource;
   let coordinator;
+  let updateRequestStrategy;
+  let queryRequestStrategy;
+  let localBackupStrategy;
 
   hooks.beforeEach(function() {
     server = sinon.fakeServer.create();
@@ -112,8 +117,8 @@ module('Integration - Coordinator', function(hooks) {
       sources: [jsonApiSource]
     });
 
-    coordinator.defineStrategy({
-      type: 'request',
+    updateRequestStrategy = new RequestStrategy({
+      coordinator,
       sourceNode: 'master',
       targetNode: 'upstream',
       sourceEvent: 'beforeUpdate',
@@ -122,8 +127,8 @@ module('Integration - Coordinator', function(hooks) {
       syncResults: true
     });
 
-    coordinator.defineStrategy({
-      type: 'request',
+    queryRequestStrategy = new RequestStrategy({
+      coordinator,
       sourceNode: 'master',
       targetNode: 'upstream',
       sourceEvent: 'beforeQuery',
@@ -132,8 +137,8 @@ module('Integration - Coordinator', function(hooks) {
       syncResults: true
     });
 
-    coordinator.defineStrategy({
-      type: 'sync',
+    localBackupStrategy = new SyncStrategy({
+      coordinator,
       sourceNode: 'master',
       targetNode: 'backup',
       blocking: false
@@ -141,6 +146,10 @@ module('Integration - Coordinator', function(hooks) {
   });
 
   hooks.afterEach(function() {
+    updateRequestStrategy.deactivate();
+    queryRequestStrategy.deactivate();
+    localBackupStrategy.deactivate();
+
     localStorage.reset();
     server.restore();
   });


### PR DESCRIPTION
Create strategies separate from the Coordinator class:

* `RequestStrategy` - coordinates requests
* `SyncStrategy` - coordinates transforms

These strategies are now more robust than the implementations in
Coordinator. `activate` activates event listener(s) and `deactivate`
deactivates them.