### PR TITLE
Reform Evented interface.

### DIFF
--- a/src/orbit/evented.js
+++ b/src/orbit/evented.js
@@ -154,32 +154,6 @@ export default {
       return listeners;
     },
 
-    resolve(eventNames) {
-      let listeners = this.listeners(eventNames);
-      let args = Array.prototype.slice.call(arguments, 1);
-
-      return new Orbit.Promise(function(resolve, reject) {
-        function resolveEach() {
-          if (listeners.length === 0) {
-            reject();
-          } else {
-            let listener = listeners.shift();
-            let response = listener[0].apply(listener[1], args);
-
-            if (response) {
-              response
-                .then(success => resolve(success))
-                .catch(() => resolveEach());
-            } else {
-              resolveEach();
-            }
-          }
-        }
-
-        resolveEach();
-      });
-    },
-
     settle(eventNames) {
       let listeners = this.listeners(eventNames);
       let args = Array.prototype.slice.call(arguments, 1);

--- a/test/tests/orbit/unit/evented-test.js
+++ b/test/tests/orbit/unit/evented-test.js
@@ -88,7 +88,8 @@ test('#off - can unregister all listeners from an event', function() {
   let listener1 = function() {};
   let listener2 = function() {};
 
-  evented.on('greeting salutation', listener1);
+  evented.on('greeting', listener1);
+  evented.on('salutation', listener1);
   evented.on('salutation', listener2);
 
   equal(evented.listeners('greeting').length, 1);
@@ -105,24 +106,6 @@ test('#off - can unregister all listeners from an event', function() {
   equal(evented.listeners('salutation').length, 0);
 });
 
-test('#off - can unregister all listeners from multiple events', function() {
-  expect(4);
-
-  let listener1 = function() {};
-  let listener2 = function() {};
-
-  evented.on('greeting salutation', listener1);
-  evented.on('salutation', listener2);
-
-  equal(evented.listeners('greeting').length, 1);
-  equal(evented.listeners('salutation').length, 2);
-
-  evented.off('salutation greeting');
-
-  equal(evented.listeners('greeting').length, 0);
-  equal(evented.listeners('salutation').length, 0);
-});
-
 test('#emit - allows listeners to be registered for multiple events', function() {
   expect(3);
 
@@ -133,7 +116,8 @@ test('#emit - allows listeners to be registered for multiple events', function()
     equal(message, 'hello', 'notification message should match');
   };
 
-  evented.on('greeting salutation', listener1);
+  evented.on('greeting', listener1);
+  evented.on('salutation', listener1);
   evented.on('salutation', listener2);
 
   evented.emit('greeting', 'hello');
@@ -178,22 +162,6 @@ test('#emit - notifies listeners when emitting events with any number of argumen
   evented.emit('greeting', 'hello', 'world');
 });
 
-test('#emit - can emit multiple events with the same arguments sequentially', function() {
-  expect(3);
-
-  let listener1 = function(message) {
-    equal(message, 'hello', 'notification message should match');
-  };
-  let listener2 = function(message) {
-    equal(message, 'hello', 'notification message should match');
-  };
-
-  evented.on('greeting salutation', listener1);
-  evented.on('salutation', listener2);
-
-  evented.emit('greeting salutation', 'hello');
-});
-
 test('#listeners - can return all the listeners (and bindings) for an event', function() {
   expect(1);
 
@@ -210,32 +178,6 @@ test('#listeners - can return all the listeners (and bindings) for an event', fu
   evented.on('greeting', greeting2, binding2);
 
   deepEqual(evented.listeners('greeting'), [[greeting1, binding1], [greeting2, binding2]], 'listeners include nested arrays of functions and bindings');
-});
-
-test('#listeners - can return all the listeners (and bindings) for multiple events', function() {
-  expect(1);
-
-  let binding1 = {};
-  let binding2 = {};
-  let greeting1 = function() {
-    return 'Hello';
-  };
-  let greeting2 = function() {
-    return 'Bon jour';
-  };
-  let parting1 = function() {
-    return 'Goodbye';
-  };
-  let parting2 = function() {
-    return 'Au revoir';
-  };
-
-  evented.on('greeting', greeting1, binding1);
-  evented.on('greeting', greeting2, binding2);
-  evented.on('parting', parting1, binding1);
-  evented.on('parting', parting2, binding2);
-
-  deepEqual(evented.listeners('greeting parting'), [[greeting1, binding1], [greeting2, binding2], [parting1, binding1], [parting2, binding2]], 'listeners include nested arrays of functions and bindings');
 });
 
 test('#settle - can fulfill all promises returned by listeners to an event, in order, until all are settled', function(assert) {

--- a/test/tests/orbit/unit/evented-test.js
+++ b/test/tests/orbit/unit/evented-test.js
@@ -238,41 +238,6 @@ test('#listeners - can return all the listeners (and bindings) for multiple even
   deepEqual(evented.listeners('greeting parting'), [[greeting1, binding1], [greeting2, binding2], [parting1, binding1], [parting2, binding2]], 'listeners include nested arrays of functions and bindings');
 });
 
-test('#resolve - can fulfill promises returned by listeners to an event, in order, until one resolves', function(assert) {
-  assert.expect(8);
-
-  let order = 0;
-  let listener1 = function(message) {
-    assert.equal(message, 'hello', 'notification message should match');
-    assert.equal(++order, 1, 'listener1 triggered first');
-    // doesn't return anything
-  };
-  let listener2 = function(message) {
-    assert.equal(message, 'hello', 'notification message should match');
-    assert.equal(++order, 2, 'listener2 triggered second');
-    return failedOperation();
-  };
-  let listener3 = function(message) {
-    assert.equal(message, 'hello', 'notification message should match');
-    assert.equal(++order, 3, 'listener3 triggered third');
-    return successfulOperation();
-  };
-  let listener4 = function() {
-    assert.ok(false, 'listener should not be reached');
-  };
-
-  evented.on('greeting', listener1, this);
-  evented.on('greeting', listener2, this);
-  evented.on('greeting', listener3, this);
-  evented.on('greeting', listener4, this);
-
-  return evented.resolve('greeting', 'hello')
-    .then(result => {
-      assert.equal(result, ':)', 'success!');
-      assert.equal(++order, 4, 'promise resolved last');
-    });
-});
-
 test('#settle - can fulfill all promises returned by listeners to an event, in order, until all are settled', function(assert) {
   assert.expect(10);
 


### PR DESCRIPTION
* remove `resolve` method - not used and poorly named
* refactor `settle` and `series` methods
* drop support for subscribing to / emitting multiple events in one call

Closes #216 