### PR TITLE
Allow `fetch` to be polyfilled or ponyfilled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,24 @@ does not implement Promises, or if you wish to use another Promise implementatio
 your promise library's `Promise` constructor as follows:
 
 ```javascript
+import Orbit from 'orbit';
+
 Orbit.Promise = RSVP.Promise;
 ```
 
 The `JSONAPISource` uses the experimental [Fetch
 API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for network
-requests. If you're running Orbit in an environment that does not support fetch,
-use a polyfill such as [whatwg-fetch](https://github.com/github/fetch) or
-[node-fetch](https://github.com/bitinn/node-fetch).
+requests. If you're running Orbit in an environment that does not support
+`fetch`, use a polyfill such as [whatwg-fetch](https://github.com/github/fetch)
+or [node-fetch](https://github.com/bitinn/node-fetch). Alternatively, you can
+use a `fetch` ponyfill and set it on the main `Orbit` object. For example:
+
+```javascript
+import Orbit from 'orbit';
+import fetch from 'ember-network/fetch';
+
+Orbit.fetch = fetch;
+```
 
 Other sources may have other configuration requirements.
 

--- a/src/orbit-common/jsonapi-source.js
+++ b/src/orbit-common/jsonapi-source.js
@@ -12,6 +12,10 @@ import { getTransformRequests, TransformRequestProcessors } from './jsonapi/tran
 import { encodeQueryParams } from './jsonapi/query-params';
 import { QueryNotAllowed, TransformNotAllowed } from './lib/exceptions';
 
+if (typeof fetch !== 'undefined' && Orbit.fetch === undefined) {
+  Orbit.fetch = fetch;
+}
+
 /**
  Source for accessing a JSON API compliant RESTful API with a network fetch
  request.
@@ -37,6 +41,7 @@ export default class JSONAPISource extends Source {
     assert('JSONAPISource\'s `schema` must be specified in `options.schema` constructor argument', options.schema);
     assert('JSONAPISource\'s `keyMap` must be specified in `options.keyMap` constructor argument', options.keyMap);
     assert('JSONAPISource requires Orbit.Promise be defined', Orbit.Promise);
+    assert('JSONAPISource requires Orbit.fetch be defined', Orbit.fetch);
 
     super(options);
 
@@ -130,7 +135,7 @@ export default class JSONAPISource extends Source {
       delete settings.params;
     }
 
-    return fetch(url, settings)
+    return Orbit.fetch(url, settings)
       .then(this.checkFetchStatus)
       .then(response => response.json());
   }

--- a/src/orbit.js
+++ b/src/orbit.js
@@ -1,8 +1,3 @@
-/* globals Promise */
 import Orbit from 'orbit/main';
-
-if (typeof Promise !== 'undefined') {
-  Orbit.Promise = Promise;
-}
 
 export default Orbit;

--- a/src/orbit/main.js
+++ b/src/orbit/main.js
@@ -1,3 +1,4 @@
+/* globals Promise */
 /**
  Contains core methods and classes for Orbit.js
 
@@ -12,5 +13,9 @@
  @static
  */
 var Orbit = {};
+
+if (typeof Promise !== 'undefined') {
+  Orbit.Promise = Promise;
+}
 
 export default Orbit;

--- a/test/tests/integration/coordinator-test.js
+++ b/test/tests/integration/coordinator-test.js
@@ -1,4 +1,4 @@
-import { planetsSchema } from 'tests/test-helper';
+import Orbit from 'orbit/main';
 import Coordinator from 'orbit-common/coordinator';
 import SyncStrategy from 'orbit-common/strategies/sync-strategy';
 import RequestStrategy from 'orbit-common/strategies/request-strategy';
@@ -21,7 +21,8 @@ import {
 import {
   verifyLocalStorageContainsRecord,
   verifyLocalStorageDoesNotContainRecord,
-  jsonapiResponse
+  jsonapiResponse,
+  planetsSchema
 } from 'tests/test-helper';
 
 let fetchStub;
@@ -36,7 +37,7 @@ module('Integration - Coordinator', function(hooks) {
   let localBackupStrategy;
 
   hooks.beforeEach(function() {
-    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub = sinon.stub(Orbit, 'fetch');
 
     let keyMap = new KeyMap();
     coordinator = new Coordinator();

--- a/test/tests/orbit-common/unit/jsonapi-source-test.js
+++ b/test/tests/orbit-common/unit/jsonapi-source-test.js
@@ -1,3 +1,4 @@
+import Orbit from 'orbit/main';
 import Source from 'orbit-common/source';
 import { uuid } from 'orbit/lib/uuid';
 import Schema from 'orbit-common/schema';
@@ -25,7 +26,7 @@ let fetchStub, keyMap, source;
 
 module('OC - JSONAPISource - with a secondary key', {
   setup() {
-    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub = sinon.stub(Orbit, 'fetch');
 
     let schema = new Schema({
       modelDefaults: {
@@ -665,7 +666,7 @@ test('#pull - relatedRecords', function(assert) {
 
 module('OC - JSONAPISource - with no secondary keys', {
   setup() {
-    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub = sinon.stub(Orbit, 'fetch');
 
     let schema = new Schema({
       modelDefaults: {

--- a/test/tests/support/orbit-setup.js
+++ b/test/tests/support/orbit-setup.js
@@ -1,9 +1,7 @@
-/* globals fetch */
 import Orbit from 'orbit/main';
 import { Promise } from 'rsvp';
 
 Orbit.Promise = Promise;
-Orbit.fetch = fetch;
 
 Orbit.pluralize = function(original) {
   return original.match(/s$/) ? original : original + 's';


### PR DESCRIPTION
By using `Orbit.fetch` instead of requiring a global `fetch`, Orbit can
more flexibly allow this method to be polyfilled or ponyfilled. 

If global `fetch` is present, it will be used as the default value for 
`Orbit.fetch`. However, `Orbit.fetch` can alternatively be set 
directly, which will override other alternatives.

This makes `Orbit.fetch` consistent with `Orbit.Promise`.

/cc @mitchlloyd 