### PR TITLE
Use an Immutable.List for state within TransformLog

### DIFF
--- a/src/orbit-store/store.js
+++ b/src/orbit-store/store.js
@@ -23,6 +23,8 @@ export default class Store extends Source {
 
     this._transforms = {};
     this._transformInverses = {};
+
+    this.transformLog.on('clear', this._logCleared, this);
     this.transformLog.on('truncate', this._logTruncated, this);
 
     this.cache = new Cache(assign({ schema, keyMap }, cacheOptions));
@@ -159,19 +161,6 @@ export default class Store extends Source {
       .map(id => this._transforms[id]);
   }
 
-  /**
-   Clears the Source's logged and tracked transforms entirely.
-
-   @method clearHistory
-   @returns {undefined}
-  */
-  clearHistory() {
-    super.clearHistory(...arguments);
-
-    this._transforms = {};
-    this._transformInverses = {};
-  }
-
   /////////////////////////////////////////////////////////////////////////////
   // Private methods
   /////////////////////////////////////////////////////////////////////////////
@@ -185,6 +174,11 @@ export default class Store extends Source {
   _clearTransformFromHistory(transformId) {
     delete this._transforms[transformId];
     delete this._transformInverses[transformId];
+  }
+
+  _logCleared(/* data */) {
+    this._transforms = {};
+    this._transformInverses = {};
   }
 
   _logTruncated(transformId, relativePosition, data) {

--- a/src/orbit-store/store.js
+++ b/src/orbit-store/store.js
@@ -4,6 +4,7 @@ import { extend as assign } from 'orbit/lib/objects';
 import Syncable from 'orbit/interfaces/syncable';
 import Queryable from 'orbit/interfaces/queryable';
 import Updatable from 'orbit/interfaces/updatable';
+import TransformLog from 'orbit/transform/log';
 import {
   coalesceTransforms,
   reduceTransforms
@@ -22,6 +23,7 @@ export default class Store extends Source {
 
     this._transforms = {};
     this._transformInverses = {};
+    this.transformLog.on('truncate', this._logTruncated, this);
 
     this.cache = new Cache(assign({ schema, keyMap }, cacheOptions));
   }
@@ -158,22 +160,6 @@ export default class Store extends Source {
   }
 
   /**
-   Truncates the Source's logged and tracked transforms to remove everything
-   before a particular `transformId`.
-
-   @method truncateHistory
-   @param {string} transformId - The ID of the transform to truncate history to.
-   @returns {undefined}
-  */
-  truncateHistory(transformId) {
-    super.truncateHistory(...arguments);
-
-    this.transformLog
-      .before(transformId)
-      .forEach(id => this._clearTransformFromHistory(id));
-  }
-
-  /**
    Clears the Source's logged and tracked transforms entirely.
 
    @method clearHistory
@@ -196,17 +182,24 @@ export default class Store extends Source {
     this._transformInverses[transform.id] = inverse;
   }
 
+  _clearTransformFromHistory(transformId) {
+    delete this._transforms[transformId];
+    delete this._transformInverses[transformId];
+  }
+
+  _logTruncated(transformId, relativePosition, data) {
+    const prevLog = new TransformLog(data);
+    prevLog
+      .before(transformId)
+      .forEach(id => this._clearTransformFromHistory(id));
+  }
+
   _rollbackTransform(transformId) {
     const inverseOperations = this._transformInverses[transformId];
     if (inverseOperations) {
       this.cache.patch(inverseOperations);
     }
     this._clearTransformFromHistory(transformId);
-  }
-
-  _clearTransformFromHistory(transformId) {
-    delete this._transforms[transformId];
-    delete this._transformInverses[transformId];
   }
 }
 

--- a/src/orbit/coordinator.js
+++ b/src/orbit/coordinator.js
@@ -107,7 +107,7 @@ export default class Coordinator {
   _truncateHistory(transformId, relativePosition) {
     this._sources.forEach(s => {
       if (s.transformLog.contains(transformId)) {
-        s.truncateHistory(transformId, relativePosition);
+        s.transformLog.truncate(transformId, relativePosition);
       }
     });
   }

--- a/src/orbit/source.js
+++ b/src/orbit/source.js
@@ -20,16 +20,6 @@ export default class Source {
     this.syncQueue = new ActionQueue();
   }
 
-  /**
-   Clears the source's logged and tracked transforms entirely.
-
-   @method clearHistory
-   @returns {undefined}
-  */
-  clearHistory() {
-    this.transformLog.clear();
-  }
-
   /////////////////////////////////////////////////////////////////////////////
   // Private methods
   /////////////////////////////////////////////////////////////////////////////

--- a/src/orbit/source.js
+++ b/src/orbit/source.js
@@ -21,19 +21,6 @@ export default class Source {
   }
 
   /**
-   Truncates the source's logged and tracked transforms to remove everything
-   before a particular `transformId`.
-
-   @method truncateHistory
-   @param {string} transformId - The ID of the transform to truncate history to.
-   @param {number} relativePosition - An integer position relative to the specified transform.
-   @returns {undefined}
-  */
-  truncateHistory(transformId, relativePosition = 0) {
-    this.transformLog.truncate(transformId, relativePosition);
-  }
-
-  /**
    Clears the source's logged and tracked transforms entirely.
 
    @method clearHistory

--- a/test/tests/orbit-store/unit/store-test.js
+++ b/test/tests/orbit-store/unit/store-test.js
@@ -226,7 +226,7 @@ module('OC - Store', function(hooks) {
       });
   });
 
-  test('#clearHistory - clears all transforms from log as well as tracked transforms', function(assert) {
+  test('transformLog.clear - clears all transforms from log as well as tracked transforms', function(assert) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const recordB = { id: 'saturn', type: 'planet', attributes: { name: 'Saturn' } };
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
@@ -241,7 +241,7 @@ module('OC - Store', function(hooks) {
       store.sync(addRecordCTransform)
     ])
       .then(() => {
-        store.clearHistory();
+        store.transformLog.clear();
 
         assert.deepEqual(
           store.allTransforms(),

--- a/test/tests/orbit-store/unit/store-test.js
+++ b/test/tests/orbit-store/unit/store-test.js
@@ -198,7 +198,7 @@ module('OC - Store', function(hooks) {
       });
   });
 
-  test('#truncateHistory - clears transforms from log as well as tracked transforms before a specified transform', function(assert) {
+  test('transformLog.truncate - clears transforms from log as well as tracked transforms before a specified transform', function(assert) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const recordB = { id: 'saturn', type: 'planet', attributes: { name: 'Saturn' } };
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
@@ -213,7 +213,7 @@ module('OC - Store', function(hooks) {
       store.sync(addRecordCTransform)
     ])
       .then(() => {
-        store.truncateHistory(addRecordBTransform.id);
+        store.transformLog.truncate(addRecordBTransform.id);
 
         assert.deepEqual(
           store.allTransforms(),

--- a/test/tests/orbit/unit/source-test.js
+++ b/test/tests/orbit/unit/source-test.js
@@ -52,23 +52,6 @@ module('Orbit - Source', function(hooks) {
       .then(() => assert.ok(source.transformLog.contains(appliedTransform.id)));
   });
 
-  test('it can truncate its transform history', function(assert) {
-    return source._transformed([transformA, transformB, transformC])
-      .then(() => {
-        assert.deepEqual(
-          source.transformLog.entries,
-          [transformA, transformB, transformC].map(t => t.id),
-          'transform log is correct');
-
-        source.truncateHistory(transformB.id);
-
-        assert.deepEqual(
-          source.transformLog.entries,
-          [transformB, transformC].map(t => t.id),
-          'transform log has been truncated');
-      });
-  });
-
   test('it can clear its transform history', function(assert) {
     return source._transformed([transformA, transformB, transformC])
       .then(() => {

--- a/test/tests/orbit/unit/source-test.js
+++ b/test/tests/orbit/unit/source-test.js
@@ -2,10 +2,6 @@ import Source from 'orbit/source';
 import Transform from 'orbit/transform';
 
 module('Orbit - Source', function(hooks) {
-  const transformA = Transform.from({ op: 'addRecord', value: {} });
-  const transformB = Transform.from({ op: 'addRecord', value: {} });
-  const transformC = Transform.from({ op: 'addRecord', value: {} });
-
   let source;
 
   hooks.beforeEach(function() {
@@ -50,22 +46,5 @@ module('Orbit - Source', function(hooks) {
     return source
       ._transformed([appliedTransform])
       .then(() => assert.ok(source.transformLog.contains(appliedTransform.id)));
-  });
-
-  test('it can clear its transform history', function(assert) {
-    return source._transformed([transformA, transformB, transformC])
-      .then(() => {
-        assert.deepEqual(
-          source.transformLog.entries,
-          [transformA, transformB, transformC].map(t => t.id),
-          'transform log is correct');
-
-        source.clearHistory();
-
-        assert.deepEqual(
-          source.transformLog.entries,
-          [],
-          'transform log has been cleared');
-      });
   });
 });


### PR DESCRIPTION
By switching from a plain Array to an Immutable.List, we can emit events from TransformLog that contain the previous state.

This allows us to remove the clumsy methods `truncateHistory` and `clearHistory` on `Source` in favor of observing changes to the `transformLog`.