### PR TITLE
Replace jQuery.ajax with fetch.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -162,7 +162,7 @@ mainWithTests = concat(mainWithTests, {
 var vendor = concat('', {
   inputFiles: [
     'node_modules/immutable/dist/immutable.js',
-    'node_modules/jquery/dist/jquery.js',
+    'node_modules/whatwg-fetch/fetch.js',
     'node_modules/rsvp/dist/rsvp.js'],
   outputFile: '/assets/vendor.js'
 });

--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ your promise library's `Promise` constructor as follows:
 Orbit.Promise = RSVP.Promise;
 ```
 
-If you're using an Orbit source that relies on an `ajax` method (such as
-`JSONAPISource`), configure it as follows:
-
-```javascript
-Orbit.ajax = jQuery.ajax;
-```
+The `JSONAPISource` uses the experimental [Fetch
+API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for network
+requests. If you're running Orbit in an environment that does not support fetch,
+use a polyfill such as [whatwg-fetch](https://github.com/github/fetch) or
+[node-fetch](https://github.com/bitinn/node-fetch).
 
 Other sources may have other configuration requirements.
 

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "broccoli-replace": "~0.12.0",
     "broccoli-sourcemap-concat": "^0.4.3",
     "git-repo-version": "^0.1.1",
-    "jquery": "^3.0.0",
     "js-string-escape": "^1.0.1",
     "loader.js": "4.0.1",
     "qunitjs": "^1.23.1",
     "rsvp": "^3.2.1",
     "testem": "1.6.0",
+    "whatwg-fetch": "1.0.0",
     "yuidocjs": "^0.8.1"
   },
   "dependencies": {

--- a/src/orbit-common/jsonapi/queries.js
+++ b/src/orbit-common/jsonapi/queries.js
@@ -22,29 +22,28 @@ function deserialize(source, data) {
 
 export const QueryRequestProcessors = {
   records(source, request) {
-    const { type } = request;
-    const hash = {};
+    const { type, filter } = request;
+    const settings = {};
 
-    if (request.filter) {
-      hash.data = hash.data || {};
-      hash.data.filter = request.filter;
+    if (filter) {
+      settings.params = { filter };
     }
 
-    return source.ajax(source.resourceURL(type), 'GET', hash)
+    return source.fetch(source.resourceURL(type), settings)
       .then(data => deserialize(source, data));
   },
 
   record(source, request) {
     const { record } = request;
 
-    return source.ajax(source.resourceURL(record.type, record.id), 'GET')
+    return source.fetch(source.resourceURL(record.type, record.id))
       .then(data => deserialize(source, data));
   },
 
   relationship(source, request) {
     const { record, relationship } = request;
 
-    return source.ajax(source.resourceRelationshipURL(record.type, record.id, relationship), 'GET')
+    return source.fetch(source.resourceRelationshipURL(record.type, record.id, relationship))
       .then(raw => {
         let relId = source.serializer.deserializeRelationship(raw.data);
         return relId;
@@ -54,7 +53,7 @@ export const QueryRequestProcessors = {
   relatedRecords(source, request) {
     const { record, relationship } = request;
 
-    return source.ajax(source.relatedResourceURL(record.type, record.id, relationship), 'GET')
+    return source.fetch(source.relatedResourceURL(record.type, record.id, relationship))
       .then(data => deserialize(source, data));
   }
 };

--- a/src/orbit-common/jsonapi/query-params.js
+++ b/src/orbit-common/jsonapi/query-params.js
@@ -1,0 +1,37 @@
+function flattenObjectToParams(obj, path = []) {
+  let params = [];
+
+  Object.keys(obj).forEach(key => {
+    if (!obj.hasOwnProperty(key)) { return; }
+
+    let newPath = path.slice();
+    newPath.push(key);
+
+    if (typeof obj[key] === 'object') {
+      Array.prototype.push.apply(params, flattenObjectToParams(obj[key], newPath));
+    } else {
+      params.push({
+        path: newPath,
+        val: obj[key]
+      });
+    }
+  });
+
+  return params;
+}
+
+export function encodeQueryParams(obj) {
+  return flattenObjectToParams(obj)
+    .map(param => {
+      if (param.path.length === 1) {
+        param.path = param.path[0];
+      } else {
+        let firstSegment = param.path[0];
+        let remainingSegments = param.path.slice(1);
+        param.path = firstSegment + '[' + remainingSegments.join('][') + ']';
+      }
+      return param;
+    })
+    .map(param => encodeURIComponent(param.path) + '=' + encodeURIComponent(param.val))
+    .join('&');
+}

--- a/src/orbit-common/jsonapi/transform-requests.js
+++ b/src/orbit-common/jsonapi/transform-requests.js
@@ -9,7 +9,7 @@ export const TransformRequestProcessors = {
     const record = serializer.initializeRecord(request.record);
     const json = serializer.serialize(record);
 
-    return source.ajax(source.resourceURL(record.type), 'POST', { data: json })
+    return source.fetch(source.resourceURL(record.type), { method: 'POST', json })
       .then((raw) => {
         let data = serializer.deserialize(raw);
         let updatedRecord = data.primary;
@@ -24,7 +24,7 @@ export const TransformRequestProcessors = {
   removeRecord(source, request) {
     const { type, id } = request.record;
 
-    return source.ajax(source.resourceURL(type, id), 'DELETE')
+    return source.fetch(source.resourceURL(type, id), { method: 'DELETE' })
       .then(() => []);
   },
 
@@ -32,7 +32,7 @@ export const TransformRequestProcessors = {
     const { type, id } = request.record;
     const json = source.serializer.serialize(request.record);
 
-    return source.ajax(source.resourceURL(type, id), 'PATCH', { data: json })
+    return source.fetch(source.resourceURL(type, id), { method: 'PATCH', json })
       .then(() => []);
   },
 
@@ -43,7 +43,7 @@ export const TransformRequestProcessors = {
       data: request.relatedRecords.map(r => source.serializer.serializeIdentifier(r))
     };
 
-    return source.ajax(source.resourceRelationshipURL(type, id, relationship), 'POST', { data: json })
+    return source.fetch(source.resourceRelationshipURL(type, id, relationship), { method: 'POST', json })
       .then(() => []);
   },
 
@@ -54,7 +54,7 @@ export const TransformRequestProcessors = {
       data: request.relatedRecords.map(r => source.serializer.serializeIdentifier(r))
     };
 
-    return source.ajax(source.resourceRelationshipURL(type, id, relationship), 'DELETE', { data: json })
+    return source.fetch(source.resourceRelationshipURL(type, id, relationship), { method: 'DELETE', json })
       .then(() => []);
   },
 
@@ -65,7 +65,7 @@ export const TransformRequestProcessors = {
       data: relatedRecord ? source.serializer.serializeIdentifier(relatedRecord) : null
     };
 
-    return source.ajax(source.resourceRelationshipURL(type, id, relationship), 'PATCH', { data: json })
+    return source.fetch(source.resourceRelationshipURL(type, id, relationship), { method: 'PATCH', json })
       .then(() => []);
   },
 
@@ -76,7 +76,7 @@ export const TransformRequestProcessors = {
       data: relatedRecords.map(r => source.serializer.serializeIdentifier(r))
     };
 
-    return source.ajax(source.resourceRelationshipURL(type, id, relationship), 'PATCH', { data: json })
+    return source.fetch(source.resourceRelationshipURL(type, id, relationship), { method: 'PATCH', json })
       .then(() => []);
   }
 };

--- a/test/test-support/test-shims.js
+++ b/test/test-support/test-shims.js
@@ -1,5 +1,5 @@
 (function() {
-  /* global define, RSVP, jQuery, sinon */
+  /* global define, RSVP, sinon */
 
   define('rsvp', [], function() {
     'use strict';
@@ -7,14 +7,6 @@
     return RSVP;
   });
 })();
-
-define('jquery', [], function() {
-  'use strict';
-
-  return {
-    'default': jQuery
-  };
-});
 
 define('sinon', [], function() {
   'use strict';

--- a/test/tests/orbit-common/unit/jsonapi/query-params-test.js
+++ b/test/tests/orbit-common/unit/jsonapi/query-params-test.js
@@ -1,0 +1,54 @@
+import { encodeQueryParams } from 'orbit-common/jsonapi/query-params';
+
+module('OC - JSONAPI - QueryParams', function() {
+  module('encodeQueryParams', function() {
+    test('empty', function(assert) {
+      assert.strictEqual(
+        encodeQueryParams(
+          { }
+        ),
+        ''
+      );
+    });
+
+    test('simple', function(assert) {
+      assert.deepEqual(
+        encodeQueryParams(
+          { a: 'b' }
+        ),
+        'a=b'
+      );
+    });
+
+    test('multiple', function(assert) {
+      assert.deepEqual(
+        encodeQueryParams(
+          { a: 'b',
+            b: 'c' }
+        ),
+        'a=b&b=c'
+      );
+    });
+
+    test('multi-layered and encoded', function(assert) {
+      assert.deepEqual(
+        encodeQueryParams(
+          {
+            a: 'b',
+            b: 'c',
+            d: {
+              e: 'f',
+              g: {
+                h: 'long sentence here'
+              }
+            }
+          }
+        ),
+        'a=b&' +
+        'b=c&' +
+        encodeURIComponent('d[e]') + '=f&' +
+        encodeURIComponent('d[g][h]') + '=' + encodeURIComponent('long sentence here')
+      );
+    });
+  });
+});

--- a/test/tests/support/jsonapi.js
+++ b/test/tests/support/jsonapi.js
@@ -1,0 +1,15 @@
+import { Promise } from 'rsvp';
+
+export function jsonapiResponse(status, _data = {}) {
+  const headers = {};
+
+  let data = JSON.stringify(_data);
+  headers['Content-Type'] = 'application/vnd.api+json';
+
+  const response = new window.Response(
+    data,
+    { status, headers }
+  );
+
+  return Promise.resolve(response);
+}

--- a/test/tests/support/orbit-setup.js
+++ b/test/tests/support/orbit-setup.js
@@ -1,9 +1,9 @@
+/* globals fetch */
 import Orbit from 'orbit/main';
 import { Promise } from 'rsvp';
-import jQuery from 'jquery';
 
 Orbit.Promise = Promise;
-Orbit.ajax = jQuery.ajax;
+Orbit.fetch = fetch;
 
 Orbit.pluralize = function(original) {
   return original.match(/s$/) ? original : original + 's';

--- a/test/tests/test-helper.js
+++ b/test/tests/test-helper.js
@@ -21,11 +21,16 @@ import {
 
 } from './support/local-storage';
 
+import {
+  jsonapiResponse
+} from './support/jsonapi';
+
 import { planetsSchema } from './support/schemas';
 
 import './support/rsvp';
 
 export {
+  jsonapiResponse,
   serializeOps,
   serializeOp,
   op,


### PR DESCRIPTION
Using `fetch` provides the following benefits:

* More natural promise-driven API with improved error handling.
* Eliminates jQuery dependency.
* Enables usage of Orbit in non-browser environments.
* Simplifies testing of network requests, which can now be done with
  simple stubbing.

Orbit now requires the use of a polyfill in environments without `fetch` 
support.