### PR TITLE
Refactor Action and ActionQueue

### DIFF
--- a/src/orbit-common/coordinator.js
+++ b/src/orbit-common/coordinator.js
@@ -121,7 +121,7 @@ export default class Coordinator {
       }
     });
 
-    return action.complete;
+    return action.settle();
   }
 
   queueTransform(source, transform) {
@@ -134,6 +134,6 @@ export default class Coordinator {
       }
     });
 
-    return action.complete;
+    return action.settle();
   }
 }

--- a/src/orbit/action-queue.js
+++ b/src/orbit/action-queue.js
@@ -57,20 +57,36 @@ export default class ActionQueue {
     this.actions = [];
   }
 
-  push(action) {
-    let actionObject;
+  push(_action) {
+    let action = Action.from(_action);
 
-    if (action instanceof Action) {
-      actionObject = action;
-    } else {
-      actionObject = new Action(action);
-    }
-
-    this.actions.push(actionObject);
+    this.actions.push(action);
 
     if (this.autoProcess) { this.process(); }
 
-    return actionObject;
+    return action;
+  }
+
+  clear() {
+    assert('ActionQueue#clear can only be called when the queue is not being processed', !this._resolution);
+
+    this.actions = [];
+  }
+
+  shift() {
+    assert('ActionQueue#shift can only be called when the queue is not being processed', !this._resolution);
+
+    return this.actions.shift();
+  }
+
+  unshift(_action) {
+    assert('ActionQueue#unshift can only be called when the queue is not being processed', !this._resolution);
+
+    let action = Action.from(_action);
+
+    this.actions.unshift(action);
+
+    return action;
   }
 
   process() {

--- a/src/orbit/action-queue.js
+++ b/src/orbit/action-queue.js
@@ -54,13 +54,13 @@ export default class ActionQueue {
     this.autoProcess = options.autoProcess !== undefined ? options.autoProcess : true;
 
     this._resolution = null;
-    this.actions = [];
+    this._actions = [];
   }
 
   push(_action) {
     let action = Action.from(_action);
 
-    this.actions.push(action);
+    this._actions.push(action);
 
     if (this.autoProcess) { this.process(); }
 
@@ -70,13 +70,13 @@ export default class ActionQueue {
   clear() {
     assert('ActionQueue#clear can only be called when the queue is not being processed', !this._resolution);
 
-    this.actions = [];
+    this._actions = [];
   }
 
   shift() {
     assert('ActionQueue#shift can only be called when the queue is not being processed', !this._resolution);
 
-    return this.actions.shift();
+    return this._actions.shift();
   }
 
   unshift(_action) {
@@ -84,14 +84,14 @@ export default class ActionQueue {
 
     let action = Action.from(_action);
 
-    this.actions.unshift(action);
+    this._actions.unshift(action);
 
     return action;
   }
 
   process() {
     if (!this._resolution) {
-      if (this.actions.length === 0) {
+      if (this._actions.length === 0) {
         this._resolution = Orbit.Promise.resolve();
       } else {
         this._resolution = new Orbit.Promise((resolve, reject) => {
@@ -110,18 +110,18 @@ export default class ActionQueue {
   }
 
   _settleEach() {
-    if (this.actions.length === 0) {
+    if (this._actions.length === 0) {
       this._resolution = null;
       this.emit('complete');
     } else {
-      let action = this.actions[0];
+      let action = this._actions[0];
 
       this.emit('beforeAction', action);
 
       action.process()
         .then(() => {
           this.emit('action', action);
-          this.actions.shift();
+          this._actions.shift();
           this._settleEach();
         })
         .catch((e) => {

--- a/src/orbit/action.js
+++ b/src/orbit/action.js
@@ -29,20 +29,23 @@ export default class Action {
     this.id = options.id;
     this.data = options.data;
     this._process = options.process;
-    this.processing = false;
-
-    this.complete = new Orbit.Promise((resolve, reject) => {
+    this._processing = false;
+    this._resolution = new Orbit.Promise((resolve, reject) => {
       this._success = resolve;
       this._fail = (e) => {
-        this.processing = false;
+        this._processing = false;
         reject(e);
       };
     });
   }
 
+  settle() {
+    return this._resolution;
+  }
+
   process() {
-    if (!this.processing) {
-      this.processing = true;
+    if (!this._processing) {
+      this._processing = true;
 
       try {
         let ret = this._process();
@@ -57,6 +60,6 @@ export default class Action {
       }
     }
 
-    return this.complete;
+    return this.settle();
   }
 }

--- a/src/orbit/action.js
+++ b/src/orbit/action.js
@@ -1,5 +1,5 @@
 /* eslint-disable valid-jsdoc */
-import Orbit from './main';
+import Orbit from 'orbit';
 
 /**
  `Action` provides a wrapper for actions that are performed in an `ActionQueue`.
@@ -29,11 +29,6 @@ export default class Action {
     this.id = options.id;
     this.data = options.data;
     this._process = options.process;
-
-    this.reset();
-  }
-
-  reset() {
     this.processing = false;
 
     this.complete = new Orbit.Promise((resolve, reject) => {

--- a/src/orbit/action.js
+++ b/src/orbit/action.js
@@ -62,3 +62,11 @@ export default class Action {
     return this.settle();
   }
 }
+
+Action.from = function(actionOrOptions) {
+  if (actionOrOptions instanceof Action) {
+    return actionOrOptions;
+  } else {
+    return new Action(actionOrOptions);
+  }
+};

--- a/src/orbit/action.js
+++ b/src/orbit/action.js
@@ -29,11 +29,10 @@ export default class Action {
     this.id = options.id;
     this.data = options.data;
     this._process = options.process;
-    this._processing = false;
+    this._started = false;
     this._resolution = new Orbit.Promise((resolve, reject) => {
       this._success = resolve;
       this._fail = (e) => {
-        this._processing = false;
         reject(e);
       };
     });
@@ -44,8 +43,8 @@ export default class Action {
   }
 
   process() {
-    if (!this._processing) {
-      this._processing = true;
+    if (!this._started) {
+      this._started = true;
 
       try {
         let ret = this._process();

--- a/test/tests/orbit/unit/action-queue-test.js
+++ b/test/tests/orbit/unit/action-queue-test.js
@@ -8,17 +8,17 @@ import { Promise } from 'rsvp';
 
 module('Orbit - ActionQueue', {});
 
-test('it exists', function() {
+test('can be instantiated', function() {
   const queue = new ActionQueue(noop);
   ok(queue);
 });
 
-test('it is set to `autoProcess` by default', function() {
+test('#autoProcess is enabled by default', function() {
   const queue = new ActionQueue(noop);
   equal(queue.autoProcess, true, 'autoProcess === true');
 });
 
-test('will auto-process pushed actions sequentially by default', function(assert) {
+test('auto-processes pushed actions sequentially by default', function(assert) {
   assert.expect(13);
   const done = assert.async();
   let order = 0;
@@ -133,7 +133,7 @@ test('with `autoProcess` disabled, will process pushed functions sequentially wh
   queue.process();
 });
 
-test('will auto-process pushed async functions sequentially by default', function(assert) {
+test('can enqueue actions while another action is being processed', function(assert) {
   expect(8);
   const done = assert.async();
 

--- a/test/tests/orbit/unit/action-queue-test.js
+++ b/test/tests/orbit/unit/action-queue-test.js
@@ -108,9 +108,9 @@ test('with `autoProcess` disabled, will process pushed functions sequentially wh
   const _transform = function(op) {
     transformCount++;
     if (transformCount === 1) {
-      assert.deepEqual(op, op1, 'op1 passed as argument');
+      assert.deepEqual(op, op1, '_transform - op1 passed as argument');
     } else if (transformCount === 2) {
-      assert.deepEqual(op, op2, 'op2 passed as argument');
+      assert.deepEqual(op, op2, '_transform - op2 passed as argument');
     }
   };
 
@@ -232,9 +232,9 @@ test('will stop processing when an action errors', function(assert) {
   const _transform = function(op) {
     transformCount++;
     if (transformCount === 1) {
-      assert.deepEqual(op, op1, 'op1 passed as argument');
+      assert.deepEqual(op, op1, '_transform - op1 passed as argument');
     } else if (transformCount === 2) {
-      assert.deepEqual(op, op2, 'op2 passed as argument');
+      assert.ok(false, '_transform should only be called once');
     }
   };
 
@@ -257,5 +257,175 @@ test('will stop processing when an action errors', function(assert) {
   return queue.process()
     .catch(err => {
       assert.equal(err.message, ':(', 'process rejection - error matches expectation');
+    });
+});
+
+test('#shift can remove failed actions from an inactive queue, allowing processing to be restarted', function(assert) {
+  assert.expect(9);
+
+  const queue = new ActionQueue({ autoProcess: false });
+
+  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+  let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+  let transformCount = 0;
+
+  queue.on('action', function(action) {
+    if (transformCount === 1) {
+      assert.deepEqual(action.data, op1, 'action - op1 processed');
+    } else if (transformCount === 2) {
+      assert.deepEqual(action.data, op3, 'action - op3 processed');
+    }
+  });
+
+  queue.on('fail', function(action, err) {
+    assert.deepEqual(action.data, op2, 'fail - op2 failed processing');
+    assert.equal(err.message, ':(', 'fail - error matches expectation');
+  });
+
+  queue.on('complete', function() {
+    assert.ok(true, 'queue should complete after processing has restarted');
+  });
+
+  const _transform = function(op) {
+    transformCount++;
+    if (transformCount === 1) {
+      assert.deepEqual(op, op1, '_transform - op1 passed as argument');
+    } else if (transformCount === 2) {
+      assert.deepEqual(op, op3, '_transform - op3 passed as argument');
+    }
+  };
+
+  queue.push({
+    id: 1,
+    process: function() {
+      _transform.call(this, this.data);
+    },
+    data: op1
+  });
+
+  queue.push({
+    id: 2,
+    process: function() {
+      throw new Error(':(');
+    },
+    data: op2
+  });
+
+  queue.push({
+    id: 3,
+    process: function() {
+      _transform.call(this, this.data);
+    },
+    data: op3
+  });
+
+  return queue.process()
+    .catch(err => {
+      assert.equal(err.message, ':(', 'process rejection - error matches expectation');
+
+      let failedAction = queue.shift();
+      assert.deepEqual(failedAction.data, op2, 'op2, which failed, is returned from `shift`');
+
+      // continue processing
+      return queue.process();
+    });
+});
+
+test('#unshift can add a new action to the beginning of an inactive queue', function(assert) {
+  assert.expect(5);
+  const done = assert.async();
+
+  const queue = new ActionQueue({ autoProcess: false });
+
+  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+  let transformCount = 0;
+
+  queue.on('action', function(action) {
+    if (transformCount === 1) {
+      assert.deepEqual(action.data, op2, 'op2 processed');
+    } else if (transformCount === 2) {
+      assert.deepEqual(action.data, op1, 'op1 processed');
+    }
+  });
+
+  queue.on('complete', function() {
+    assert.ok(true, 'queue completed');
+    done();
+  });
+
+  const _transform = function(op) {
+    transformCount++;
+    if (transformCount === 1) {
+      assert.deepEqual(op, op2, '_transform - op2 passed as argument');
+    } else if (transformCount === 2) {
+      assert.deepEqual(op, op1, '_transform - op1 passed as argument');
+    }
+  };
+
+  queue.push({
+    id: 1,
+    process: function() {
+      _transform.call(this, this.data);
+    },
+    data: op1
+  });
+
+  queue.unshift({
+    id: 2,
+    process: function() {
+      _transform.call(this, this.data);
+    },
+    data: op2
+  });
+
+  queue.process();
+});
+
+test('#clear removes all actions from an inactive queue', function(assert) {
+  assert.expect(1);
+  const done = assert.async();
+
+  const queue = new ActionQueue({ autoProcess: false });
+
+  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+
+  queue.on('action', function() {
+    assert.ok(false, 'no actions should be processed');
+  });
+
+  queue.on('complete', function() {
+    assert.ok(false, 'queue should not complete');
+    done();
+  });
+
+  const _transform = function() {
+    assert.ok(false, '_transform should not be called');
+  };
+
+  queue.push({
+    id: 1,
+    process: function() {
+      _transform.call(this, this.data);
+    },
+    data: op1
+  });
+
+  queue.push({
+    id: 2,
+    process: function() {
+      _transform.call(this, this.data);
+    },
+    data: op2
+  });
+
+  queue.clear();
+
+  queue.process()
+    .then(() => {
+      assert.ok(true, 'queue was cleared so no processing was needed');
+      done();
     });
 });

--- a/test/tests/orbit/unit/action-test.js
+++ b/test/tests/orbit/unit/action-test.js
@@ -107,3 +107,13 @@ test('it created a promise immediately that won\'t be resolved until process is 
 
   return action.process();
 });
+
+test('Action.from will return an action instance passed into it', function(assert) {
+  let action = new Action({process: function() {}});
+  assert.strictEqual(Action.from(action), action);
+});
+
+test('Action.from will create an action from options passed into it', function(assert) {
+  let action = Action.from({process: function() {}});
+  assert.ok(action instanceof Action);
+});

--- a/test/tests/orbit/unit/action-test.js
+++ b/test/tests/orbit/unit/action-test.js
@@ -100,7 +100,7 @@ test('it created a promise immediately that won\'t be resolved until process is 
     }
   });
 
-  action.complete
+  action.settle()
     .then(function() {
       assert.ok(true, 'process resolved');
     });


### PR DESCRIPTION
Refactor `Action#complete` -> `Action#settle()`. Settled is the appropriate term for a non-pending promise. Thus the `settle()` method returns a settled promise that has either been
resolved or rejected.

Introduce `Action.from` helper method, which coerces arg to an `Action`.

Introduce `clear`, `shift`, and `unshift` methods to `ActionQueue` to allow fine control of queue.